### PR TITLE
Slightly prioritize contested tiles for border expansion

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -477,6 +477,7 @@ object Automation {
                 isContested = true
                 continue
             }
+            // the neighbor tile is not owned by anyone
             val adjacentDistance = city.getCenterTile().aerialDistanceTo(adjacentTile)
             val adjacentResource = adjacentTile.tileResource
             if (city.civ.canSeeResource(adjacentResource) &&


### PR DESCRIPTION
<img width="1005" height="696" alt="image" src="https://github.com/user-attachments/assets/fafc486e-0a82-46f1-9b0c-50747155651f" />

Strategically it makes sense to expand to the western iron tile next to Greece first.

If you expand to the eastern iron tile first, it is likely that Greece will take the other one, and you will only have 2 iron instead of 4.

This PR adds a slight weight to contested tiles.

<img width="1005" height="696" alt="image" src="https://github.com/user-attachments/assets/f7d6789c-f8bb-461c-ac54-b798a4feceb8" />