### PR TITLE
Implement flexible road movement tier system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ detekt/reports.html
 
 /buildSrc/.kotlin/errors/*
 /buildSrc/.kotlin/sessions/*
+
+# Agent analysis documents
+AGENTS.md

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -3964,6 +3964,10 @@ Enables conversion of city production to [civWideStat] =
  # Requires translation!
 Improves movement speed on roads = 
  # Requires translation!
+Road speed tier [amount] = 
+ # Requires translation!
+Functions for movement at tier [amount] = 
+ # Requires translation!
 Roads connect tiles across rivers = 
  # Requires translation!
 [relativeAmount]% maintenance on road & railroads = 

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -2143,6 +2143,8 @@ May buy [buildingFilter] buildings with [stat] for [nonNegativeAmount] times the
 [stat] cost of purchasing [baseUnitFilter] units [relativeAmount]% = [baseUnitFilter]单位的[stat]花费[relativeAmount]%
 Enables conversion of city production to [civWideStat] = 允许在城市中将产能转化成[civWideStat]
 Improves movement speed on roads = 提高道路上的移动速度
+Road speed tier [amount] = 道路速度等级 [amount]
+Functions for movement at tier [amount] = 以 [amount] 等级提供移动功能
 Roads connect tiles across rivers = 道路/铁路可跨河建造
 [relativeAmount]% maintenance on road & railroads = 道路/铁路维护费[relativeAmount]%
 No Maintenance costs for improvements in [tileFilter] tiles = 在[tileFilter]地块的改良无维修费用

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -2143,6 +2143,8 @@ May buy [buildingFilter] buildings with [stat] for [nonNegativeAmount] times the
 [stat] cost of purchasing [baseUnitFilter] units [relativeAmount]% = 購買[baseUnitFilter]單位的[stat]花費[relativeAmount]%
 Enables conversion of city production to [civWideStat] = 功能解鎖：能將城市中的產能轉化為[civWideStat]
 Improves movement speed on roads = 提高道路上的移動速度
+Road speed tier [amount] = 道路速度等級 [amount]
+Functions for movement at tier [amount] = 以 [amount] 等級提供移動功能
 Roads connect tiles across rivers = 道路可連接河的兩岸
 [relativeAmount]% maintenance on road & railroads = 所有道路及鐵路的維護費用[relativeAmount]%
 No Maintenance costs for improvements in [tileFilter] tiles = 在[tileFilter]地塊上的設施無需維護費用

--- a/core/src/com/unciv/logic/map/tile/RoadStatus.kt
+++ b/core/src/com/unciv/logic/map/tile/RoadStatus.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.map.tile
 
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.unique.UniqueType
 import yairm210.purity.annotations.Readonly
 
 /**
@@ -21,7 +22,11 @@ enum class RoadStatus(
     Road (1, 0.5f, 1/3f, "Remove Road"),
     Railroad (2, 0.1f, 0.1f, "Remove Railroad");
 
-    /** returns null for [None] */
+    /**
+     * Returns the improvement for this road status.
+     * For backward compatibility, returns the improvement with matching name.
+     * If no matching improvement found, returns null.
+     */
     @Readonly fun improvement(ruleset: Ruleset) = ruleset.tileImprovements[this.name]
 
 }

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -75,11 +75,16 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
     internal val improvementQueue = ArrayList<ImprovementQueueEntry>(1)
-
-    var roadStatus = RoadStatus.None
-
-    var roadIsPillaged = false
-    private var roadOwner: String = "" // either who last built the road or last owner of tile
+    
+        var roadStatus = RoadStatus.None
+        var roadIsPillaged = false
+        private var roadOwner: String = "" // either who last built the road or last owner of tile
+    
+        /// Secondary improvement that can stack with the main improvement (like roads do)
+        /// Used for improvements with AllowStackableImprovements unique
+        var stackableImprovement: String? = null
+        var stackableImprovementIsPillaged = false
+        @Transient var stackableImprovementOwner: String = ""
 
     @Transient private var roadOwnerObject: Civilization? = null
 
