### PR TITLE
Proguard minification enabled in release builds

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -36,6 +36,8 @@ android {
         versionName = BuildConfig.appVersion
 
         base.archivesName.set("Unciv")
+        signingConfig = signingConfigs.getByName("debug")
+        proguardFiles("proguard-rules.pro", getDefaultProguardFile("proguard-android.txt"))
     }
 
     // necessary for Android Work lib
@@ -62,8 +64,8 @@ android {
             isDebuggable = true
         }
         release {
-            // If you make this true you get a version of the game that just flat-out doesn't run
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            // TODO: In the future, switch to "proguard-android-optimize.txt"
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
             isDebuggable = false
         }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -12,19 +12,15 @@
 
 # Add any project specific keep options here:
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
 -verbose
 
 -dontwarn android.support.**
 -dontwarn com.badlogic.gdx.backends.android.AndroidFragmentApplication
 -dontwarn com.badlogic.gdx.utils.GdxBuild
 -dontwarn com.badlogic.gdx.jnigen.BuildTarget*
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean
+-dontwarn java.awt.Rectangle
 
 -keepclassmembers class com.badlogic.gdx.backends.android.AndroidInput* {
    <init>(com.badlogic.gdx.Application, android.content.Context, java.lang.Object, com.badlogic.gdx.backends.android.AndroidApplicationConfiguration);
@@ -37,7 +33,33 @@
 -keep public class com.badlogic.gdx.graphics.g2d.BitmapFont { *; }
 # You will probably need this line in most cases:
 -keep public class com.badlogic.gdx.graphics.Color { *; }
+-keep class * implements com.badlogic.gdx.utils.Json$Serializable { *; }
+
+# These are for Kotlin serialization
+-keep class * implements kotlinx.serialization.KSerializer { *; }
+-keep @kotlinx.serialization.Serializable class * { *; }
+
+# keep annotations
+-keepattributes RuntimeVisibleAnnotations
+
+# Keep classes, fields, or methods, annotated with @UsedByReflection
+-keep @com.unciv.utils.UsedByReflection class * { *; }
+-keep class * {
+  @com.unciv.utils.UsedByReflection *;
+}
+
+# Keep  @JsonSerialized classes and all members
+-keep @com.unciv.utils.JsonSerialized class * { *; }
+
+# Keep unciv Ruleset and game serialization
+-keep class * implements com.unciv.models.ruleset.IRulesetObject { *; }
+-keep class * implements com.unciv.models.stats.INamed { *; }
+-keep class * implements com.unciv.logic.IsPartOfGameInfoSerialization { *; }
 
 # These two lines are used with mapping files; see https://developer.android.com/build/shrink-code#retracing
 -keepattributes LineNumberTable,SourceFile
 -renamesourcefileattribute SourceFile
+
+-dontobfuscate #This hides potential bugs, but also makes deobfuscation unnecessary
+
+

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -1,5 +1,8 @@
 package com.unciv
 
+import com.unciv.utils.JsonSerialized
+
+@JsonSerialized
 object Constants {
     const val settler = "Settler"
     const val eraSpecificUnit = "Era Starting Unit"

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -84,12 +84,14 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
     private val screenStack = ArrayDeque<BaseScreen>()
 
     override fun create() {
+        print("DO_NOT_SUBMIT UncivGame#create enter gameId=${gameInfo?.gameId}\n")
         isInitialized = false // this could be on reload, therefore we need to keep setting this to false
         Gdx.input.setCatchKey(Input.Keys.BACK, true)
         if (Gdx.app.type != Application.ApplicationType.Desktop) {
             DebugUtils.VISIBLE_MAP = false
         }
         Current = this
+        print("DO_NOT_SUBMIT UncivGame#create prepare files gameId=${gameInfo?.gameId}\n")
         files = UncivFiles(Gdx.files, customDataDirectory)
         Concurrency.run {
             // Delete temporary files created when downloading mods
@@ -109,6 +111,7 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
          * - Skin (hence BaseScreen.setSkin())
          * - Font (hence Fonts.resetFont() inside setSkin())
          */
+        print("DO_NOT_SUBMIT UncivGame#create getGeneralSettings\n")
         settings = files.getGeneralSettings() // needed for the screen
         Display.setScreenMode(settings.screenMode, settings)
         setAsRootScreen(GameStartScreen())  // NOT dependent on any atlas or skin
@@ -145,6 +148,7 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
 
             val vanillaRuleset = RulesetCache.getVanillaRuleset()
 
+            print("DO_NOT_SUBMIT UncivGame#create userId=${settings.multiplayer.getUserId()} gameId=${gameInfo?.gameId}\n")
             if (settings.multiplayer.getUserId().isEmpty()) { // assign permanent user id
                 settings.multiplayer.setUserId(UUID.randomUUID().toString())
                 settings.save()

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -37,6 +37,7 @@ import com.unciv.ui.audio.MusicTrackChooserFlags
 import com.unciv.ui.screens.savescreens.Gzip
 import com.unciv.ui.screens.worldscreen.status.NextTurnProgress
 import com.unciv.utils.DebugUtils
+import com.unciv.utils.JsonSerialized
 import com.unciv.utils.debug
 import yairm210.purity.annotations.Readonly
 import java.security.MessageDigest
@@ -321,6 +322,8 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     fun calculateChecksum(): String {
         val oldChecksum = checksum
         checksum = "" // Checksum calculation cannot include old checksum, obvs
+        val str = json().toJson(this).toByteArray(Charsets.UTF_8)
+        print("DO_NOT_SUBMIT GameInfo#calculateChecksum $str\n")
         val bytes = MessageDigest
             .getInstance("SHA-1")
             .digest(json().toJson(this).toByteArray(Charsets.UTF_8))
@@ -837,6 +840,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
  * Reduced variant of GameInfo used for load preview and multiplayer saves.
  * Contains additional data for multiplayer settings.
  */
+@JsonSerialized
 class GameInfoPreview() {
     var civilizations = mutableListOf<CivilizationInfoPreview>()
     var difficulty = "Chieftain"

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -36,6 +36,7 @@ import com.unciv.models.stats.SubStat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.screens.victoryscreen.RankingType
+import com.unciv.utils.JsonSerialized
 import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.Readonly
@@ -1205,6 +1206,7 @@ class Civilization : IsPartOfGameInfoSerialization {
 /**
  * Reduced variant of CivilizationInfo used for load preview.
  */
+@JsonSerialized
 class CivilizationInfoPreview() {
     var civName = ""
     var civID = ""

--- a/core/src/com/unciv/logic/civilization/PlayerType.kt
+++ b/core/src/com/unciv/logic/civilization/PlayerType.kt
@@ -1,7 +1,9 @@
 package com.unciv.logic.civilization
 
 import com.unciv.logic.IsPartOfGameInfoSerialization
+import com.unciv.utils.JsonSerialized
 
+@JsonSerialized
 enum class PlayerType : IsPartOfGameInfoSerialization {
     AI,
     Human;

--- a/core/src/com/unciv/logic/files/MapSaver.kt
+++ b/core/src/com/unciv/logic/files/MapSaver.kt
@@ -25,6 +25,7 @@ object MapSaver {
     fun mapToSavedString(tileMap: TileMap): String {
         tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign)
         val mapJson = json().toJson(tileMap)
+        print("DO_NOT_SUBMIT MapSaver#mapToSavedString $mapJson\n")
         return if (saveZipped) Gzip.zip(mapJson) else mapJson
     }
 

--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -199,6 +199,8 @@ class UncivFiles(
     fun saveMultiplayerGamePreview(game: GameInfoPreview, file: FileHandle, saveCompletionCallback: (Exception?) -> Unit = ::rethrowIfNotNull) {
         try {
             debug("Saving GameInfoPreview %s to %s", game.gameId, file.path())
+            val str = json().toJson(game)
+            print("DO_NOT_SUBMIT UncivFiles#saveMultiplayerGamePreview $str\n")
             json().toJson(game, file)
             saveCompletionCallback(null)
         } catch (ex: Exception) {
@@ -254,6 +256,8 @@ class UncivFiles(
     }
 
     fun loadGamePreviewFromFile(gameFile: FileHandle): GameInfoPreview {
+        val str = gameFile.readString()
+        print("DO_NOT_SUBMIT UncivFiles#getGeneralSettings $str\n")
         val preview = json().fromJson(GameInfoPreview::class.java, gameFile)
             ?: throw emptyFile(gameFile)
         preview.migrateCivID()
@@ -309,6 +313,8 @@ class UncivFiles(
         var settings: GameSettings? = null
         if (settingsFile.exists()) {
             try {
+                val str = settingsFile.readString()
+                print("DO_NOT_SUBMIT UncivFiles#getGeneralSettings $str\n")
                 settings = json().fromJson(GameSettings::class.java, settingsFile)
                 if (settings.isMigrationNecessary()) {
                     settings.doMigrations(JsonReader().parse(settingsFile))
@@ -325,7 +331,9 @@ class UncivFiles(
     }
 
     fun setGeneralSettings(gameSettings: GameSettings) {
-        getGeneralSettingsFile().writeString(json().toJson(gameSettings), false, Charsets.UTF_8.name())
+        val str = json().toJson(gameSettings)
+        print("DO_NOT_SUBMIT UncivFiles#setGeneralSettings $str\n")
+        getGeneralSettingsFile().writeString(str, false, Charsets.UTF_8.name())
     }
 
     //endregion
@@ -347,6 +355,8 @@ class UncivFiles(
     fun saveModCache(modDataList: List<ModUIData>) {
         val file = getLocalFile(MOD_LIST_CACHE_FILE_NAME)
         try {
+            val str = json().toJson(modDataList)
+            print("DO_NOT_SUBMIT UncivFiles#saveModCache $str\n")
             json().toJson(modDataList, file)
         }
         catch (ex: Exception){ // Not a huge deal if this fails
@@ -395,6 +405,8 @@ class UncivFiles(
             val file = FileHandle(baseDirectory).child(SETTINGS_FILE_NAME)
             if (file.exists()){
                 try {
+                    val str = file.readString()
+                    print("DO_NOT_SUBMIT UncivFiles#getSettingsForPlatformLaunchers $str\n")
                     return json().fromJson(GameSettings::class.java, file)
                 } catch (ex: Exception) {
                     Log.error("Exception while deserializing GameSettings JSON", ex)
@@ -411,6 +423,7 @@ class UncivFiles(
             } catch (ex: Exception) {
                 fixedData
             }
+            print("DO_NOT_SUBMIT UncivFiles#gameInfoFromString $unzippedJson\n")
             val gameInfo = try {
                 json().fromJson(GameInfo::class.java, unzippedJson)
             } catch (ex: Exception) {
@@ -432,6 +445,8 @@ class UncivFiles(
          * @throws SerializationException
          */
         fun gameInfoPreviewFromString(gameData: String): GameInfoPreview {
+            val str = Gzip.unzip(gameData)
+            print("DO_NOT_SUBMIT UncivFiles#gameInfoPreviewFromString $str\n")
             val preview = json().fromJson(GameInfoPreview::class.java, Gzip.unzip(gameData))
             preview.migrateCivID()
             return preview
@@ -443,13 +458,16 @@ class UncivFiles(
 
             if (updateChecksum) game.checksum = game.calculateChecksum()
             val plainJson = json().toJson(game)
+            print("DO_NOT_SUBMIT UncivFiles#gameInfoToString $plainJson\n")
 
             return if (forceZip ?: saveZipped) Gzip.zip(plainJson) else plainJson
         }
 
         /** Returns gzipped serialization of preview [game] */
         fun gameInfoToString(game: GameInfoPreview): String {
-            return Gzip.zip(json().toJson(game))
+            val str = json().toJson(game)
+            print("DO_NOT_SUBMIT UncivFiles#gameInfoToString $str\n")
+            return Gzip.zip(str)
         }
 
         private val charsForbiddenInFileNames = setOf('\\', '/', ':')

--- a/core/src/com/unciv/logic/github/GithubAPI.kt
+++ b/core/src/com/unciv/logic/github/GithubAPI.kt
@@ -7,6 +7,7 @@ import com.unciv.json.json
 import com.unciv.logic.UncivKtor
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.github.Github.repoNameToFolderName
+import com.unciv.utils.JsonSerialized
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -179,6 +180,7 @@ object GithubAPI {
     }
 
     /** Part of [RepoSearch] in Github API response - one repository entry in [items][RepoSearch.items] */
+    @JsonSerialized
     class Repo {
 
         /** Unlike the rest of this class, this is not part of the API but added by us locally
@@ -226,6 +228,7 @@ object GithubAPI {
     }
 
     /** Part of [Repo] in Github API response */
+    @JsonSerialized
     class RepoOwner {
         var login = ""
         var avatar_url: String? = null

--- a/core/src/com/unciv/logic/map/mapgenerator/MapResourceSetting.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapResourceSetting.kt
@@ -1,5 +1,8 @@
 package com.unciv.logic.map.mapgenerator
 
+import com.unciv.utils.JsonSerialized
+
+@JsonSerialized
 enum class MapResourceSetting(
     val label: String,
     val randomLuxuriesPercent: Int = 100,

--- a/core/src/com/unciv/logic/multiplayer/MultiplayerGamePreview.kt
+++ b/core/src/com/unciv/logic/multiplayer/MultiplayerGamePreview.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.MultiplayerServer
 import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.components.extensions.isLargerThan
+import com.unciv.utils.Log
 import com.unciv.utils.debug
 import com.unciv.utils.launchOnGLThread
 import com.unciv.utils.withGLContext
@@ -49,6 +50,7 @@ class MultiplayerGamePreview(
             try {
                 loadPreviewFromFile()
             } catch (e: Throwable) {
+                Log.error("Error loading MultiplayerGamePreview", e)
                 error = e
             }
         }

--- a/core/src/com/unciv/models/metadata/BaseRuleset.kt
+++ b/core/src/com/unciv/models/metadata/BaseRuleset.kt
@@ -1,6 +1,9 @@
 package com.unciv.models.metadata
 
+import com.unciv.utils.JsonSerialized
+
 @Suppress("EnumEntryName")  // These merit unusual names
+@JsonSerialized
 enum class BaseRuleset(val fullName: String) {
     Civ_V_Vanilla("Civ V - Vanilla"),
     Civ_V_GnK("Civ V - Gods & Kings"),

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -17,16 +17,16 @@ import com.unciv.ui.components.input.KeyboardBindings
 import com.unciv.ui.screens.worldscreen.NotificationsScroll
 import com.unciv.utils.Display
 import com.unciv.utils.ScreenOrientation
+import com.unciv.utils.JsonSerialized
 import java.awt.Rectangle
 import yairm210.purity.annotations.Readonly
 import java.text.Collator
 import java.text.NumberFormat
 import java.time.Duration
 import java.util.Locale
-import kotlin.reflect.KClass
-import kotlin.reflect.KMutableProperty0
 
 /** Settings that apply across all games, stored in GameSettings.json */
+@JsonSerialized
 class GameSettings {
 
     /** Allows panning the map by moving the pointer to the screen edges */
@@ -220,6 +220,7 @@ class GameSettings {
      *  Open to future enhancement - but:
      *  retrieving a valid position from our upstream libraries while the window is maximized or iconified has proven tricky so far.
      */
+    @JsonSerialized
     data class WindowState(val width: Int = 900, val height: Int = 600) {
         constructor(bounds: Rectangle) : this(bounds.width, bounds.height)
 
@@ -257,6 +258,7 @@ class GameSettings {
             coerceIn(maximumWindowBounds.width, maximumWindowBounds.height)
     }
 
+    @JsonSerialized
     enum class ScreenSize(
         @Suppress("unused")  // Actual width determined by screen aspect ratio, this as comment only
         val virtualWidth: Float,
@@ -273,11 +275,13 @@ class GameSettings {
         override fun toString() = name.tr() // Allow direct use in a SelectBox
     }
 
+    @JsonSerialized
     enum class NationPickerListMode { Icons, List }
 
     //endregion
     //region Multiplayer-specific
 
+    @JsonSerialized
     class GameSettingsMultiplayer {
         private var userId = ""
         fun getUserId() = userId
@@ -335,6 +339,7 @@ class GameSettings {
         }
     }
 
+    @JsonSerialized
     class GameSettingsAutoPlay {
         var showAutoPlayButton: Boolean = false
         var autoPlayUntilEnd: Boolean = false

--- a/core/src/com/unciv/models/metadata/GameSetupInfo.kt
+++ b/core/src/com/unciv/models/metadata/GameSetupInfo.kt
@@ -5,7 +5,9 @@ import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.map.MapParameters
 import com.unciv.logic.map.MapShape
+import com.unciv.utils.JsonSerialized
 
+@JsonSerialized
 class GameSetupInfo(
     val gameParameters: GameParameters = GameParameters(),
     val mapParameters: MapParameters = MapParameters()

--- a/core/src/com/unciv/models/metadata/OverviewPersistableData.kt
+++ b/core/src/com/unciv/models/metadata/OverviewPersistableData.kt
@@ -5,7 +5,9 @@ import com.badlogic.gdx.utils.JsonValue
 import com.badlogic.gdx.utils.SerializationException
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewTab
+import com.unciv.utils.JsonSerialized
 
+@JsonSerialized
 class OverviewPersistableData(
     private val map: LinkedHashMap<EmpireOverviewCategories, EmpireOverviewTab.EmpireOverviewTabPersistableData> = linkedMapOf()
 ) : Json.Serializable,

--- a/core/src/com/unciv/models/ruleset/ModOptions.kt
+++ b/core/src/com/unciv/models/ruleset/ModOptions.kt
@@ -5,7 +5,9 @@ import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTarget
+import com.unciv.utils.JsonSerialized
 
+@JsonSerialized
 class ModOptions : IHasUniques {
     //region Modder choices
     var isBaseRuleset = false

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -35,6 +35,7 @@ import com.unciv.models.stats.SubStat
 import com.unciv.models.translations.tr
 import com.unciv.ui.screens.civilopediascreen.ICivilopediaText
 import com.unciv.utils.Log
+import com.unciv.utils.JsonSerialized
 import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Readonly
 import kotlin.collections.set
@@ -73,6 +74,7 @@ enum class RulesetFile(
     Ruins("Ruins.json", { ruinRewards.values.asSequence() });
 }
 
+@JsonSerialized
 class Ruleset {
 
     /** If (and only if) this Ruleset is a mod, this will be the source folder.

--- a/core/src/com/unciv/models/ruleset/tech/TechColumn.kt
+++ b/core/src/com/unciv/models/ruleset/tech/TechColumn.kt
@@ -1,5 +1,8 @@
 package com.unciv.models.ruleset.tech
 
+import com.unciv.utils.JsonSerialized
+
+@JsonSerialized
 class TechColumn {
     var columnNumber: Int = 0
     lateinit var era: String

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.stats
 
 import com.unciv.models.translations.tr
+import com.unciv.utils.JsonSerialized
 import yairm210.purity.annotations.*
 
 /**
@@ -12,6 +13,7 @@ import yairm210.purity.annotations.*
  * Also possible: `<Stats>`.[values].sum() and similar aggregates over a Sequence<Float>.
  */
 @InternalState
+@JsonSerialized
 open class Stats(
     var production: Float = 0f,
     var food: Float = 0f,

--- a/core/src/com/unciv/ui/components/fonts/FontFamilyData.kt
+++ b/core/src/com/unciv/ui/components/fonts/FontFamilyData.kt
@@ -1,10 +1,12 @@
 package com.unciv.ui.components.fonts
 
 import com.unciv.models.translations.tr
+import com.unciv.utils.JsonSerialized
 
 // If save in `GameSettings` need use invariantFamily.
 // If show to user need use localName.
 // If save localName in `GameSettings` may generate garbled characters by encoding.
+@JsonSerialized
 class FontFamilyData(
     val localName: String,
     val invariantName: String = localName,

--- a/core/src/com/unciv/ui/components/input/KeyCharAndCode.kt
+++ b/core/src/com/unciv/ui/components/input/KeyCharAndCode.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.utils.Json
 import com.badlogic.gdx.utils.JsonValue
 import com.unciv.ui.components.extensions.GdxKeyCodeFixes
+import com.unciv.utils.JsonSerialized
 
 
 /*
@@ -26,6 +27,7 @@ import com.unciv.ui.components.extensions.GdxKeyCodeFixes
  * @see KeyboardBinding
  * @see KeyShortcutListener
  */
+@JsonSerialized
 data class KeyCharAndCode(val char: Char, val code: Int) {
     /** helper 'cloning constructor' to allow feeding both fields from a factory function */
     private constructor(from: KeyCharAndCode): this(from.char, from.code)

--- a/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.components.input
 import com.badlogic.gdx.Input
 import com.unciv.Constants
 import com.unciv.models.stats.Stat
+import com.unciv.utils.JsonSerialized
 
 
 private val unCamelCaseRegex = Regex("([A-Z])([A-Z])([a-z])|([a-z])([A-Z])")
@@ -16,6 +17,7 @@ private fun unCamelCase(name: String) = unCamelCaseRegex.replace(name, """$1$4 $
  *
  *  [label] entries containing a placeholder need special treatment - see [getTranslationEntries] and update it when adding more.
  */
+@JsonSerialized
 enum class KeyboardBinding(
     val category: Category,
     label: String? = null,
@@ -220,6 +222,7 @@ enum class KeyboardBinding(
     ;
     //endregion
 
+    @JsonSerialized
     enum class Category {
         None,
         MainMenu,

--- a/core/src/com/unciv/ui/components/input/KeyboardBindings.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBindings.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.components.input
 import com.badlogic.gdx.utils.Json
 import com.badlogic.gdx.utils.JsonValue
 import com.unciv.GUI
+import com.unciv.utils.JsonSerialized
 
 /**
  *  Manage user-configurable keyboard bindings
@@ -10,6 +11,7 @@ import com.unciv.GUI
  *  A primary instance lives in [UncivGame.Current.settings][com.unciv.models.metadata.GameSettings]
  *  and is read/write accessible through the `KeyboardBindings[]` syntax.
  **/
+@JsonSerialized
 class KeyboardBindings : HashMap<KeyboardBinding, KeyCharAndCode>(), Json.Serializable {
 
     /** this [put] overload helps the Json [Serializer] read method */

--- a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
@@ -56,6 +56,7 @@ abstract class BaseScreen : Screen {
     val globalShortcuts = KeyShortcutDispatcher()
 
     init {
+        print("DO_NOT_SUBMIT BaseScreen#init gameId=${game.gameInfo?.gameId}\n")
         val screenSize = game.settings.screenSize
         val height = screenSize.virtualHeight
 

--- a/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
@@ -23,6 +23,7 @@ import com.unciv.ui.components.widgets.ColorMarkupLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Log
+import com.unciv.utils.JsonSerialized
 import kotlin.math.max
 
 /* Ideas:
@@ -45,6 +46,7 @@ import kotlin.math.max
  *  - A separator line ([separator])
  *  - Automatic external links ([link] begins with a URL protocol)
  */
+@JsonSerialized
 class FormattedLine (
     /** Text to display. */
     val text: String = "",

--- a/core/src/com/unciv/ui/screens/modmanager/ModUIData.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModUIData.kt
@@ -5,6 +5,7 @@ import com.unciv.models.metadata.ModCategories
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.utils.JsonSerialized
 
 /** Helper class holds combined mod info for ModManagementScreen, used for both installed and online lists.
  *
@@ -12,6 +13,7 @@ import com.unciv.ui.components.fonts.Fonts
  *  (This is important on resize - ModUIData are passed to the new screen)
  *  Note it is guaranteed either ruleset or repo are non-null, never both.
  */
+@JsonSerialized
 class ModUIData private constructor(
     val name: String,
     val description: String,

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/GameList.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/GameList.kt
@@ -115,7 +115,7 @@ private class GameDisplay(
         return container
     }
 
-    fun isPlayersTurn() = preview?.isUsersTurn() == true
+    fun isPlayersTurn() = try { preview?.isUsersTurn() == true } catch (e: Exception) { false } // DO_NOT_SUBMIT
 
     override fun compareTo(other: GameDisplay): Int =
             if (isPlayersTurn() != other.isPlayersTurn()) // games where it's the player's turn are displayed first, thus must get the lower number

--- a/core/src/com/unciv/ui/screens/pickerscreens/PromotionScreenColors.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PromotionScreenColors.kt
@@ -2,12 +2,14 @@ package com.unciv.ui.screens.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
 import com.unciv.ui.images.ImageGetter
+import com.unciv.utils.JsonSerialized
 
 
 /** Colours used on the [PromotionPickerScreen]
  *
  *  These are backed by Skin.json
  */
+@JsonSerialized
 class PromotionScreenColors {
     val default: Color = ImageGetter.CHARCOAL
     val selected: Color = Color(0.2824f, 0.5765f, 0.6863f, 1f)          // colorFromRGB(72, 147, 175)

--- a/core/src/com/unciv/utils/Display.kt
+++ b/core/src/com/unciv/utils/Display.kt
@@ -3,6 +3,7 @@ package com.unciv.utils
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.translations.tr
 
+@JsonSerialized
 enum class ScreenOrientation(val description: String)  {
     Landscape("Landscape (fixed)"),
     Portrait("Portrait (fixed)"),

--- a/core/src/com/unciv/utils/JsonSerialized.kt
+++ b/core/src/com/unciv/utils/JsonSerialized.kt
@@ -1,0 +1,5 @@
+package com.unciv.utils
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class JsonSerialized()

--- a/core/src/com/unciv/utils/UsedByReflection.kt
+++ b/core/src/com/unciv/utils/UsedByReflection.kt
@@ -1,0 +1,5 @@
+package com.unciv.utils
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
+annotation class UsedByReflection()


### PR DESCRIPTION
isMinifyEnabled=true

Classes with @JsonSerialized @UsedByReflection, @Serializable, or extending KSerializer, IRulesetObject, INamed, or IsPartOfGameInfoSerialization and their members and methods are not renamed or removed.

Follow up CLs should switch to proguard-android-optimize.txt, and ensure `-allowaccessmodification` as well.