### PR TITLE
Adjust duration of violationOccurred flags by game speed

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -14,6 +14,7 @@ import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.utils.withItem
 import yairm210.purity.annotations.Readonly
+import kotlin.math.roundToInt
 
 class CityFounder {
     fun foundCity(civInfo: Civilization, cityLocation: HexCoord, unit: MapUnit? = null): City {
@@ -245,7 +246,10 @@ class CityFounder {
                     .map { it.civ }
                     .distinct()
                     .filter { it.knows(city.civ) && it.hasExplored(city.getCenterTile()) }
-        for (otherCiv in civsWithCloseCities)
-            otherCiv.getDiplomacyManager(city.civ)!!.setFlag(DiplomacyFlags.SettledCitiesNearUs, 30)
+        for (otherCiv in civsWithCloseCities) {
+            val flagDuration = (30 * city.civ.gameInfo.speed.modifier).roundToInt()
+            otherCiv.getDiplomacyManager(city.civ)!!.setFlag(DiplomacyFlags.SettledCitiesNearUs, flagDuration)
+        }
+            
     }
 }

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -12,6 +12,7 @@ import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import yairm210.purity.annotations.Readonly
 import kotlin.math.ceil
+import kotlin.math.roundToInt
 import kotlin.random.Random
 
 
@@ -258,7 +259,8 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
     private fun demandToNotBeSpiedOn(otherCiv: Civilization) {
         val otherCivDiplomacyManager = otherCiv.getDiplomacyManager(civInfo)!!
         otherCivDiplomacyManager.addModifier(DiplomaticModifiers.SpiedOnUs, -15f)
-        otherCivDiplomacyManager.setFlag(DiplomacyFlags.DiscoveredSpiesInOurCities, 30)
+        val flagDuration = (30 * civInfo.gameInfo.speed.modifier).roundToInt()
+        otherCivDiplomacyManager.setFlag(DiplomacyFlags.DiscoveredSpiesInOurCities, flagDuration)
     }
 
     @Readonly fun canDoCoup(): Boolean = getCityOrNull() != null && getCity().civ.isCityState && isSetUp()

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -11,6 +11,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.ui.components.extensions.toPercent
 import yairm210.purity.annotations.Readonly
+import kotlin.math.roundToInt
 
 object UnitActionsReligion {
 
@@ -111,8 +112,11 @@ object UnitActionsReligion {
 
                 UnitActionModifiers.activateSideEffects(unit, newStyleUnique)
 
-                if (city.civ != unit.civ) city.civ.getDiplomacyManager(unit.civ)!!
-                    .setFlag(DiplomacyFlags.SpreadReligionInOurCities, 30)
+                if (city.civ != unit.civ) {
+                    val flagDuration = (30 * unit.civ.gameInfo.speed.modifier).roundToInt()
+                    city.civ.getDiplomacyManager(unit.civ)!!
+                        .setFlag(DiplomacyFlags.SpreadReligionInOurCities, flagDuration)
+                }
 
             }.takeIf { unit.civ.religionManager.maySpreadReligionNow(unit)
                 && UnitActionModifiers.canActivateSideEffects(unit, newStyleUnique)}


### PR DESCRIPTION
After contemplating 
> An observation I made is that the Demand.violationOccurred flag appears to always be cleared on the next turn (AI responds to violation), yet the flag durations are set to 30 turns. Perhaps this should be set to 1 turn for clarity. Assuming my observation is correct.

in [PR](https://github.com/yairm210/Unciv/pull/14600), I realized it is not always cleared on the next turn. The response may be delayed until an ongoing war has ended. Therefore it makes sense to adjust it with gamespeed rather than setting its value to 1.

I would like to make a constant (or function) for the base duration (30) of these flags, but I am not sure where to place it since they are in separate files. It feels a bit out of place in Constants.kt looking at the other values there, but I am not sure..