### PR TITLE
MapGen baseTerrainPicker now ignores Lands with occursOn

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -50,9 +50,10 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
         .toList()
         .sortedBy { it.isConstrained }
     private val baseTerrainPicker = terrainConditions
-        .filter{ it.terrain.type == TerrainType.Land || it.terrain.type == TerrainType.Water }
+        .filter{ (it.terrain.type == TerrainType.Land || it.terrain.type == TerrainType.Water)
+            && it.terrain.occursOn.isEmpty() }
     private val terrainFeaturePicker = terrainConditions
-        .filter{ it.terrain.type == TerrainType.TerrainFeature }
+        .filter{ it.terrain.type == TerrainType.TerrainFeature}
 
     /** Associates [terrain] with a range of temperatures and a range of humidities (both open to closed) */
     internal class TerrainOccursRange(


### PR DESCRIPTION
Apparently AutumnCat0w0/Hodgepodge-mod has a natural wonder Eyjafjallajokull that spawns Andosols on Tundra around it, but that terrain should otherwise not appear.

Found by Kaier https://discord.com/channels/586194543280390151/588357826758574106/1475162024211255540