### PR TITLE
WOrkers no longer forget road automation

### DIFF
--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -8,22 +8,17 @@ import com.unciv.logic.map.FixedPointMovement.Companion.FPM_ZERO
 import com.unciv.logic.map.FixedPointMovement.Companion.fpmFromMovement
 import com.unciv.logic.map.MapPathing.roadPreferredMovementCost
 import com.unciv.logic.map.RouteNode.Companion.MAX_MOVE_THIS_TURN
-import com.unciv.logic.map.RouteNode.Companion.MAX_TURNS
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.movement.MovementCost
 import com.unciv.logic.map.mapunit.movement.PathsToTilesWithinTurn
 import com.unciv.logic.map.mapunit.movement.UnitMovement.ParentTileAndTotalMovement
 import com.unciv.logic.map.tile.Tile
 import com.unciv.utils.Log
-import com.unciv.utils.LongPriorityQueue
 import com.unciv.utils.forEachSetBit
 import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.InternalState
 import yairm210.purity.annotations.Readonly
-import java.util.BitSet
-import java.util.Formatter
-import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -76,7 +71,7 @@ class PathingMap(
     private val relationshipLevel: (Tile) -> RelationshipLevel,
 ) {
     @Cache
-    private val cacheRef: AtomicReference<PathingMapCache?> = AtomicReference<PathingMapCache?>(null)
+    private val cacheRef = AtomicReference<PathingMapCache?>(null)
 
     /**
      * This is the only method that is NOT thread-safe.
@@ -147,7 +142,7 @@ class PathingMap(
             
         }
         // if we don't already know the shortest path, and might yet find it, search
-        var targetNode = RouteNode(cache.routeNodes[destination.zeroBasedIndex])
+        val targetNode = RouteNode(cache.routeNodes[destination.zeroBasedIndex])
         if (!targetNode.initialized  && !cache.nodesNeedingNeighbors.isEmpty) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#getShortestPath(${destination.position}) calculcating for $debugMapType $debugId")
@@ -321,13 +316,13 @@ class PathingMap(
                 else "createUnitPathingMap"
             // These two precalculated because for some reason they're rediculously slow
             val selfFullMove = unit.getMaxMovement()
-            val otherUntilFullMove = if (includeEscortUnit) unit.getOtherEscortUnit()?.getMaxMovement() ?: MAX_TURNS else MAX_TURNS
+            val otherUntilFullMove = if (includeEscortUnit) unit.getOtherEscortUnit()?.getMaxMovement() ?: MAX_VALID_TURNS else MAX_VALID_TURNS
             val getCurrentCacheKey = {
                 val escort = if (includeEscortUnit && unit.isEscorting()) unit.getOtherEscortUnit() else null
                 PathingMapCacheKey(
                     unit.currentTile.position, 
                     fpmFromMovement(unit.currentMovement).coerceAtMost(escort?.currentMovement?.toFixedPointMove() ?: MAX_MOVE_THIS_TURN),
-                    selfFullMove.coerceAtMost(if (escort != null) otherUntilFullMove else MAX_VALID_TURNS),
+                    fpmFromMovement(selfFullMove.coerceAtMost(if (escort != null) otherUntilFullMove else MAX_VALID_TURNS)),
                     )
             }
             return PathingMap(
@@ -349,7 +344,7 @@ class PathingMap(
                 civ.gameInfo.tileMap,
                 civ,
                 "createLandAttackPathingMap",
-                { civPathingCacheKey(startingPoint.position)},
+                { civPathExistCacheKey(startingPoint.position)},
                 { isLandTileCanAttackThrough(civ, it, targetCiv) },
                 { 0 },
                 { from, to -> fpmFromMovement(roadPreferredMovementCost(civ, from, to)) },
@@ -364,7 +359,7 @@ class PathingMap(
                 civ.gameInfo.tileMap,
                 civ,
                 "createAmphibiousAttackPathingMap",
-                { civPathingCacheKey(startingPoint.position)},
+                { civPathExistCacheKey(startingPoint.position)},
                 { isTileCanAttackThrough(civ, it, targetCiv) },
                 { 0 },
                 { from, to -> fpmFromMovement(roadPreferredMovementCost(civ, from, to)) },
@@ -375,11 +370,15 @@ class PathingMap(
 
         @Readonly
         fun createRoadPathingMap(civ: Civilization, startingPoint: Tile): PathingMap {
+            // Use a max movement speed equal to improved (non-rail) road speed, to ensure that the
+            // path "ends its turn" on every non-rail tile along the route. Right now, the costs
+            // are weird, so this is a full movement of 0.5.  If we used the correct move costs
+            // here, then this would be 1/3f.
             return PathingMap(
                 civ.gameInfo.tileMap,
                 civ,
                 "createRoadPathingMap",
-                { civPathingCacheKey(startingPoint.position)},
+                { PathingMapCacheKey(startingPoint.position,  FPM_POINT_FIVE, FPM_POINT_FIVE) },
                 {MapPathing.isValidRoadPathTile(civ, it) },
                 { 0 },
                 { _, to -> if ((to.hasRoadConnection(civ, false) || to.hasRailroadConnection(false))) FPM_POINT_FIVE else FPM_ONE },
@@ -389,7 +388,7 @@ class PathingMap(
         }
         
         @Readonly
-        private fun civPathingCacheKey(startingPoint: HexCoord) = PathingMapCacheKey(startingPoint, MAX_MOVE_THIS_TURN, MAX_VALID_TURNS)
+        private fun civPathExistCacheKey(startingPoint: HexCoord) = PathingMapCacheKey(startingPoint, MAX_MOVE_THIS_TURN, MAX_MOVE_THIS_TURN)
 
         @Readonly
         private fun isTileCanAttackThrough(civInfo: Civilization, tile: Tile, targetCiv: Civilization): Boolean {

--- a/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
+++ b/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
@@ -19,6 +19,7 @@ import com.unciv.logic.map.RouteNode.Companion.TILE_IDX_OFFSET
 import com.unciv.logic.map.RouteNode.Companion.UNDERESTIMATED_TOTAL_HI_MASK
 import com.unciv.logic.map.RouteNode.Companion.UNDERESTIMATED_TOTAL_LO_MASK
 import com.unciv.logic.map.RouteNode.Companion.UNDERESTIMATED_TOTAL_OFFSET
+import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
 import com.unciv.utils.Log
 import com.unciv.utils.LongPriorityQueue
@@ -27,7 +28,6 @@ import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.InternalState
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
-import java.util.PriorityQueue
 
 // This crams all the information we need about prioritizing a node into a single Long, avoiding allocations
 @JvmInline
@@ -45,7 +45,7 @@ value class PrioritizedNode(val bits: Long) {
     val tileIdx: Int get() { require(initialized); return ((bits shr TILE_IDX_OFFSET) and TILE_IDX_LO_MASK).toInt() }
 
     val underestimatedTotal: FixedPointMovement get() {
-        val b = ((bits shr UNDERESTIMATED_TOTAL_OFFSET) and UNDERESTIMATED_TOTAL_LO_MASK);
+        val b = ((bits shr UNDERESTIMATED_TOTAL_OFFSET) and UNDERESTIMATED_TOTAL_LO_MASK)
         return FixedPointMovement.fpmFromFixedPointBits(b.toInt())
     }
 
@@ -58,8 +58,6 @@ value class PrioritizedNode(val bits: Long) {
         @Pure
         private fun toUnderestimatedTotalbits(priority: FixedPointMovement): Long
             = priority.bits.toLong() shl UNDERESTIMATED_TOTAL_OFFSET
-
-        val COMPARATOR: Comparator<PrioritizedNode> = Comparator<PrioritizedNode>{ a, b -> a.bits.compareTo(b.bits) }
     }
 }
 
@@ -107,7 +105,7 @@ internal class AStarPathfinder(
     @Readonly
     private fun calculateUnderestimatedMovement(node: RouteNode): FixedPointMovement {
         val tile = node.tile(tileMap)
-        val movementSoFar = FixedPointMovement.fpmFromMovement(node.turns * cache.key.fullMove) + node.moveUsedThisTurn
+        val movementSoFar = cache.key.fullMove * node.turns + node.moveUsedThisTurn
         val minRemainingTiles = destination?.let { tile.aerialDistanceTo(it) } ?: 1
         val minRemainingCost = tileRoadCost(tile) + (minRemainingTiles - 1) * (FASTEST_ROAD_COST)
         val underestimatedTotal = movementSoFar + minRemainingCost
@@ -167,7 +165,6 @@ internal class AStarPathfinder(
         val canEndTurnOrProbablyMoveAway = endTurnThereDamage == 0 || (newUsedMovement < fullMovement)
         val relationship = relationshipLevel(neighborTile)
         
-        val newNode: RouteNode
         // This can use more than the remaining movement, but that's correct behavior.
         // https://yairm210.medium.com/multi-turn-pathfinding-7136bd0bdaf0
         if (currentNode.moveUsedThisTurn < fullMovement  && canEndTurnOrProbablyMoveAway) {
@@ -235,5 +232,9 @@ internal class AStarPathfinder(
         // towards the earlier pathfinding, potentially causing it to miss even obvious railroads
         // for later paths.  If we eliminate the caching, then it would be safe to set this higher.
         const val FASTEST_ROAD_COST = 0.1f
+        
+        init {
+            require(FASTEST_ROAD_COST == RoadStatus.Railroad.movementImproved)
+        }
     }
 }

--- a/core/src/com/unciv/logic/map/PathingMapCache.kt
+++ b/core/src/com/unciv/logic/map/PathingMapCache.kt
@@ -261,6 +261,10 @@ value class RouteNode(val bits: Long=0L) {
 value class FixedPointMovement private constructor(val bits: Int) {
     @Pure operator fun plus(other: FixedPointMovement) = FixedPointMovement(bits + other.bits)
     @Pure operator fun minus(other: FixedPointMovement) = FixedPointMovement(bits - other.bits)
+    @Pure operator fun times(other: Int) = FixedPointMovement(bits * other)
+    // #times(FixedPointMovement) is currently unused, but implemented here because I'm afraid
+    // someone will implement it later, and forget the division.
+    @Pure operator fun times(other: FixedPointMovement) = FixedPointMovement((bits.toLong() * other.bits / MOVE_SPEED_BASE).toInt())
     @Pure operator fun plus(other: Float) = FixedPointMovement(bits + (other * MOVE_SPEED_BASE).toInt())
     @Pure operator fun minus(other: Float) = FixedPointMovement(bits - (other * MOVE_SPEED_BASE).toInt())
     @Pure operator fun compareTo(other: FixedPointMovement) = bits.compareTo(other.bits)
@@ -294,7 +298,7 @@ value class FixedPointMovement private constructor(val bits: Int) {
 data class PathingMapCacheKey(
     val startingPoint: HexCoord,
     val moveRemaining: FixedPointMovement,
-    val fullMove: Int,
+    val fullMove: FixedPointMovement,
 )
 
 @InternalState

--- a/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
+++ b/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.automation.unit
 
 import com.unciv.Constants
+import com.unciv.UncivGame
 import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.managers.TurnManager
@@ -24,6 +25,7 @@ internal class WorkerAutomationTest {
 
     @Before
     fun setUp() {
+        UncivGame.Current.settings.useAStarPathfinding = true
         testGame.makeHexagonalMap(7)
         civInfo = testGame.addCiv()
         workerAutomation = WorkerAutomation(civInfo, 3)
@@ -271,6 +273,12 @@ internal class WorkerAutomationTest {
 
         val city1 = testGame.addCity(civInfo, testGame.tileMap[3,3])
         val city2 = testGame.addCity(civInfo, testGame.tileMap[-3,-3])
+        // preexisting road along half, just to complicate things
+        testGame.tileMap[3,3].setRoadStatus(RoadStatus.Railroad, civInfo)
+        testGame.tileMap[2,2].setRoadStatus(RoadStatus.Railroad, civInfo)
+        testGame.tileMap[1,1].setRoadStatus(RoadStatus.Railroad, civInfo)
+        testGame.tileMap[0,0].setRoadStatus(RoadStatus.Railroad, civInfo)
+        //testGame.tileMap[1,1].setRoadStatus(RoadStatus.Railroad, civInfo)
         val cities = listOf(city1, city2)
         civInfo.addGold(100000000)
         for (city in cities) {


### PR DESCRIPTION
City#getRoadPath and UnitMovement#getRoadPath now both return all tiles, not just the tiles where the unit ends their turn.

Bug found by General_E https://discord.com/channels/586194543280390151/1477654146822963351/1477654146822963351