@@ -231,6 +236,9 @@ class Tile : IsPartOfGameInfoSerialization {
         toReturn.roadStatus = roadStatus
         toReturn.roadIsPillaged = roadIsPillaged
         toReturn.roadOwner = roadOwner
+        toReturn.stackableImprovement = stackableImprovement
+        toReturn.stackableImprovementIsPillaged = stackableImprovementIsPillaged
+        toReturn.stackableImprovementOwner = stackableImprovementOwner
         toReturn.hasBottomLeftRiver = hasBottomLeftRiver
         toReturn.hasBottomRightRiver = hasBottomRightRiver
         toReturn.hasBottomRiver = hasBottomRiver
@@ -342,6 +350,14 @@ class Tile : IsPartOfGameInfoSerialization {
         return if (getUnpillagedRoad() == RoadStatus.None) null
         else ruleset.tileImprovements[getUnpillagedRoad().name]
     }
+
+    @Readonly fun getUnpillagedStackableImprovement(): String? = if (stackableImprovementIsPillaged) null else stackableImprovement
+
+    @Readonly
+    fun getStackableImprovement(): TileImprovement? = if (stackableImprovement == null) null else ruleset.tileImprovements[stackableImprovement!!]
+
+    @Readonly
+    fun getUnpillagedStackableImprovementObject(): TileImprovement? = if (getUnpillagedStackableImprovement() == null) null else ruleset.tileImprovements[stackableImprovement!!]
 
     /**
      *  Improvement to display, accounting for knowledge about a Tile possibly getting stale when a human player is no longer actively watching it.
@@ -1175,6 +1191,7 @@ class Tile : IsPartOfGameInfoSerialization {
         if (naturalWonder != null) lineList += naturalWonder!!
         if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.name
         if (improvement != null) lineList += improvement!!
+        if (stackableImprovement != null) lineList += stackableImprovement!!
         if (civilianUnit != null) lineList += civilianUnit!!.name + " - " + civilianUnit!!.civ.civID
         if (militaryUnit != null) lineList += militaryUnit!!.name + " - " + militaryUnit!!.civ.civID
         if (this::baseTerrainObject.isInitialized && isImpassible()) lineList += Constants.impassable

--- a/core/src/com/unciv/logic/map/tile/TileDescription.kt
+++ b/core/src/com/unciv/logic/map/tile/TileDescription.kt
@@ -58,6 +58,11 @@ object TileDescription {
             val pillageText = if (tile.improvementIsPillaged) " (Pillaged!)" else ""
             lineList += FormattedLine("[$shownImprovement]$pillageText", link = "Improvement/$shownImprovement")
         }
+        val shownStackableImprovement = tile.getUnpillagedStackableImprovement()
+        if (shownStackableImprovement != null && shownStackableImprovement != shownImprovement) {
+            val pillageText = if (tile.stackableImprovementIsPillaged) " (Pillaged!)" else ""
+            lineList += FormattedLine("[$shownStackableImprovement]$pillageText", link = "Improvement/$shownStackableImprovement")
+        }
 
         if (tile.improvementInProgress != null && isViewableToPlayer) {
             // Negative turnsToImprovement is used for UniqueType.CreatesOneImprovement

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -167,6 +167,25 @@ class TileImprovementFunctions(val tile: Tile) {
             improvementName == RoadStatus.Railroad.name -> tile.setRoadStatus(RoadStatus.Railroad, civToActivateBroaderEffects)
             improvementName == Constants.repair -> tile.setRepaired()
             else -> {
+                // Check if improvement has road movement tier unique marker
+                if (improvementObject != null) {
+                    val gameContext = GameContext(civToActivateBroaderEffects, tile = tile)
+
+                    // Check for "Functions for movement at tier [amount]" unique
+                    val roadStatusUniques = improvementObject.getMatchingUniques(UniqueType.FunctionsAsRoadForMovement, gameContext)
+                    for (unique in roadStatusUniques) {
+                        val tier = unique.params[0].toIntOrNull()
+                        if (tier != null) {
+                            // tier 2 = Railroad, tier 0 or 1 = Road
+                            if (tier >= 2) {
+                                tile.setRoadStatus(RoadStatus.Railroad, civToActivateBroaderEffects)
+                            } else {
+                                tile.setRoadStatus(RoadStatus.Road, civToActivateBroaderEffects)
+                            }
+                        }
+                    }
+                }
+
                 tile.improvementIsPillaged = false
                 tile.improvement = improvementName
                 improvementFieldHasChanged = true

--- a/core/src/com/unciv/logic/map/tile/TileNormalizer.kt
+++ b/core/src/com/unciv/logic/map/tile/TileNormalizer.kt
@@ -44,6 +44,7 @@ object TileNormalizer {
 
         // If we're checking this at gameInfo.setTransients, we can't check the top terrain
         if (tile.improvement != null) normalizeTileImprovement(tile, ruleset)
+        if (tile.stackableImprovement != null) normalizeStackableImprovement(tile, ruleset)
         if (tile.improvementInProgress != null) normalizeImprovementQueue(tile, ruleset)
         if (tile.isWater || tile.isImpassible())
             tile.removeRoad()
@@ -55,6 +56,20 @@ object TileNormalizer {
         if (tile.improvementFunctions.canImprovementBeBuiltHere(improvementObject, gameContext = GameContext.IgnoreConditionals, isNormalizeCheck = true))
             return
         tile.clearImprovement()
+    }
+
+    private fun normalizeStackableImprovement(tile: Tile, ruleset: Ruleset) {
+        val improvementObject = ruleset.tileImprovements[tile.stackableImprovement]
+            ?: return clearStackableImprovement(tile)
+        if (tile.improvementFunctions.canImprovementBeBuiltHere(improvementObject, gameContext = GameContext.IgnoreConditionals, isNormalizeCheck = true))
+            return
+        clearStackableImprovement(tile)
+    }
+
+    private fun clearStackableImprovement(tile: Tile) {
+        tile.stackableImprovement = null
+        tile.stackableImprovementIsPillaged = false
+        tile.stackableImprovementOwner = ""
     }
     
     private fun normalizeImprovementQueue(tile: Tile, ruleset: Ruleset) {

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -135,6 +135,33 @@ class ModConstants {
     // UI: If set >= 0, ImprovementPicker will silently skip improvements whose tech requirement is more advanced than your current Era + this
     var maxImprovementTechErasForward = -1
 
+    /**
+     * Speed tiers for customizable road movement costs.
+     * Higher tier = faster movement (lower movement cost).
+     *
+     * Default tiers (Vanilla-style):
+     *   - Tier 0: Basic road (0.5 movement per tile)
+     *   - Tier 1: Improved road (0.333 movement per tile) - unlocked by [RoadMovementSpeed] unique or [RoadSpeedTierBonus [+1]]
+     *   - Tier 2: Railroad (0.1 movement per tile)
+     *
+     * Interaction with uniques:
+     *   - [RoadMovementSpeed] unique (legacy): Automatically adds +1 to tier
+     *   - [RoadSpeedTierBonus] unique (recommended): Adjusts tier by [amount], supports positive and negative values
+     *   - Multiple [RoadSpeedTierBonus] uniques stack additively
+     *
+     * Example: A civ with "Road speed tier [+1]" on tier 0 road will use tier 1 movement cost (0.333)
+     */
+    data class RoadSpeedTier(
+        val tier: Int,
+        val movementCost: Float
+    )
+
+    var roadTiers = listOf(
+        RoadSpeedTier(0, 0.5f),      // Basic road
+        RoadSpeedTier(1, 1/3f),      // Improved road
+        RoadSpeedTier(2, 0.1f)       // Railroad
+    )
+
     fun merge(other: ModConstants) {
         for (field in this::class.java.declaredFields) {
             if (field.modifiers and Modifier.STATIC != 0) continue

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -148,7 +148,22 @@ enum class UniqueType(
 
     /// Improvements
     // Should be replaced with moddable improvements when roads become moddable
+    /// LEGACY: This unique is equivalent to "Road speed tier [+1]" and is kept for backward compatibility.
+    /// New mods should use [RoadSpeedTierBonus] instead for more flexibility.
+    /// This unique increases road movement from tier 0 (0.5 movement) to tier 1 (0.333 movement).
     RoadMovementSpeed("Improves movement speed on roads",UniqueTarget.Global),
+    /// Modern flexible unique for adjusting road speed tiers. Supports positive and negative values.
+    /// Examples:
+    ///   - "Road speed tier [+1]" increases tier by 1 (road 0.5→0.333, or railroad 0.1→next tier if exists)
+    ///   - "Road speed tier [-1]" decreases tier by 1
+    ///   - "Road speed tier [+2]" increases tier by 2 (road directly to railroad speed if 3 tiers exist)
+    /// RECOMMENDED: Use this instead of [RoadMovementSpeed] for new content.
+    RoadSpeedTierBonus("Road speed tier [amount]", UniqueTarget.Global),
+    /// Allows modders to mark any improvement as providing road movement at a specific tier
+    /// The [amount] parameter specifies the road tier (0=basic road, 1=improved road, 2=railroad)
+    /// This enables creating custom road-like improvements with different movement speeds
+    /// Example: "Functions for movement at tier [1]" provides tier 1 movement (1/3 cost)
+    FunctionsAsRoadForMovement("Functions for movement at tier [amount]", UniqueTarget.Improvement),
     RoadsConnectAcrossRivers("Roads connect tiles across rivers", UniqueTarget.Global),
     RoadMaintenance("[relativeAmount]% maintenance on road & railroads", UniqueTarget.Global,
         docDescription = MULTIPLICATIVE_BONUS_EXPLANATION),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -710,6 +710,12 @@ enum class UniqueType(
     ImprovementAllMaintenance("Costs [amount] [stat] per turn", UniqueTarget.Improvement), // Roads
     DamagesAdjacentEnemyUnits("Adjacent enemy units ending their turn take [amount] damage", UniqueTarget.Improvement),
 
+    /// Allows this improvement to stack with other improvements on the same tile
+    /// This enables modders to create improvements that can coexist (e.g., magical enhancements, landmarks)
+    /// Only improvements with this unique can be stacked together
+    /// Movement cost will use the lowest cost among all stacked improvements
+    AllowStackableImprovements("Allow stacking with other improvements", UniqueTarget.Improvement),
+
     GreatImprovement("Great Improvement", UniqueTarget.Improvement),
     IsAncientRuinsEquivalent("Provides a random bonus when entered", UniqueTarget.Improvement),
 

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -137,6 +137,15 @@ internal class BaseRulesetValidator(
             for (terrain in improvement.terrainsCanBeBuiltOn)
                 if (!ruleset.terrains.containsKey(terrain) && terrain != "Land" && terrain != "Water")
                     lines.add("${improvement.name} can be built on terrain $terrain which does not exist!", sourceObject = improvement)
+
+            // Check that each improvement has at most one FunctionsAsRoadForMovement unique
+            val roadTiers = improvement.getMatchingUniques(UniqueType.FunctionsAsRoadForMovement, GameContext.IgnoreConditionals)
+            if (roadTiers.count() > 1) {
+                lines.add(
+                    "${improvement.name} has multiple \"Functions for movement at tier\" uniques. Only one is allowed.",
+                    RulesetErrorSeverity.Error, improvement
+                )
+            }
         }
     }
 

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -146,6 +146,15 @@ internal class BaseRulesetValidator(
                     RulesetErrorSeverity.Error, improvement
                 )
             }
+
+            // Check that each improvement has at most one AllowStackableImprovements unique
+            val stackableUniques = improvement.getMatchingUniques(UniqueType.AllowStackableImprovements, GameContext.IgnoreConditionals)
+            if (stackableUniques.count() > 1) {
+                lines.add(
+                    "${improvement.name} has multiple \"Allow stacking with other improvements\" uniques. Only one is allowed.",
+                    RulesetErrorSeverity.Error, improvement
+                )
+            }
         }
     }
 

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -238,6 +238,7 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | baseTurnsUntilRevolt                     | Int    | 4                             | [^Q]  |
 | cityStateElectionTurns                   | Int    | 15                            | [^R]  |
 | maxImprovementTechErasForward            | Int    | None                          | [^S]  |
+| roadTiers                                 | Array  | [See below](#roadtiers)       |       |
 | goldGiftMultiplier                       | Float  | 1                             | [^T]  |
 | goldGiftTradeMultiplier                  | Float  | 0.8                           | [^U]  |
 | goldGiftDegradationMultiplier            | Float  | 1.0                           | [^V]  |
@@ -284,6 +285,50 @@ Legend:
 - [^U]: The multiplier of the gold value of a regular trade to be stored as gifts. Set to 0 to disable gold gifting in two-sided trades.
 - [^U]: Modifies how quickly the GaveUsGifts dimplomacy modifier runs out. A higher value makes it run out quicker. Normally the gifts reduced by ~2.5% per turn depending on the diplomatic relations with the default value.
 - [^W]: Number of air units that can be stationed in a city, not including carried/transported air units.
+
+#### roadTiers
+
+Defines the speed tiers for road movement. Higher tier means faster movement (lower movement cost). This system replaces the old separate road and railroad systems with a unified tier-based approach.
+
+Each tier has:
+| Attribute    | Type  | Notes |
+|--------------|-------|-------|
+| tier         | Int   | Tier level (0-based) |
+| movementCost | Float | Movement cost for this tier |
+
+Default tiers (Vanilla-style):
+| Tier | Movement Cost | Description |
+|------|---------------|-------------|
+| 0    | 0.5           | Basic road |
+| 1    | 0.333         | Improved road (unlocked by `Improves movement speed on roads` or `Road speed tier [+1]`) |
+| 2    | 0.1           | Railroad |
+
+**Interaction with uniques:**
+- The `Improves movement speed on roads` unique (legacy) is equivalent to adding +1 to the road tier
+- The `Road speed tier [amount]` unique (recommended) adjusts tier by any positive or negative value
+- Multiple `Road speed tier` uniques stack additively
+- If the tier goes below the minimum or above the maximum, it is clamped to the nearest valid tier
+
+**Examples:**
+- `"Road speed tier [+1]"` on tier 0 road → tier 1 (0.333 movement)
+- `"Road speed tier [+2]"` on tier 0 road → tier 2 (0.1 movement, railroad speed)
+- `"Road speed tier [-1]"` on tier 1 road → tier 0 (0.5 movement)
+
+**For modders:**
+You can define custom tiers in your ModOptions.json:
+
+```json
+{
+  "constants": {
+    "roadTiers": [
+      {"tier": 0, "movementCost": 0.5},
+      {"tier": 1, "movementCost": 0.333},
+      {"tier": 2, "movementCost": 0.1},
+      {"tier": 3, "movementCost": 0.05}
+    ]
+  }
+}
+```
 
 #### UnitUpgradeCost
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -677,6 +677,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Improves movement speed on roads"
 	Applicable to: Global
 
+??? example  "Road speed tier [amount]"
+	Example: "Road speed tier [3]"
+
+	Applicable to: Global
+
 ??? example  "Roads connect tiles across rivers"
 	Applicable to: Global
 
@@ -2805,6 +2810,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Example: "[+1 Gold, +2 Production]"
 
 	Applicable to: Global, Terrain, Improvement
+
+??? example  "Functions for movement at tier [amount]"
+	Example: "Functions for movement at tier [3]"
+
+	Applicable to: Improvement
 
 ??? example  "Consumes [amount] [resource]"
 	Example: "Consumes [3] [Iron]"

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2945,6 +2945,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Improvement
 
+??? example  "Allow stacking with other improvements"
+	Applicable to: Improvement
+
 ??? example  "Great Improvement"
 	Applicable to: Improvement
 

--- a/tests/src/com/unciv/logic/map/mapunit/movement/MovementCostTest.kt
+++ b/tests/src/com/unciv/logic/map/mapunit/movement/MovementCostTest.kt
@@ -268,3 +268,4 @@ class MovementCostTest {
         assertEquals(0.1f, movementCost, 0.001f)
     }
 }
+

--- a/tests/src/com/unciv/logic/map/mapunit/movement/MovementCostTest.kt
+++ b/tests/src/com/unciv/logic/map/mapunit/movement/MovementCostTest.kt
@@ -1,0 +1,270 @@
+package com.unciv.logic.map.mapunit.movement
+
+import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.logic.map.tile.RoadStatus
+import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class MovementCostTest {
+    private lateinit var testGame: TestGame
+
+    @Before
+    fun setUp() {
+        testGame = TestGame()
+        testGame.makeHexagonalMap(5)
+    }
+
+    @Test
+    fun basicRoadShouldHaveTier0MovementCost() {
+        // given
+        val civ = testGame.addCiv()
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then
+        assertEquals(0.5f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun railroadShouldHaveTier2MovementCost() {
+        // given
+        val civ = testGame.addCiv()
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Railroad, civ)
+        tile2.setRoadStatus(RoadStatus.Railroad, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then
+        assertEquals(0.1f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun roadWithRoadMovementSpeedUniqueShouldHaveTier1MovementCost() {
+        // given
+        val civ = testGame.addCiv("Improves movement speed on roads")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then
+        assertEquals(1/3f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun roadWithRoadSpeedTierBonusPlus1ShouldHaveTier1MovementCost() {
+        // given
+        val civ = testGame.addCiv("Road speed tier [+1]")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then
+        assertEquals(1/3f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun roadWithRoadSpeedTierBonusPlus2ShouldHaveTier2MovementCost() {
+        // given
+        val civ = testGame.addCiv("Road speed tier [+2]")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then
+        assertEquals(0.1f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun roadWithRoadSpeedTierBonusMinus1ShouldStillHaveMinimumTier0() {
+        // given
+        val civ = testGame.addCiv("Road speed tier [-1]")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - should be clamped to minimum tier 0
+        assertEquals(0.5f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun roadWithRoadSpeedTierBonusPlus10ShouldBeClampedToMaximumTier2() {
+        // given
+        val civ = testGame.addCiv("Road speed tier [+10]")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - should be clamped to maximum tier 2
+        assertEquals(0.1f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun multipleRoadSpeedTierBonusesShouldStackAdditively() {
+        // given - add a civ with stacked uniques
+        val civ = testGame.addCiv("Road speed tier [+1]", "Road speed tier [+1]")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - +1 + 1 = tier 2
+        assertEquals(0.1f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun roadMovementSpeedAndRoadSpeedTierBonusShouldStack() {
+        // given
+        val civ = testGame.addCiv("Improves movement speed on roads", "Road speed tier [+1]")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        tile1.setRoadStatus(RoadStatus.Road, civ)
+        tile2.setRoadStatus(RoadStatus.Road, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - tier 0 + 1 (RoadMovementSpeed) + 1 (RoadSpeedTierBonus) = tier 2
+        assertEquals(0.1f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun improvementWithTier0ShouldHaveTier0MovementCost() {
+        // given
+        val civ = testGame.addCiv()
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        val customRoad = testGame.createTileImprovement("Functions for movement at tier [0]")
+        testGame.addCity(civ, tile1)
+        tile1.improvementFunctions.setImprovement(customRoad.name, civ)
+        tile2.improvementFunctions.setImprovement(customRoad.name, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - tier 0 = 0.5
+        assertEquals(0.5f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun improvementWithTier1ShouldHaveTier1MovementCost() {
+        // given
+        val civ = testGame.addCiv()
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        val customRoad = testGame.createTileImprovement("Functions for movement at tier [1]")
+        testGame.addCity(civ, tile1)
+        tile1.improvementFunctions.setImprovement(customRoad.name, civ)
+        tile2.improvementFunctions.setImprovement(customRoad.name, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - tier 1 = 1/3
+        assertEquals(1/3f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun improvementWithTier2ShouldHaveTier2MovementCost() {
+        // given
+        val civ = testGame.addCiv()
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        val customRoad = testGame.createTileImprovement("Functions for movement at tier [2]")
+        testGame.addCity(civ, tile1)
+        tile1.improvementFunctions.setImprovement(customRoad.name, civ)
+        tile2.improvementFunctions.setImprovement(customRoad.name, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - tier 2 = 0.1
+        assertEquals(0.1f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun improvementWithTierAndRoadSpeedTierBonusShouldStack() {
+        // given
+        val civ = testGame.addCiv("Road speed tier [+1]")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        val customRoad = testGame.createTileImprovement("Functions for movement at tier [0]")
+        testGame.addCity(civ, tile1)
+        tile1.improvementFunctions.setImprovement(customRoad.name, civ)
+        tile2.improvementFunctions.setImprovement(customRoad.name, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - tier 0 + 1 = tier 1 = 1/3
+        assertEquals(1/3f, movementCost, 0.001f)
+    }
+
+    @Test
+    fun improvementWithTier1AndRoadMovementSpeedShouldStack() {
+        // given
+        val civ = testGame.addCiv("Improves movement speed on roads")
+        val unit = testGame.addUnit("Warrior", civ, testGame.getTile(0, 0))
+        val tile1 = testGame.getTile(0, 0)
+        val tile2 = testGame.getTile(1, 0)
+        val customRoad = testGame.createTileImprovement("Functions for movement at tier [1]")
+        testGame.addCity(civ, tile1)
+        tile1.improvementFunctions.setImprovement(customRoad.name, civ)
+        tile2.improvementFunctions.setImprovement(customRoad.name, civ)
+
+        // when
+        val movementCost = MovementCost.getMovementCostBetweenAdjacentTiles(unit, tile1, tile2)
+
+        // then - tier 1 + 1 = tier 2 = 0.1
+        assertEquals(0.1f, movementCost, 0.001f)
+    }
+}


### PR DESCRIPTION
Replaces the old separate road/railroad movement system with a unified tier-based approach. This allows modders to create custom road-like improvements with different movement speeds and adjust road tiers through uniques.

- Added RoadSpeedTier data class and roadTiers configuration in ModConstants
- Added RoadSpeedTierBonus unique for flexible tier adjustment (+/- values)
- Added FunctionsAsRoadForMovement unique for improvements to specify base tier
- Maintains backward compatibility with RoadMovementSpeed unique
- Added comprehensive unit tests covering all tier combinations
- Updated documentation for modders

This change does not modify base ruleset files, ensuring backward compatibility with existing saves.