### PR TITLE
Border expansion logic work range fix

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -474,10 +474,10 @@ object Automation {
             val adjacentDistance = city.getCenterTile().aerialDistanceTo(adjacentTile)
             val adjacentResource = adjacentTile.tileResource
             if (city.civ.canSeeResource(adjacentResource) &&
-                (adjacentDistance < city.getWorkRange() || adjacentResource.resourceType != ResourceType.Bonus)
+                (adjacentDistance <= city.getWorkRange() || adjacentResource.resourceType != ResourceType.Bonus)
             ) score -= 1
             if (adjacentTile.naturalWonder != null) {
-                if (adjacentDistance < city.getWorkRange()) adjacentNaturalWonder = true
+                if (adjacentDistance <= city.getWorkRange()) adjacentNaturalWonder = true
                 score -= 1
             }
         }


### PR DESCRIPTION
Fix border expansion logic not properly considering neighboring bonus resources at the edge of city work range.

When we rank a tile, if it has good neigbors that we can expand to later on, we should prioritize that tile.
If the "good" tiles are bonus resources, but they are outside of work range, we should ignore them.
Current logic incorrectly ignores bonus resources that are inside of the work range (outermost ring).
This PR ensures the outermost work ring is also considered.