### PR TITLE
CityStateCanBeBoughtForStat + Stat.Tourism

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
@@ -1,6 +1,5 @@
 package com.unciv.logic.automation.civilization
 
-import com.unciv.UncivGame
 import com.unciv.logic.battle.BattleDamage
 import com.unciv.logic.battle.CityCombatant
 import com.unciv.logic.battle.MapUnitCombatant
@@ -342,9 +341,7 @@ object MotivationToAttackAutomation {
             // We only want to calculate the best attack path and use it's value
             // Land routes are clearly better than sea routes
             for ((_, cityToAttack) in attacksGroupedByCity.value) {
-                val landAttackPath = 
-                    if (UncivGame.Current.settings.useAStarPathfinding) cityToAttackFrom.getLandAttackPath(cityToAttack, maxTurns = 17)
-                    else MapPathing.getConnection(civInfo, cityToAttackFrom.getCenterTile(), cityToAttack.getCenterTile(), ::isLandTileCanMoveThrough)
+                val landAttackPath = MapPathing.getConnection(civInfo, cityToAttackFrom.getCenterTile(), cityToAttack.getCenterTile(), ::isLandTileCanMoveThrough)
                 if (landAttackPath != null && landAttackPath.size < 16) {
                     attackPaths.add(landAttackPath)
                     cityAttackValue = 3f
@@ -353,9 +350,7 @@ object MotivationToAttackAutomation {
 
                 if (cityAttackValue > 0) continue
 
-                val landAndSeaAttackPath =
-                    if (UncivGame.Current.settings.useAStarPathfinding) cityToAttackFrom.getAmphibiousAttackPath(cityToAttack, maxTurns = 17)
-                    else MapPathing.getConnection(civInfo, cityToAttackFrom.getCenterTile(), cityToAttack.getCenterTile(), ::isTileCanMoveThrough)
+                val landAndSeaAttackPath = MapPathing.getConnection(civInfo, cityToAttackFrom.getCenterTile(), cityToAttack.getCenterTile(), ::isTileCanMoveThrough)
                 if (landAndSeaAttackPath != null  && landAndSeaAttackPath.size < 16) {
                     attackPaths.add(landAndSeaAttackPath)
                     cityAttackValue += 1

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -28,7 +28,6 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
 import com.unciv.ui.screens.victoryscreen.RankingType
 import com.unciv.utils.randomWeighted
-import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Readonly
 import kotlin.random.Random
 
@@ -495,9 +494,7 @@ object NextTurnAutomation {
             Battle.moveAndAttack(MapUnitCombatant(unit), mostSurroundedEnemy)
         }
     }
-    
-    @VisibleForTesting
-    fun automateSettlerEscorting(civInfo: Civilization){
+    private fun automateSettlerEscorting(civInfo: Civilization){
         val capitalTile = civInfo.getCapital()!!.getCenterTile()
         @Readonly fun bestUnitInRange(tile: Tile, range: Int) = tile.getTilesInDistance(range)
             .mapNotNull { it.militaryUnit }.filter {

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -44,10 +44,11 @@ object UseGoldAutomation {
         val knownCityStates = civ.getKnownCivs().filter { it.isCityState && MotivationToAttackAutomation.hasAtLeastMotivationToAttack(civ, it, 0f) <= 0 }.toList()
 
         // canBeMarriedBy checks actual cost, but it can't be below 500*speedmodifier, and the later check is expensive
-        if (civ.gold >= 330 && civ.getHappiness() > 0 && civ.hasUnique(UniqueType.CityStateCanBeBoughtForGold)) {
+        if (civ.gold >= 330 && civ.getHappiness() > 0 && civ.hasUnique(UniqueType.CityStateCanBeBoughtForStat)) { 
+            //TODO: Add support for other stats
             for (cityState in knownCityStates.toList() ) {  // Materialize sequence as diplomaticMarriage may kill a CS
                 if (cityState.cityStateFunctions.canBeMarriedBy(civ))
-                    cityState.cityStateFunctions.diplomaticMarriage(civ)
+                    cityState.cityStateFunctions.diplomaticMarriage(civ, Stat.Gold)
                 if (civ.getHappiness() <= 0) break // Stop marrying if happiness is getting too low
             }
         }

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -303,8 +303,8 @@ class CityStateFunctions(val civInfo: Civilization) {
             )
             newAlly.cache.updateViewableTiles()
             newAlly.cache.updateCivResources()
-            for (unique in newAlly.getMatchingUniques(UniqueType.CityStateCanBeBoughtForGold))
-                newAlly.getDiplomacyManager(civInfo)!!.setFlag(DiplomacyFlags.MarriageCooldown, unique.params[0].toInt())
+            for (unique in newAlly.getMatchingUniques(UniqueType.CityStateCanBeBoughtForStat))
+                newAlly.getDiplomacyManager(civInfo)!!.setFlag(DiplomacyFlags.MarriageCooldown, unique.params[2].toInt())
 
             // Join the wars of our new ally - loop through all civs they are at war with
             for (newEnemy in civInfo.gameInfo.civilizations.filter { it.isAtWarWith(newAlly) && it.isAlive() } ) {
@@ -363,23 +363,58 @@ class CityStateFunctions(val civInfo: Civilization) {
         return cost
     }
 
-    @Readonly
-    fun canBeMarriedBy(otherCiv: Civilization): Boolean {
-        return (!civInfo.isDefeated()
-                && civInfo.isCityState
-                && civInfo.cities.any()
-                && civInfo.getDiplomacyManager(otherCiv)!!.isRelationshipLevelEQ(RelationshipLevel.Ally)
-                && !otherCiv.getDiplomacyManager(civInfo)!!.hasFlag(DiplomacyFlags.MarriageCooldown)
-                && otherCiv.getMatchingUniques(UniqueType.CityStateCanBeBoughtForGold).any()
-                && otherCiv.gold >= getDiplomaticMarriageCost())
-
+    fun enoughToGetMarried(otherCiv: Civilization, stat:Stat): Boolean{
+        for (unique in otherCiv.getMatchingUniques(UniqueType.CityStateCanBeBoughtForStat)){
+            
+        }
+        return false;
     }
 
-    fun diplomaticMarriage(otherCiv: Civilization) {
-        if (!canBeMarriedBy(otherCiv))  // Just in case
+    fun enoughToGetMarriedAny(otherCiv: Civilization): Boolean{
+        return (
+            (enoughToGetMarried(otherCiv, Stat.Culture)) ||
+            (enoughToGetMarried(otherCiv, Stat.Science)) ||
+            (enoughToGetMarried(otherCiv, Stat.Gold)) ||
+            (enoughToGetMarried(otherCiv, Stat.Faith)) ||
+            (enoughToGetMarried(otherCiv, Stat.Happiness)) || 
+            (enoughToGetMarried(otherCiv, Stat.Tourism))
+            )
+    }
+    @Readonly
+    fun canBeMarriedBy(otherCiv: Civilization): Boolean {
+        return (
+            (canBeMarriedByStat(otherCiv, Stat.Culture)) ||
+            (canBeMarriedByStat(otherCiv, Stat.Science)) ||
+            (canBeMarriedByStat(otherCiv, Stat.Gold)) ||
+            (canBeMarriedByStat(otherCiv, Stat.Faith)) ||
+            (canBeMarriedByStat(otherCiv, Stat.Happiness)) ||
+            (canBeMarriedByStat(otherCiv, Stat.Tourism))
+        )
+    }
+
+    @Readonly
+    fun canBeMarriedByStat(otherCiv: Civilization, stat:Stat): Boolean {
+        if (!civInfo.isDefeated()
+            && civInfo.isCityState
+            && civInfo.cities.any()
+            && civInfo.getDiplomacyManager(otherCiv)!!.isRelationshipLevelEQ(RelationshipLevel.Ally)
+            && !otherCiv.getDiplomacyManager(civInfo)!!.hasFlag(DiplomacyFlags.MarriageCooldown)
+            ){
+            for(unique in otherCiv.getMatchingUniques(UniqueType.CityStateCanBeBoughtForStat)){
+                if(Stat.isStat(unique.params[0])){
+                    val uniqueStat = Stat.safeValueOf(unique.params[0])
+                    return (uniqueStat == stat && otherCiv.getStatReserve(stat) >= getDiplomaticMarriageCost())
+                }
+            }
+        }
+        return false;
+    }
+
+    fun diplomaticMarriage(otherCiv: Civilization, stat:Stat) {
+        if (!canBeMarriedByStat(otherCiv,stat))  // Just in case
             return
 
-        otherCiv.addGold(-getDiplomaticMarriageCost())
+        otherCiv.addStat(stat,-getDiplomaticMarriageCost())
         
         val notificationLocation = civInfo.getCapital()!!.location
         otherCiv.addNotification("We have married into the ruling family of [${civInfo.civName}], bringing them under our control.",

--- a/core/src/com/unciv/models/UncivSound.kt
+++ b/core/src/com/unciv/models/UncivSound.kt
@@ -15,6 +15,7 @@ data class UncivSound(
         val Bombard = UncivSound("bombard")
         val Chimes = UncivSound("chimes")
         val Choir = UncivSound("choir")
+        val Flight = UncivSound("flight")
         val Click = UncivSound("click")
         val Coin = UncivSound("coin")
         val Construction = UncivSound("construction")

--- a/core/src/com/unciv/models/ruleset/nation/Personality.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Personality.kt
@@ -41,6 +41,7 @@ enum class PersonalityValue {
                 Stat.Culture -> Culture
                 Stat.Happiness -> Happiness
                 Stat.Faith -> Faith
+                Stat.Tourism -> Culture //TODO: Create Tourism personality or something
             }
         }
     }

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -341,7 +341,7 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
     },
 
-    /** Please leave this one in, it is tested against in [com.unciv.uniques.CountableTests.testRulesetValidation] */
+    /** Please leave this one in, it is tested against in [ com.unciv.uniques.CountableTests.testRulesetValidation] */
     @Deprecated("because it was never actually supported", ReplaceWith("Remaining [City-State] Civilizations"), DeprecationLevel.ERROR)
     CityStates("City-States", shortDocumentation = "counts all undefeated city-states") {
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
@@ -375,6 +375,7 @@ enum class Countables(
                 Stat.Culture -> speed.cultureCostModifier
                 Stat.Happiness -> speed.modifier
                 Stat.Faith -> speed.faithCostModifier
+                Stat.Tourism -> speed.cultureCostModifier //TODO: Check if this is right
             }
             return modifier.times(100).toInt()
         }
@@ -406,16 +407,6 @@ enum class Countables(
             "Since on translation, the brackets are removed, the expression will be displayed as `(Melee units + 1) / Cities`",
             "Supported operations between 2 values are: "+ Operator.BinaryOperators.entries.joinToString { it.symbol },
             "Supported operations on 1 value are: " + Operator.UnaryOperators.entries.joinToString { "${it.symbol} (${it.description})" },
-            "Supported functions:",
-            *Operator.Functions.entries.map { 
-                val arityText = if (it.arityRange.first == it.arityRange.last) 
-                    "${it.arityRange.first} argument${if (it.arityRange.first != 1) "s" else ""}"
-                else 
-                    "${it.arityRange.first} to ${it.arityRange.last} arguments"
-                var functionParameters = List(it.arityRange.first){"expression"}.joinToString(",")
-                if (it.arityRange.first != it.arityRange.last) functionParameters += ",..."
-                " - `${it.symbol}($functionParameters)`"
-            }.toTypedArray(),
         )
     }
     ;
@@ -434,7 +425,7 @@ enum class Countables(
     @Readonly open fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf(text)
 
     /** This indicates whether a parameter *is of this countable type*, not *whether its parameters are correct*
-     * E.g. "[fakeBuilding] Buildings" is obviously a countable of type "[buildingFilter] Buildings", therefore matches will return true.
+     * E.g. "[ fakeBuilding] Buildings" is obviously a countable of type "[ buildingFilter] Buildings", therefore matches will return true.
      * But it has another problem, which is that the building filter is bad, so its getErrorSeverity will return "ruleset specific" */
     @Readonly open fun matches(parameterText: String, ruleset: Ruleset): Boolean = false
     @Readonly abstract fun eval(parameterText: String, gameContext: GameContext): Int?

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -80,14 +80,13 @@ enum class UniqueType(
     CityStateMilitaryUnits("Provides military units every ≈[positiveAmount] turns", UniqueTarget.CityState),
     CityStateUniqueLuxury("Provides a unique luxury", UniqueTarget.CityState), // No conditional support as of yet
 
-    // Todo: Lowercase the 'U' of 'Units' in this unique
-    CityStateGiftedUnitsStartWithXp("Military Units gifted from City-States start with [positiveAmount] XP", UniqueTarget.Global),
+    CityStateGiftedUnitsStartWithXp("Military units gifted from City-States start with [positiveAmount] XP", UniqueTarget.Global),
+    
     CityStateMoreGiftedUnits("Militaristic City-States grant units [positiveAmount] times as fast when you are at war with a common nation", UniqueTarget.Global),
 
     CityStateGoldGiftsProvideMoreInfluence("Gifts of Gold to City-States generate [relativeAmount]% more Influence", UniqueTarget.Global),
-    
-    
-    CityStateCanBeBoughtForGold("Can spend Gold to annex or puppet a City-State that has been your Ally for [nonNegativeAmount] turns", UniqueTarget.Global),
+
+    CityStateCanBeBoughtForStat("Can spend [stat] to annex or puppet a City-State that has been your [comment] for [nonNegativeAmount] turns", UniqueTarget.Global),
     CityStateTerritoryAlwaysFriendly("City-State territory always counts as friendly territory", UniqueTarget.Global),
 
     CityStateCanGiftGreatPeople("Allied City-States will occasionally gift Great People", UniqueTarget.Global),  // used in Policy
@@ -1069,9 +1068,15 @@ enum class UniqueType(
     ConditionalModEnabled("if [modFilter] is enabled", UniqueTarget.Conditional),
     ConditionalModNotEnabled("if [modFilter] is not enabled", UniqueTarget.Conditional),
 
+    //lab
+
     // endregion
 
     ///////////////////////////////////////////// region 99 DEPRECATED AND REMOVED /////////////////////////////////////////////
+    //
+    @Deprecated("As of 4.20.1", ReplaceWith("Military units gifted from City-States start with [positiveAmount] XP"), DeprecationLevel.ERROR)
+    CityStateGiftedUnitsStartWithXpOld("Military Units gifted from City-States start with [positiveAmount] XP",  UniqueTarget.Global),
+
     @Deprecated("As of 4.18.15", ReplaceWith("Receive [+200]% Gold from Barbarian encampments and pillaging Cities"), DeprecationLevel.ERROR)
     TripleGoldFromEncampmentsAndCities("Receive triple Gold from Barbarian encampments and pillaging Cities", UniqueTarget.Global),
     @Deprecated("As of 4.18.15", ReplaceWith("[+100]% Gold given to enemy if city is captured <in this city>"), DeprecationLevel.ERROR)
@@ -1101,8 +1106,10 @@ enum class UniqueType(
     HiddenBeforeAmountPolicies("Hidden until [amount] social policy branches have been completed", UniqueTarget.Building, UniqueTarget.Unit),
     @Deprecated("As of 4.15.11", ReplaceWith("New [baseUnitFilter] units start with [amount] XP [cityFilter]"), DeprecationLevel.ERROR)
     UnitStartingExperienceOld("New [baseUnitFilter] units start with [amount] Experience [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    @Deprecated("As of 4.15.2", ReplaceWith("Can spend Gold to annex or puppet a City-State that has been your Ally for [amount] turns"), DeprecationLevel.ERROR)
+    @Deprecated("As of 4.15.2", ReplaceWith("Can spend [Gold] to annex or puppet a City-State that has been your [Ally] for [amount] turns"), DeprecationLevel.ERROR)
     CityStateCanBeBoughtForGoldOld("Can spend Gold to annex or puppet a City-State that has been your ally for [amount] turns.", UniqueTarget.Global),
+    @Deprecated("As of 4.20.0", ReplaceWith("Can spend [Gold] to annex or puppet a City-State that has been your [Ally] for [nonNegativeAmount] turns"), DeprecationLevel.Global)
+    CityStateCanBeBoughtForGold("Can spend Gold to annex or puppet a City-State that has been your Ally for [nonNegativeAmount] turns", UniqueTarget.Global),
     @Deprecated("As of 4.14.6", ReplaceWith("[+100]% Strength <when defending> <when [Embarked]>"), DeprecationLevel.ERROR)
     DefenceBonusWhenEmbarked("Defense bonus when embarked", UniqueTarget.Unit, UniqueTarget.Global),
     @Deprecated("As of 4.13.18", ReplaceWith("Only available <when [victoryType] Victory is enabled>"), DeprecationLevel.ERROR)

--- a/core/src/com/unciv/models/ruleset/unique/expressions/Node.kt
+++ b/core/src/com/unciv/models/ruleset/unique/expressions/Node.kt
@@ -23,6 +23,7 @@ internal sealed interface Node {
     }
 
     class UnaryOperation(private val operator: Operator.Unary, private val operand: Node): Node {
+        @Suppress("purity") // cannot mark class val as @Read
         override fun eval(context: GameContext): Double = operator.implementation(operand.eval(context))
         override fun toString() = "($operator $operand)"
         override fun getErrors(ruleset: Ruleset) = operand.getErrors(ruleset)
@@ -56,6 +57,7 @@ internal sealed interface Node {
                 ?: Countables.getMatching(parameterText, ruleset)
         }
 
+        @Readonly
         override fun getErrors(ruleset: Ruleset): List<String> {
             if (getCountable(ruleset) == null)
                 return listOf("Unknown countable: $parameterText")
@@ -63,18 +65,5 @@ internal sealed interface Node {
         }
 
         override fun toString() = "[Countable: $parameterText]"
-    }
-
-    class FunctionCall(private val function: Operator.Function, private val arguments: List<Node>): Node {
-        override fun eval(context: GameContext): Double {
-            val evaluatedArgs = arguments.map { it.eval(context) }
-            return function.implementation(evaluatedArgs)
-        }
-
-        override fun getErrors(ruleset: Ruleset): List<String> {
-            return arguments.flatMap { it.getErrors(ruleset) }
-        }
-
-        override fun toString() = "[FunctionCall: ${function.symbol}(${arguments.joinToString(", ")})]"
     }
 }

--- a/core/src/com/unciv/models/ruleset/unique/expressions/Operator.kt
+++ b/core/src/com/unciv/models/ruleset/unique/expressions/Operator.kt
@@ -27,12 +27,6 @@ internal sealed interface Operator : Tokenizer.Token {
         val binary: Binary
     }
 
-    interface Function : Operator {
-        /** Number of arguments the function accepts - can be a range for variadic functions */
-        val arityRange: IntRange
-        val implementation: (List<Double>) -> Double
-    }
-
     enum class UnaryOperators(
         override val symbol: String,
         override val implementation: (Double) -> Double,
@@ -74,17 +68,6 @@ internal sealed interface Operator : Tokenizer.Token {
         override fun toString() = symbol
     }
 
-    enum class Functions(
-        override val symbol: String,
-        override val arityRange: IntRange,
-        override val implementation: (List<Double>) -> Double
-    ) : Function {
-        Max("max", 2..Int.MAX_VALUE, { args -> args.maxOrNull() ?: 0.0 }),
-        Min("min", 2..Int.MAX_VALUE, { args -> args.minOrNull() ?: 0.0 }),
-        ;
-        override fun toString() = symbol
-    }
-
     enum class NamedConstants(override val symbol: String, override val value: Double) : Node.Constant, Operator {
         Pi("pi", PI),
         Pi2("π", PI),
@@ -104,7 +87,6 @@ internal sealed interface Operator : Tokenizer.Token {
             UnaryOperators.entries.asSequence() +
             BinaryOperators.entries +
             UnaryOrBinaryOperators.entries + // Will overwrite the previous entries in the map
-            Functions.entries +
             NamedConstants.entries +
             Parentheses.entries
         @Immutable private val cache = allEntries().associateBy { it.symbol }

--- a/core/src/com/unciv/models/ruleset/unique/expressions/Parser.kt
+++ b/core/src/com/unciv/models/ruleset/unique/expressions/Parser.kt
@@ -22,7 +22,7 @@ import yairm210.purity.annotations.Readonly
  *  - Non-Alphanumeric tokens are always one character (ie needs work to support `<=` and similar operators).
  *  - Numeric constants do not support scientific notation.
  *  - Alphanumeric identifiers (can be matched with simple countables or function names) can _only_ contain letters and digits as defined by  defined by unicode properties, and '_'.
- *  - Functions support comma-separated arguments, e.g., max(a, b, c).
+ *  - Functions with arity > 1 aren't supported. No parameter lists with comma - in fact, functions are just implemented as infix operators.
  *  - Only prefix Unary operators, e.g. no standard factorial notation.
  */
 object Parser {
@@ -57,7 +57,6 @@ object Parser {
     class MissingOperand(position: Int) : SyntaxError("Missing operand", position)
     class InvalidConstant(position: Int, text: String) : SyntaxError("Invalid constant: $text", position)
     class UnknownIdentifier(position: Int, text: String) : ParsingError("Unknown identifier: \"$text\"", position)
-    class InvalidFunctionArity(position: Int, functionName: String, expected: String, actual: Int) : ParsingError("Function $functionName at position $position should get $expected arguments, got $actual", position)
     class EmptyExpression : ParsingError("Empty expression", 0)
     //endregion
 
@@ -109,39 +108,6 @@ object Parser {
             return Node.UnaryOperation(operator, fetchOperand())
         }
 
-        private fun handleFunction(function: Operator.Function): Node {
-            val functionPosition = currentPosition
-            next() // consume function name
-            expect(Parentheses.Opening)
-            next() // consume '('
-
-            val arguments = mutableListOf<Node>()
-            // Parse first argument
-            arguments.add(expression())
-
-            // Parse additional arguments separated by commas
-            while (currentToken == Tokenizer.Comma) {
-                next() // consume ','
-                arguments.add(expression())
-            }
-
-            expect(Parentheses.Closing)
-            next() // consume ')'
-
-            // Check arity range
-            if (arguments.size !in function.arityRange) {
-                val expectedRange = function.arityRange
-                val expectedDesc = when {
-                    expectedRange.last == Int.MAX_VALUE -> "${expectedRange.first} arguments and up"
-                    expectedRange.first == expectedRange.last -> "${expectedRange.first} argument${if (expectedRange.first == 1) "" else "s"}"
-                    else -> "${expectedRange.first}-${expectedRange.last} arguments"
-                }
-                throw InvalidFunctionArity(functionPosition, function.symbol, expectedDesc, arguments.size)
-            }
-
-            return Node.FunctionCall(function, arguments)
-        }
-
         /**
          * EXAMPLE 1 - 1+2*3
          * We first build the '1' node in the initial fetchOperand().
@@ -183,8 +149,6 @@ object Parser {
             if (currentToken == StartToken) next()
             if (currentToken.canBeUnary()) {
                 return handleUnary()
-            } else if (currentToken is Operator.Function) {
-                return handleFunction(currentToken as Operator.Function)
             } else if (currentToken == Parentheses.Opening) {
                 next()
                 val node = expression()

--- a/core/src/com/unciv/models/ruleset/unique/expressions/Tokenizer.kt
+++ b/core/src/com/unciv/models/ruleset/unique/expressions/Tokenizer.kt
@@ -18,7 +18,6 @@ internal object Tokenizer {
      *  - [Operator]
      *  - [Node.Constant]
      *  - [Node.Countable]
-     *  - [Comma] - argument separator in function calls
      */
     internal sealed interface Token {
         @Pure fun canBeUnary() = this is Operator.Unary || this is Operator.UnaryOrBinary
@@ -38,10 +37,6 @@ internal object Tokenizer {
         }
     }
 
-    data object Comma : Token {
-        override fun toString() = ","
-    }
-
     // Define our own "Char is part of literal constant" and "Char is part of identifier" functions - decouple from Java CharacterData
     @Pure private fun Char.isNumberLiteral() = this == '.' || this in '0'..'9' // NOT using library isDigit() here - potentially non-latin
     @Pure private fun Char.isIdentifierStart() = isLetter() // Allow potentially non-latin script //TODO questionable
@@ -55,9 +50,6 @@ internal object Tokenizer {
         assert(text.isNotBlank())
         if (text.first().isNumberLiteral())
             return position to Node.NumericConstant(text.toDouble())
-        if (text == ",") return position to Comma
-        
-        // Check if this is a function (identifier followed by parentheses will be handled in parsing)
         val operator = Operator.of(text)
         if (operator != null) return position to operator
         

--- a/core/src/com/unciv/models/stats/Stat.kt
+++ b/core/src/com/unciv/models/stats/Stat.kt
@@ -20,16 +20,17 @@ enum class Stat(
     Science(NotificationIcon.Science, UncivSound.Chimes, Fonts.science, colorFromHex(0x8c9dff)),
     Culture(NotificationIcon.Culture, UncivSound.Paper, Fonts.culture, colorFromHex(0x8b60ff)),
     Happiness(NotificationIcon.Happiness, UncivSound.Click, Fonts.happiness, colorFromHex(0xffd800)),
-    Faith(NotificationIcon.Faith, UncivSound.Choir, Fonts.faith, colorFromHex(0xcbdfff))
+    Faith(NotificationIcon.Faith, UncivSound.Choir, Fonts.faith, colorFromHex(0xcbdfff)),
+    Tourism(NotificationIcon.Tourism, UncivSound.Flight, Fonts.tourism, colorFromHex(0x8b60ff))
     ;
     val isCityWide by lazy { this !in statsWithCivWideField }
 
     companion object {
-        @Immutable val statsUsableToBuy = setOf(Gold, Food, Science, Culture, Faith)
+        @Immutable val statsUsableToBuy = setOf(Gold, Food, Science, Culture, Faith, Tourism)
         @Immutable private val valuesAsMap = entries.associateBy { it.name }
         @Pure fun safeValueOf(name: String) = valuesAsMap[name]
         @Pure fun isStat(name: String) = name in valuesAsMap
         @Pure fun names() = valuesAsMap.keys
-        val statsWithCivWideField = setOf(Gold, Science, Culture, Faith, Happiness)
+        val statsWithCivWideField = setOf(Gold, Science, Culture, Faith, Happiness, Tourism)
     }
 }

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -19,7 +19,8 @@ open class Stats(
     var science: Float = 0f,
     var culture: Float = 0f,
     var happiness: Float = 0f,
-    var faith: Float = 0f
+    var faith: Float = 0f,
+    var tourism: Float = 0f
 ): Iterable<Stats.StatValuePair> {
 
     /** Indexed read of a value for a given [Stat], e.g. `this.gold == this[Stat.Gold]` */
@@ -33,6 +34,7 @@ open class Stats(
             Stat.Culture -> culture
             Stat.Happiness -> happiness
             Stat.Faith -> faith
+            Stat.Tourism -> tourism
         }
     }
     /** Indexed write of a value for a given [Stat], e.g. `this.gold += 1f` is equivalent to `this[Stat.Gold] += 1f` */
@@ -45,6 +47,7 @@ open class Stats(
             Stat.Culture -> culture = value
             Stat.Happiness -> happiness = value
             Stat.Faith -> faith = value
+            Stat.Tourism -> tourism = value
         }
     }
 
@@ -61,6 +64,7 @@ open class Stats(
                 && culture == otherStats.culture
                 && happiness == otherStats.happiness
                 && faith == otherStats.faith
+                && tourism == otherStats.tourism
     }
 
     /** **Non-Mutating function**
@@ -76,7 +80,8 @@ open class Stats(
             && science == 0f
             && culture == 0f
             && happiness == 0f
-            && faith == 0f )
+            && faith == 0f 
+            && tourism == 0f)
 
     /** Reset all values to zero (in place) */
     fun clear() {
@@ -87,6 +92,7 @@ open class Stats(
         culture = 0f
         happiness = 0f
         faith = 0f
+        tourism = 0f
     }
 
     /** **Mutating function** (but does **not** mutate [other])
@@ -100,6 +106,7 @@ open class Stats(
         culture += other.culture
         happiness += other.happiness
         faith += other.faith
+        tourism += other.tourism
         return this
     }
 
@@ -133,7 +140,8 @@ open class Stats(
         science * number,
         culture * number,
         happiness * number,
-        faith * number
+        faith * number,
+        tourism * number
     )
 
     /** **Mutating function**
@@ -146,6 +154,7 @@ open class Stats(
         culture *= number
         happiness *= number
         faith *= number
+        tourism *= number
     }
 
     /** **Non-Mutating function**
@@ -162,6 +171,7 @@ open class Stats(
         culture *= 8
         happiness *= 10 // base
         faith *= 7
+        tourism *= 8 //TODO: Chose ranking weight
     }
 
     /** ***Not*** only a debug helper. It returns a string representing the content, already _translated_.
@@ -219,6 +229,7 @@ open class Stats(
         if (culture != 0f) yield(StatValuePair(Stat.Culture, culture))
         if (happiness != 0f) yield(StatValuePair(Stat.Happiness, happiness))
         if (faith != 0f) yield(StatValuePair(Stat.Faith, faith))
+        if (tourism != 0f) yield (StatValuePair(Stat.Tourism, tourism))
     }
 
     /** Enables aggregates over the values, never empty */
@@ -233,6 +244,7 @@ open class Stats(
             yield(culture)
             yield(happiness)
             yield(faith)
+            yield(tourism)
         }
 
     /** Returns an iterator over the elements of this object, wrapped as [StatValuePair]s */

--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -128,6 +128,7 @@ object Fonts {
     const val culture = '♪'             // U+266A 'eighth note' (🎵 U+1F3B5 'musical note')
     const val happiness = '⌣'           // U+2323 'smile' (😀 U+1F600 'grinning face')
     const val faith = '☮'               // U+262E 'peace symbol' (🕊 U+1F54A 'dove of peace')
+    const val tourism = '✈'             // U+2708 'airplane' (💼 U+1F4BC 'suitcase')
     @Suppress("MemberVisibilityCanBePrivate") // offer for mods
     const val greatArtist = '♬'         // U+266C 'sixteenth note'
     @Suppress("MemberVisibilityCanBePrivate") // offer for mods

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
@@ -19,6 +19,7 @@ import com.unciv.models.ruleset.Quest
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.addSeparator
@@ -75,8 +76,10 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         if (otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.getCenterTile()))
             diplomacyTable.add(diplomacyScreen.getGoToOnMapButton(otherCiv)).row()
 
-        val diplomaticMarriageButton = getDiplomaticMarriageButton(otherCiv)
-        if (diplomaticMarriageButton != null) diplomacyTable.add(diplomaticMarriageButton).row()
+        val diplomaticMarriageButtons = getDiplomaticMarriageButtons(otherCiv) ?: arrayOf()
+        for(diplomaticMarriageButton in diplomaticMarriageButtons){
+            diplomacyTable.add(diplomaticMarriageButton).row()
+        }
 
         for (assignedQuest in otherCiv.questManager.getAssignedQuestsFor(viewingCiv)) {
             diplomacyTable.addSeparator()
@@ -309,22 +312,40 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         return improveTileButton
     }
 
-    private fun getDiplomaticMarriageButton(otherCiv: Civilization): TextButton? {
-        if (!viewingCiv.hasUnique(UniqueType.CityStateCanBeBoughtForGold))
-            return null
-
-        val diplomaticMarriageButton =
-            "Diplomatic Marriage ([${otherCiv.cityStateFunctions.getDiplomaticMarriageCost()}] Gold)".toTextButton()
-        diplomaticMarriageButton.onClick {
-            val newCities = otherCiv.cities
-            otherCiv.cityStateFunctions.diplomaticMarriage(viewingCiv)
-            UncivGame.Current.popScreen() // The other civ will no longer exist
-            for (city in newCities)
-                viewingCiv.popupAlerts.add(PopupAlert(AlertType.DiplomaticMarriage, city.id))   // Player gets to choose between annex and puppet
+    private fun getDiplomaticMarriageButtons(otherCiv: Civilization): Array<TextButton>? {
+        if (!viewingCiv.hasUnique(UniqueType.CityStateCanBeBoughtForStat))
+            return arrayOf()
+        var diplomaticMarriageButtons: Array<TextButton> = arrayOf()
+        //listing all stats which the civilization can marry by
+        for (unique in viewingCiv.getMatchingUniques(UniqueType.CityStateCanBeBoughtForStat)){
+            if(Stat.isStat(unique.params[0])) {
+                val stat = Stat.safeValueOf(unique.params[0]) ?: return null
+                val diplomaticMarriageButton =
+                    "Diplomatic Marriage ([${otherCiv.cityStateFunctions.getDiplomaticMarriageCost()}] ${unique.params[0]})".toTextButton()
+                diplomaticMarriageButton.onClick {
+                    val newCities = otherCiv.cities
+                    otherCiv.cityStateFunctions.diplomaticMarriage(viewingCiv, stat)
+                    UncivGame.Current.popScreen() // The other civ will no longer exist
+                    for (city in newCities)
+                        viewingCiv.popupAlerts.add(
+                            PopupAlert(
+                                AlertType.DiplomaticMarriage,
+                                city.id
+                            )
+                        )   // Player gets to choose between annex and puppet
+                }
+                if (diplomacyScreen.isNotPlayersTurn() || !otherCiv.cityStateFunctions.canBeMarriedByStat(
+                        viewingCiv,
+                        stat
+                    )
+                )
+                    diplomaticMarriageButton.disable()
+                diplomaticMarriageButtons += diplomaticMarriageButton
+            }
         }
-        if (diplomacyScreen.isNotPlayersTurn() || !otherCiv.cityStateFunctions.canBeMarriedBy(viewingCiv))
-            diplomaticMarriageButton.disable()
-        return diplomaticMarriageButton
+        
+        
+        return diplomaticMarriageButtons
     }
 
     private fun getGoldGiftTable(otherCiv: Civilization): Table {


### PR DESCRIPTION
The following changes were made:
· Added Tourism as a Stat
· Deprecated CityStateCanBeBoughtForGold, replaced for CityStateCanBeBoughtForStat
· Deprecated some uniques that were listed to be deprecated on a TODO comment.
· Updated diplomaticMarriage and canBeMarriedBy so that it includes the possibility of paying with Stats other than Gold.
· Created canBeMarriedByStat