### PR TITLE
Fix misaligned buttons in DoW popup

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -421,8 +421,9 @@ class AlertPopup(
         if (civInfo.isDefeated()) return false
         addLeaderName(civInfo)
         addGoodSizedLabel(civInfo.nation.declaringWar).row()
-        addCloseButton("You'll pay for this!").row()
-        addCloseButton("Very well.").row()
+        addCloseButton("You'll pay for this!")
+        addCloseButton("Very well.")
+        equalizeLastTwoButtonWidths()
         music.chooseTrack(civInfo.civName, MusicMood.War, MusicTrackChooserFlags.setSpecific)
         music.playVoice("${civInfo.civName}.declaringWar")
         return true


### PR DESCRIPTION
Before (button with more text is wider than the other):

<img width="1132" height="438" alt="image" src="https://github.com/user-attachments/assets/9f9610da-5223-4d52-bb10-7b88cdc98a13" />

After:

<img width="1132" height="438" alt="image" src="https://github.com/user-attachments/assets/db265335-e564-4681-a66b-6179dc393c24" />

I'd prefer to keep them on the same row with a 50/50 split, but it was not obvious how to do that.

After v2:

<img width="1130" height="432" alt="image" src="https://github.com/user-attachments/assets/9e079542-ad39-478e-913d-1895b5b32dce" />
