### PR TITLE
Do not consider unexplored tiles in border expansion logic

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -471,7 +471,7 @@ object Automation {
         var adjacentNaturalWonder = false
         var isContested = false
 
-        for (adjacentTile in tile.neighbors.filter { city.civ.hasExplored(it) && it.getOwner() == null  }) {
+        for (adjacentTile in tile.neighbors.filter { city.civ.hasExplored(it) && it.getOwner() != city.civ  }) {
             // the neighbor tile is owned by another civ
             if (adjacentTile.getOwner() != null) {
                 isContested = true


### PR DESCRIPTION
This applies when considering neighbors of the tile we are ranking. These neighbors may be 2 tiles away from our territory, and therefore unexplored.