### PR TITLE
Ensure newly fetched mod list entries respect the currently applied filter

### DIFF
--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -337,7 +337,9 @@ class ModManagementScreen private constructor(
             val mod = ModUIData(repo, isUpdatedVersionOfInstalledMod)
             onlineModInfo[repo.name] = mod
             modButtons.remove(mod) // Remove *cached* mod button since we have NEW DATA
-            onlineModsTable.add(getCachedModButton(mod)).row()
+            if (mod.matchesFilter(optionsManager.getFilter())) {
+                onlineModsTable.add(getCachedModButton(mod)).row()
+            }
         }
 
         Concurrency.run("Cache mod list"){


### PR DESCRIPTION
Fixes bug where mod list entires loaded in the background are added to the GUI despite not matching filter.
Can be reproduced by deleting the mod list cache file and then applying a filter soon after opening the mod list page.