### PR TITLE
Eliminated most Hardcoded Terrains in Unciv /logic/

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -22,10 +22,10 @@ object Constants {
     const val mountain = "Mountain"
     const val hill = "Hill"
     const val plains = "Plains"
-    const val lakes = "Lakes"
     const val desert = "Desert"
     const val grassland = "Grassland"
-    const val tundra = "Tundra"
+    // TODO: GameStarter places "Tundra" startBias first. Can we make it generic by checking count by terrain?
+    const val tundra = "Tundra" 
     const val snow = "Snow"
 
     const val forest = "Forest"

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -103,7 +103,10 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
                 humidFrom < (tile.humidity ?: 0.0) && (tile.humidity?:0.0) <= humidTo &&
                 matchesBaseTerrain(tile)
 
-        fun matchesIce() = terrain.type == TerrainType.TerrainFeature && terrain.impassable && terrain.occursOn.contains(Constants.ocean) && !rareFeature
+        fun maybeSnow() = terrain.type == TerrainType.Land 
+            && tempFrom <= -1 && tempTo <= -.5 
+            && humidFrom >= 0.2 && humidTo >= 1 
+            && !rareFeature
 
         override fun toString(): String {
             return name
@@ -344,8 +347,8 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
     }
 
     private fun spawnLakesAndCoasts(map: TileMap) {
-        if (ruleset.terrains.containsKey(Constants.lakes)) {
-            val lakeTerrains = terrainConditions.filter { it.freshWater && !it.rareFeature && it.terrain.type == TerrainType.Water }
+        val lakeTerrains = terrainConditions.filter { it.freshWater && !it.rareFeature && it.terrain.type == TerrainType.Water }
+        if (lakeTerrains.isNotEmpty()) {
             //define lakes
             val waterTiles = map.values.filter { it.isWater }.toMutableList()
 
@@ -414,13 +417,14 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
         for (tile in tileMap.values)
             tile.tileResource = null
 
-        spreadStrategicResources(tileMap, mapRadius)
-        spreadResources(tileMap, mapRadius, ResourceType.Luxury)
-        spreadResources(tileMap, mapRadius, ResourceType.Bonus)
+        val snowTerrains = terrainConditions.filter { it.maybeSnow()}
+        spreadStrategicResources(tileMap, mapRadius, snowTerrains)
+        spreadResources(tileMap, mapRadius, ResourceType.Luxury, snowTerrains)
+        spreadResources(tileMap, mapRadius, ResourceType.Bonus, snowTerrains)
     }
 
     // Here, we need each specific resource to be spread over the map - it matters less if specific resources are near each other
-    private fun spreadStrategicResources(tileMap: TileMap, mapRadius: Int) {
+    private fun spreadStrategicResources(tileMap: TileMap, mapRadius: Int, snowTerrains: List<TerrainOccursRange>) {
         val strategicResources = ruleset.tileResources.values.filter { it.resourceType == ResourceType.Strategic }
         // passable land tiles (no mountains, no wonders) without resources yet
         // can't be next to NW
@@ -431,7 +435,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
         for (resource in strategicResources) {
             // remove the tiles where previous resources have been placed
             val suitableTiles = candidateTiles
-                    .filterNot { it.baseTerrain == Constants.snow && it.isHill() }
+                    .filterNot { snowTerrains.any {terrain -> it.baseTerrain == terrain.name } && it.isHill() }
                     .filter { it.resource == null && resource.generatesNaturallyOn(it) }
 
             val locations = randomness.chooseSpreadOutLocations(resourcesPerType, suitableTiles, mapRadius)
@@ -445,11 +449,11 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
      * which is determined from [mapRadius] and then tuned down until the desired number fits.
      * [MapParameters.resourceRichness] used to control how many resources to spawn.
      */
-    private fun spreadResources(tileMap: TileMap, mapRadius: Int, resourceType: ResourceType) {
+    private fun spreadResources(tileMap: TileMap, mapRadius: Int, resourceType: ResourceType, snowTerrains: List<TerrainOccursRange>) {
         val resourcesOfType = ruleset.tileResources.values.filter { it.resourceType == resourceType }
 
         val suitableTiles = tileMap.values
-                .filterNot { it.baseTerrain == Constants.snow && it.isHill() }
+                .filterNot { snowTerrains.any {terrain -> it.baseTerrain == terrain.name } && it.isHill() }
                 .filter { it.resource == null
                     && it.neighbors.none { neighbor -> neighbor.isNaturalWonder() }
                     && resourcesOfType.any { r -> r.generatesNaturallyOn(it) }
@@ -638,8 +642,9 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
         val rareFeatures = terrainFeaturePicker.filter { it.rareFeature }
         for (tile in tileMap.values.asSequence().filter { it.terrainFeatures.isEmpty() }) {
             if (randomness.RNG.nextDouble() <= tileMap.mapParameters.rareFeaturesRichness) {
+                val hillFeature = tile.getHillTerrain()
                 val possibleFeatures = rareFeatures.filter { it.matches(tile) 
-                    && (!tile.isHill() || it.terrain.occursOn.contains(Constants.hill))
+                    && (hillFeature == null || it.terrain.occursOn.contains(hillFeature.name))
                     && NaturalWonderGenerator.fitsTerrainUniques(it.terrain, tile)
                 }
                 if (possibleFeatures.any())
@@ -656,7 +661,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             ruleset.terrains.values.asSequence()
             .filter { it.type == TerrainType.Water }
             .map { it.name }.toSet()
-        val iceTerrains: List<TerrainOccursRange> = terrainFeaturePicker.filter { it.matchesIce() }
+        val iceTerrains: List<TerrainOccursRange> = terrainFeaturePicker.filter { it.terrain.isIce }
 
         if (tileMap.mapParameters.shape == MapShape.flatEarth) {
             spawnFlatEarthIceWalls(tileMap, iceTerrains)
@@ -688,7 +693,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
     }
 
     private fun spawnFlatEarthIceWalls(tileMap: TileMap, iceTerrains: List<TerrainOccursRange>) {
-        val snowTerrains = listOf(baseTerrainPicker.first { it.terrain.type == TerrainType.Land && it.tempFrom <= -1 && it.humidTo >= 1 && !it.rareFeature })
+        val snowTerrains = listOf(baseTerrainPicker.first { it.maybeSnow() })
         val mountainTerrains = baseTerrainPicker.filter { it.terrain.impassable && it.occursInChains && !it.rareFeature }
         val allArcticTerrains = iceTerrains + snowTerrains + mountainTerrains
 

--- a/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
@@ -159,7 +159,8 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
                     if (!unique.conditionalsApply(state)) continue
                     val convertTo = unique.params[0]
                     if (tile.baseTerrain == convertTo || convertTo in tile.terrainFeatures) continue
-                    if (convertTo == Constants.lakes && tile.isCoastalTile()) continue
+                    val convertToTerrain = location.ruleset.terrains[convertTo]!!
+                    if (convertToTerrain.hasUnique(UniqueType.FreshWater) && tile.isCoastalTile()) continue
                     val terrainObject = location.ruleset.terrains[convertTo] ?: continue
                     if (terrainObject.type == TerrainType.TerrainFeature && tile.baseTerrain !in terrainObject.occursOn) continue
                     if (convertTo == Constants.coast)
@@ -232,7 +233,7 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
             for (neighbor in tile.neighbors) {
                 // This is so we don't have this tile turn into Coast, and then it's touching a Lake tile.
                 // We just turn the lake tiles into this kind of tile.
-                if (neighbor.baseTerrain == Constants.lakes) {
+                if (neighbor.getBaseTerrain().hasUnique(UniqueType.FreshWater)) {
                     clearTile(neighbor)
                     neighbor.baseTerrain = tile.baseTerrain
                     neighbor.setTerrainTransients()
@@ -243,7 +244,7 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
 
         /** Implements [UniqueParameterType.SimpleTerrain][com.unciv.models.ruleset.unique.UniqueParameterType.SimpleTerrain] */
         private fun Tile.matchesWonderFilter(filter: String) = when (filter) {
-            "Elevated" -> baseTerrain == Constants.mountain || isHill()
+            "Elevated" -> getBaseTerrain().isMountain || isHill()
             "Water" -> isWater
             "Land" -> isLand
             Constants.hill -> isHill()

--- a/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
@@ -31,7 +31,7 @@ class RiverGenerator(
         val numberOfRivers = (tileMap.values.count { it.isLand } * riverCountMultiplier).roundToInt()
 
         var optionalTiles = tileMap.values.asSequence()
-            .filter { it.baseTerrain == Constants.mountain && it.isFarEnoughFromWater() }
+            .filter { it.getBaseTerrain().isMountain && it.isFarEnoughFromWater() }
             .toMutableList()
         if (optionalTiles.size < numberOfRivers)
             optionalTiles.addAll(tileMap.values.filter { it.isHill() && it.isFarEnoughFromWater() })

--- a/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
@@ -90,7 +90,7 @@ class MapUnitCache(private val mapUnit: MapUnit) {
             doubleMovementInTerrain[param] = DoubleMovement(unique = unique,
                 terrainTarget =  when {
                     terrain == null -> DoubleMovementTerrainTarget.Filter
-                    terrain.name == Constants.hill -> DoubleMovementTerrainTarget.Hill
+                    terrain.isHill -> DoubleMovementTerrainTarget.Hill
                     terrain.type == TerrainType.TerrainFeature -> DoubleMovementTerrainTarget.Feature
                     terrain.type.isBaseTerrain -> DoubleMovementTerrainTarget.Base
                     else -> DoubleMovementTerrainTarget.Filter

--- a/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
@@ -108,8 +108,8 @@ object MovementCost {
 
         if (hasDoubleMovement(unit, to.baseTerrain, MapUnitCache.DoubleMovementTerrainTarget.Base, gameContext))
             return terrainCost * 0.5f + extraCost
-        if (hasDoubleMovement(unit, Constants.hill, MapUnitCache.DoubleMovementTerrainTarget.Hill, gameContext)
-            && to.isHill())
+        val hillTerrain = to.getHillTerrain()
+        if (hillTerrain != null && hasDoubleMovement(unit, hillTerrain.name, MapUnitCache.DoubleMovementTerrainTarget.Hill, gameContext))
             return terrainCost * 0.5f + extraCost
 
         if (unit.cache.noFilteredDoubleMovementUniques)

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -759,7 +759,7 @@ class UnitMovement(val unit: MapUnit) {
         if (tile.isImpassible()) {
             // special exception - ice tiles are technically impassible, but some units can move through them anyway
             // helicopters can pass through impassable tiles like mountains
-            if (!unit.cache.canPassThroughImpassableTiles && !(unit.cache.canEnterIceTiles && tile.terrainFeatures.contains(Constants.ice))
+            if (!unit.cache.canPassThroughImpassableTiles && !(unit.cache.canEnterIceTiles && tile.terrainFeatureObjects.any { it.isIce })
                 // carthage-like uniques sometimes allow passage through impassible tiles
                 && !(unit.civ.passThroughImpassableUnlocked && unit.civ.passableImpassables.contains(tile.lastTerrain.name)))
                 return false

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -248,7 +248,13 @@ class Tile : IsPartOfGameInfoSerialization {
 
     //region pure functions
 
-    @Readonly fun isHill() = baseTerrain == Constants.hill || terrainFeatures.contains(Constants.hill)
+    @Readonly fun getHillTerrain(): Terrain? {
+        val base = getBaseTerrain()
+        if (base.isHill)
+            return base
+        return terrainFeatureObjects.firstOrNull {it.isHill }
+    }
+    @Readonly fun isHill() = getHillTerrain() != null
 
     /** Returns military, civilian and air units in tile */
     @Readonly
@@ -391,7 +397,7 @@ class Tile : IsPartOfGameInfoSerialization {
         return civInfo.isAtWarWith(tileOwner)
     }
 
-    @Readonly fun isRoughTerrain() = allTerrains.any { it.isRough() }
+    @Readonly fun isRoughTerrain() = allTerrains.any { it.isRough }
 
     @Transient
     internal var stateThisTile: GameContext = GameContext.EmptyState
@@ -550,7 +556,7 @@ class Tile : IsPartOfGameInfoSerialization {
             "resource" -> return observingCiv != null && observingCiv.canSeeResource(tileResource)
             "Water resource" -> return isWater && observingCiv != null && observingCiv.canSeeResource(tileResource)
             "Featureless" -> return terrainFeatures.isEmpty()
-            "Open terrain" -> return allTerrains.all { !it.isRough() } // special case - if *one* terrain is open, we don't care, we need *all*
+            "Open terrain" -> return allTerrains.all { !it.isRough } // special case - if *one* terrain is open, we don't care, we need *all*
             Constants.freshWaterFilter ->
                 return isAdjacentTo(Constants.freshWater, observingCiv)
         }

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -268,7 +268,7 @@ class TileStatFunctions(val tile: Tile) {
             sum -= 2f
         if (tile.isAdjacentToRiver())
             sum += 2f
-        if (tile.neighbors.any { it.baseTerrain == Constants.mountain })
+        if (tile.neighbors.any { it.getBaseTerrain().isMountain })
             sum += 2f
         if (tile.isCoastalTile())
             sum += 3f

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -48,9 +48,11 @@ class Terrain : RulesetStatsObject() {
     @Transient
     var damagePerTurn = 0
 
-    // Shouldn't this just be a lazy property so it's automatically cached?
-    @Readonly
-    fun isRough(): Boolean = hasUnique(UniqueType.RoughTerrain)
+    val isRough by lazy { hasUnique(UniqueType.RoughTerrain) }
+    val isMountain by lazy { hasUnique(UniqueType.OccursInChains) }
+    val isHill by lazy { hasUnique(UniqueType.OccursInGroups) }
+    val isVegetation by lazy { hasUnique(UniqueType.Vegetation) }
+    val isIce by lazy { type == TerrainType.TerrainFeature && impassable && occursOn.contains(Constants.ocean) }
 
     /** Tests base terrains, features and natural wonders whether they should be treated as Land/Water.
      *  Currently only used for civilopedia display, as other code can test the tile itself.
@@ -134,7 +136,7 @@ class Terrain : RulesetStatsObject() {
 
         textList += FormattedLine()
         // For now, natural wonders show no "open terrain" - may change later
-        if (turnsInto == null && displayAs(TerrainType.Land, ruleset) && !isRough())
+        if (turnsInto == null && displayAs(TerrainType.Land, ruleset) && !isRough)
             textList += FormattedLine("Open terrain")   // Rough is in uniques
         uniquesToCivilopediaTextLines(textList, leadingSeparator = null)
 
@@ -190,8 +192,8 @@ class Terrain : RulesetStatsObject() {
         return when (filter) {
             "all", "All" -> true
             "Terrain" -> true
-            "Open terrain" -> !isRough()
-            "Rough terrain" -> isRough()
+            "Open terrain" -> !isRough
+            "Rough terrain" -> isRough
             "Natural Wonder" -> type == TerrainType.NaturalWonder
             "Terrain Feature" -> type == TerrainType.TerrainFeature
             else -> when(filter){ // non-constants

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorWesnothImporter.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorWesnothImporter.kt
@@ -149,8 +149,8 @@ class MapEditorWesnothImporter(private val editorScreen: MapEditorScreen) : Disp
             translateTerrainWML(base) + translateTerrainWML(layer) + fallback
         // Map to RulesetObjects and ensure Hills are always under other features
         val allObjects = allStrings
-            .sortedBy { it != Constants.hill }
             .mapNotNull { ruleset.tileImprovements[it] ?: ruleset.terrains[it] }
+            .sortedBy { if (it is Terrain) !it.isHill else true }
             .toList()
         // BaseTerrain is simply the first candidate, the fallback above makes first() not crash (unless the json breaks it)
         baseTerrain = allObjects.first { it is Terrain && it.type.isBaseTerrain }.name

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditSubTabs.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditSubTabs.kt
@@ -348,7 +348,7 @@ class MapEditorEditRiversTab(
 ): Table(BaseScreen.skin), IMapEditorEditSubTabs, TabbedPager.IPageExtensions {
     private val iconSize = 50f
     private val showOnTerrain = ruleset.terrains.values.asSequence()
-        .filter { it.type.isBaseTerrain && !it.isRough() }
+        .filter { it.type.isBaseTerrain && !it.isRough }
         .sortedByDescending { it.production * 2 + it.food }
         .firstOrNull()
         ?: ruleset.terrains[Constants.plains]


### PR DESCRIPTION
This should make modded terrains more useful.

Water and Coast are still hardcoded.
GameStarter still places "tundra" first - I didn't see a trivial way to make that generic. DoubleMovementTerrainTarget.Hill is still hardcoded, though applies to any modded hills. The "hill" filter now includes modded hills.