### PR TITLE
Do not show DoF popup if they also declared war on the same turn

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -243,7 +243,7 @@ class AlertPopup(
 
     private fun addDeclarationOfFriendship(): Boolean {
         val otherciv = getCiv(popupAlert.value)
-        if (otherciv.isDefeated()) return false
+        if (otherciv.isDefeated() || otherciv.getDiplomacyManager(viewingCiv)!!.diplomaticStatus == DiplomaticStatus.War) return false
         val playerDiploManager = viewingCiv.getDiplomacyManager(otherciv)!!
         addLeaderName(otherciv)
         addGoodSizedLabel(


### PR DESCRIPTION
Happens if they offer DoF and declare war on the same turn.