### PR TITLE
Colored topic headers for DoF and DoW popups

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -144,6 +144,8 @@ Cancel =
 
 Diplomacy = 
 War = 
+DECLARATION OF WAR = 
+DECLARATION OF FRIENDSHIP = 
 Peace = 
 Research Agreement = 
 Declare war = 

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -124,6 +124,7 @@ object Constants {
 
     const val defaultFontSize = 18
     const val headingFontSize = 24
+    const val smallerHeadingFontSize = 21
 
     /** URL to the root of the Unciv repository, including trailing slash */
     // Note: Should the project move, this covers external links, but not comments e.g. mentioning issues

--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -1,6 +1,6 @@
 package com.unciv.ui.screens.worldscreen
 
-import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.Constants
@@ -18,7 +18,6 @@ import com.unciv.logic.civilization.PopupAlert
 import com.unciv.logic.civilization.diplomacy.*
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.mapunit.MapUnit
-import com.unciv.logic.map.toHexCoord
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
@@ -63,6 +62,11 @@ class AlertPopup(
     private val worldScreen: WorldScreen,
     private val popupAlert: PopupAlert
 ): Popup(worldScreen) {
+    
+    companion object {
+        private val LIGHTER_RED_COLOR = Color(1f, 1/3f, 1/3f, 1f)
+        private val LIGHTER_GREEN_COLOR = Color(1/3f, 1f, 1/3f, 1f)
+    }
 
     //region convenience getters
     private val music get() = UncivGame.Current.musicController
@@ -246,6 +250,7 @@ class AlertPopup(
         if (otherciv.isDefeated()) return false
         val playerDiploManager = viewingCiv.getDiplomacyManager(otherciv)!!
         addLeaderName(otherciv)
+        addTopicHeader("DECLARATION OF FRIENDSHIP", LIGHTER_GREEN_COLOR)
         addGoodSizedLabel(
                 if (otherciv.nation.declaringFriendship.isNotEmpty()) otherciv.nation.declaringFriendship else "My friend, shall we declare our friendship to the world?"
         ).row()
@@ -420,6 +425,7 @@ class AlertPopup(
         // technically they already declared war, but if they're dead it'll be strange that they talk to us
         if (civInfo.isDefeated()) return false
         addLeaderName(civInfo)
+        addTopicHeader("DECLARATION OF WAR", LIGHTER_RED_COLOR)
         addGoodSizedLabel(civInfo.nation.declaringWar).row()
         bottomTable.defaults().pad(0f, 5f)
         addCloseButton("You'll pay for this!")
@@ -427,6 +433,11 @@ class AlertPopup(
         music.chooseTrack(civInfo.civName, MusicMood.War, MusicTrackChooserFlags.setSpecific)
         music.playVoice("${civInfo.civName}.declaringWar")
         return true
+    }
+
+    private fun addTopicHeader(text: String, color: Color) {
+        addGoodSizedLabel(text, color=color, size=Constants.smallerHeadingFontSize)
+            .padBottom(20f).row()
     }
 
     private fun addWonderBuilt() {


### PR DESCRIPTION
The DoW popup currently relies on the leader's comment to explicitly state that war has been declared, which is often not the case (Babylon example). The new header has red text, making it abundantly clear that something bad has happened, and specifies that war has been declared.

<img width="1132" height="438" alt="image" src="https://github.com/user-attachments/assets/2fa35f46-abd0-4b5c-a76d-4d5400e44be2" />

The DoF popup is fairly clear already. While the header text may be repetitive, the green color makes it clear that something good has happened. It also conforms with the layout of the DoW and Denouncement (soon TM) popups.

<img width="1132" height="438" alt="image" src="https://github.com/user-attachments/assets/021e265a-e0e8-4c9e-9493-2ccbb840f562" />

When denounced in Civ V, the info box contains red, upper case text saying "DENOUNCING". Adding a similar header (not in this PR) in Unciv conforms with Civ V and makes it clear that you have been denounced, and that it is negative.