### PR TITLE
Jungles again no longer spawn on hills

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -88,7 +88,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
                     tile.getBaseTerrain().type == TerrainType.Land
                         && tile.getBaseTerrain().hasUnique(UniqueType.OccursInChains) == occursInChains
                 else
-                    terrain.occursOn.contains(tile.baseTerrain)
+                    terrain.occursOn.contains(tile.lastTerrain.name)
         }
         
         /** Checks if both [temperature] and [humidity] satisfy their ranges (>From, <=To)
@@ -100,8 +100,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
         fun matches(tile: Tile, overrideTileTemp: Double) =
             tempFrom < overrideTileTemp && overrideTileTemp <= tempTo &&
                 humidFrom < (tile.humidity ?: 0.0) && (tile.humidity?:0.0) <= humidTo &&
-                matchesBaseTerrain(tile) &&
-                tile.hasVegetation == hasVegitation
+                matchesBaseTerrain(tile)
 
         fun matchesIce() = terrain.type == TerrainType.TerrainFeature && terrain.impassable && terrain.occursOn.contains(Constants.ocean)
 
@@ -493,7 +492,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             elevationTerrains.add(Constants.mountain)
 
         for (tile in tileMap.values.asSequence()) {
-            if (tile.isWater)
+            if (tile.isWater || tile.baseTerrain in elevationTerrains)
                 continue
 
             val humidityRandom = randomness.getPerlinNoise(tile, humiditySeed, scale = scale, nOctaves = 1)
@@ -621,12 +620,12 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             val vegetation = (randomness.getPerlinNoise(tile, vegetationSeed, scale = 3.0, nOctaves = 1) + 1.0) / 2.0
 
             if (vegetation <= tileMap.mapParameters.vegetationRichness) {
-                tile.hasVegetation = true
                 val possibleVegetation = vegetationTerrains.filter { it.matches(tile)
                     && NaturalWonderGenerator.fitsTerrainUniques(it.terrain, tile)
                 }
                 if (possibleVegetation.isEmpty()) continue
                 val randomVegetation = possibleVegetation.random(randomness.RNG)
+                tile.hasVegetation = true
                 tile.addTerrainFeature(randomVegetation.name)
             }
         }


### PR DESCRIPTION
Specifically, new features must again able to occur on the LAST feature on the tile (or baseTerrain).  This reproduces the old conditions, weird as they were.

I also removed the hasVegitation from matches, better matching prior conditions. It only affected the case where the MapEditor generated vegetation, and then regenerated temperature, mountains or lakes, which is rare enough that keeping old behavior is safer.

applyHumidityAndTemperature now again ignores hills and mountains, like it used to. Again, It only affected the case where the MapEditor generated elevation, and then regenerated temperature, which is rare enough that keeping old behavior is safer.

Bug detected by Lodo the Bear in https://discord.com/channels/586194543280390151/588357826758574106/1474933903461716030