### PR TITLE
PathingMap can BFS

### DIFF
--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -9,21 +9,18 @@ import com.unciv.logic.map.FixedPointMovement.Companion.fpmFromMovement
 import com.unciv.logic.map.MapPathing.roadPreferredMovementCost
 import com.unciv.logic.map.RouteNode.Companion.MAX_MOVE_THIS_TURN
 import com.unciv.logic.map.RouteNode.Companion.MAX_TURNS
+import com.unciv.logic.map.RouteNode.Companion.MAX_TILES_BEYOND_TURN_RANGE
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.movement.MovementCost
 import com.unciv.logic.map.mapunit.movement.PathsToTilesWithinTurn
 import com.unciv.logic.map.mapunit.movement.UnitMovement.ParentTileAndTotalMovement
 import com.unciv.logic.map.tile.Tile
 import com.unciv.utils.Log
-import com.unciv.utils.LongPriorityQueue
 import com.unciv.utils.forEachSetBit
 import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.InternalState
 import yairm210.purity.annotations.Readonly
-import java.util.BitSet
-import java.util.Formatter
-import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -151,7 +148,7 @@ class PathingMap(
         if (!targetNode.initialized  && !cache.nodesNeedingNeighbors.isEmpty) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#getShortestPath(${destination.position}) calculcating for $debugMapType $debugId")
-            stepUntilDestination(cache, destination, maxTurns)
+            aStarStepUntilDestination(cache, destination, maxTurns)
         }
         val bestTarget =  RouteNode(cache.routeNodes[destination.zeroBasedIndex])
         // if the target is not reachable within maxTurns, return nothing
@@ -183,8 +180,7 @@ class PathingMap(
         }
         return result.asReversed()
     }
-
-
+    
     /**
      * Gets the tiles the unit could move to with remaining movement this turn.
      * Does not consider if tiles can actually be entered, use canMoveTo for that.
@@ -205,10 +201,107 @@ class PathingMap(
         if (!cache.nodesNeedingNeighbors.isEmpty) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#getMovementToTilesAtPosition calculcating for $debugMapType $debugId")
-            stepUntilDestination(cache, null, 1)
+            bfsStepUntilDestination(cache, { _,attackRange -> attackRange == 1 }, 1)
         }
         getTilesSameTurn(cache)
         return tilesSameTurn
+    }
+
+    /**
+     * finds the closest tile that match a predicate.
+     * 
+     * If there are multiple matches with the same movement cost, then this uses 
+     * tile-owner-relationship as a tiebreaker, followed by zeroBasedIndex (roughly, distance from
+     * center of map).
+     *
+     * The results of the method, and the per-tile-predicate-results are NOT cached, and so this has
+     * to check all tiles starting from the origin every call, even if the tiles' nodes have already
+     * been cached from prior pathfinding. However, this uses/generates the same cached nodes as the
+     * other pathfinding (movement cost, relationship level, shortest route, damage numbers, etc),
+     * and so if the nodes were already cached, then this is fast, and if the nodes were not already
+     * cached, then this makes subsequent pathfinding fast.
+     *
+     * IMPORTANT NOTE: This does NOT consider obstacles (hills/mountains) in the attack range.
+     * Callers have to check for obstacles along the path themselves.
+     **/
+    // @IgnorableReturnValue
+    fun bfsForTurns(timeLimitTurns: Int = MAX_VALID_TURNS, endSearchPredicate: EndSearchPredicate): Tile?
+        = bfsStepUntilDestination(fetchCache(), endSearchPredicate, timeLimitTurns)
+
+    /**
+     * finds the closest tile that match a predicate.
+     *
+     * If there are multiple matches with the same movement cost, then this uses
+     * tile-owner-relationship as a tiebreaker, followed by zeroBasedIndex (roughly, distance from
+     * center of map).
+     *
+     * The results of the method, and the per-tile-predicate-results are NOT cached, and so this has
+     * to check all tiles starting from the origin every call, even if the tiles' nodes have already
+     * been cached from prior pathfinding. However, this uses/generates the same cached nodes as the
+     * other pathfinding (movement cost, relationship level, shortest route, damage numbers, etc),
+     * and so if the nodes were already cached, then this is fast, and if the nodes were not already
+     * cached, then this makes subsequent pathfinding fast.
+     *
+     * IMPORTANT NOTE: This does NOT consider obstacles (hills/mountains) in the attack range.
+     * Callers have to check for obstacles along the path themselves.
+     **/
+    // @IgnorableReturnValue
+    fun bfsInAttackRange(attackRange: Int, endSearchPredicate: EndSearchPredicate): Tile? {
+        require(attackRange < MAX_TILES_BEYOND_TURN_RANGE)
+        val searchPredicate = EndSearchPredicate { tile:Tile, tilesBeyondTurn: Int ->
+                tilesBeyondTurn < attackRange && endSearchPredicate(tile, tilesBeyondTurn) 
+            }
+        return bfsStepUntilDestination(fetchCache(), searchPredicate, MAX_VALID_TURNS)
+    }
+
+    /**
+     * finds all tiles in attack range that match a predicate.
+     *
+     * This does not cache the results of the predicate matching, and so has to check all tiles
+     * starting from the origin, even if the tiles' nodes have already been cached from prior
+     * pathfinding. However, this uses/generates the same cached nodes as the other pathfinding
+     * (movement cost, relationship level, shortest route, damage numbers, etc), so if any other 
+     * pathing also occurs before or after, then these checks are effectively free.
+     * 
+     * If you do not care about movement cost, then the BFS class is probably faster.
+     *
+     * IMPORTANT NOTE: This does NOT consider sight obstacles (hills/mountains) in the attack range.
+     *
+     * IMPORTANT NOTE: The results of this method are not cached.  The *nodes* are cached , but the list of tiles
+     **/
+    // @IgnorableReturnValue
+    fun bfsAllTilesInTurns(timeLimitTurns: Int = MAX_VALID_TURNS, tilePredicate: EndSearchPredicate): List<Tile> {
+        val results = ArrayList<Tile>()
+        val searchPredicate = EndSearchPredicate { tile:Tile, tilesBeyondTurn: Int ->
+            if (tilePredicate(tile, tilesBeyondTurn)) results.add(tile)
+            false
+        }
+        bfsStepUntilDestination(fetchCache(), searchPredicate, timeLimitTurns)
+        return results
+    }
+
+    /**
+     * finds all tiles in attack range that match a predicate.
+     * 
+     * This does not cache the results of the predicate matching, and so has to check all tiles
+     * starting from the origin, even if the tiles' nodes have already been cached from prior
+     * pathfinding. However, this uses/generates the same cached nodes as the other pathfinding (movement cost, relationship
+     * level, shortest route, damage numbers, etc), but 
+     * 
+     * IMPORTANT NOTE: This does NOT consider obstacles (hills/mountains) in the attack range.
+     * 
+     * IMPORTANT NOTE: The results of this method are not cached.  The *nodes* are cached , but the list of tiles
+     **/
+    // @IgnorableReturnValue
+    fun bfsAllTilesInAttackRange(attackRange: Int, tilePredicate: EndSearchPredicate): List<Tile> {
+        require(attackRange < MAX_TILES_BEYOND_TURN_RANGE)
+        val results = ArrayList<Tile>()
+        val searchPredicate = EndSearchPredicate { tile:Tile, tilesBeyondTurn: Int -> 
+                if (tilesBeyondTurn < attackRange && tilePredicate(tile, tilesBeyondTurn)) results.add(tile)
+                /*return*/ tilesBeyondTurn >= attackRange // >= because unit needs SOME movement left to attack, so can't use ALL movement
+            }
+        bfsStepUntilDestination(fetchCache(), searchPredicate, MAX_VALID_TURNS)
+        return results
     }
 
     private fun getTilesSameTurn(cache: PathingMapCache) {
@@ -250,9 +343,9 @@ class PathingMap(
     }
 
     /**
-     * Use a AStarPathfinder instance to calculate the route, with thread-safe way
+     * Use AStar algorithm to calculate the route to the destination, in thread-safe way
      **/
-    private fun stepUntilDestination(cache: PathingMapCache, destination: Tile?, timeLimitTurns: Int) {
+    private fun aStarStepUntilDestination(cache: PathingMapCache, destination: Tile?, timeLimitTurns: Int) {
         val finder = AStarPathfinder(
             debugId,
             debugMapType,
@@ -262,7 +355,8 @@ class PathingMap(
             cost,
             tileRoadCost,
             relationshipLevel,
-            cache.forkForPathfinding(),
+            {_,_ -> false},
+            cache.forkForAStarPathfinding(),
             timeLimitTurns.coerceAtMost(MAX_VALID_TURNS),
             tileMap,
         )
@@ -271,6 +365,34 @@ class PathingMap(
         // now merge the pathfinder's tilesChecked and tilesToCheck back into the shared PathingData
         // again using a synchronized block not just for thread-safety, but also to ensure atomicity
         cache.mergePathfindingFork(finder.cache)
+    }
+
+    /**
+     * Use Breadth-First Search algorithm to find a target tile, in a thread safe way
+     **/
+    // @IgnorableReturnValue
+    private fun bfsStepUntilDestination(cache: PathingMapCache, endSearchPredicate: EndSearchPredicate, timeLimitTurns: Int): Tile? {
+        val finder = AStarPathfinder(
+            debugId,
+            debugMapType,
+            null,
+            moveThroughPredicate,
+            endTurnDamage,
+            cost,
+            tileRoadCost,
+            relationshipLevel,
+            endSearchPredicate,
+            cache.forkForBfsPathfinding(tileMap),
+            timeLimitTurns.coerceAtMost(MAX_VALID_TURNS),
+            tileMap,
+        )
+        val result = finder.stepUntilDestination()
+        
+        // now merge the pathfinder's tilesChecked and tilesToCheck back into the shared PathingData
+        // again using a synchronized block not just for thread-safety, but also to ensure atomicity
+        cache.mergePathfindingFork(finder.cache)
+        
+        return result
     }
     
     override fun toString(): String {
@@ -303,6 +425,11 @@ class PathingMap(
         fun interface TileRoadCost {
             @Readonly
             operator fun invoke(it: Tile): FixedPointMovement
+        }
+        @FunctionalInterface
+        fun interface EndSearchPredicate {
+            @Readonly
+            operator fun invoke(tile: Tile, tilesBeyondTurn: Int): Boolean
         }
 
         @Suppress("unused")

--- a/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
+++ b/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
@@ -4,12 +4,15 @@ import com.badlogic.gdx.utils.IntIntMap
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.FixedPointMovement.Companion.FPM_ZERO
+import com.unciv.logic.map.FixedPointMovement.Companion.fpmFromMovement
 import com.unciv.logic.map.PathingMap.Companion.ALWAYS_LOG
 import com.unciv.logic.map.PathingMap.Companion.VERBOSE_PATHFINDING_LOGS
 import com.unciv.logic.map.PathingMap.Companion.EndTurnDamageLookup
+import com.unciv.logic.map.PathingMap.Companion.EndSearchPredicate
 import com.unciv.logic.map.PathingMap.Companion.MoveThroughPredicate
 import com.unciv.logic.map.PathingMap.Companion.TileMovementCost
 import com.unciv.logic.map.PathingMap.Companion.TileRoadCost
+import com.unciv.logic.map.RouteNode.Companion.MAX_TILES_BEYOND_TURN_RANGE
 import com.unciv.logic.map.RouteNode.Companion.MAX_DAMAGING_TILES
 import com.unciv.logic.map.RouteNode.Companion.MAX_MOVE_THIS_TURN
 import com.unciv.logic.map.RouteNode.Companion.MAX_TURNS
@@ -27,7 +30,6 @@ import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.InternalState
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
-import java.util.PriorityQueue
 
 // This crams all the information we need about prioritizing a node into a single Long, avoiding allocations
 @JvmInline
@@ -73,6 +75,7 @@ internal class AStarPathfinder(
     private val cost: TileMovementCost,
     private val tileRoadCost: TileRoadCost,
     private val relationshipLevel: (Tile) -> RelationshipLevel,
+    private val endSearchPredicate: EndSearchPredicate,
     internal val cache: PathingMapCache,
     private val timeLimitTurns: Int,
     private val tileMap: TileMap,
@@ -80,7 +83,8 @@ internal class AStarPathfinder(
     internal val routeNodes = cache.routeNodes // Actually Array<RouteNode>
     private val initialBufferSize = tileMap.tileMatrix.size + tileMap.tileMatrix[0].size
     internal val tilesInTodo: IntIntMap = IntIntMap(initialBufferSize)
-
+    private val fullMovementFpm = fpmFromMovement(cache.key.fullMove)
+    
     /**
      * Frontier priority queue for managing the tiles to be checked.
      * Tiles are ordered based on their priority, determined by the cumulative cost so far and the
@@ -107,14 +111,13 @@ internal class AStarPathfinder(
     @Readonly
     private fun calculateUnderestimatedMovement(node: RouteNode): FixedPointMovement {
         val tile = node.tile(tileMap)
-        val movementSoFar = FixedPointMovement.fpmFromMovement(node.turns * cache.key.fullMove) + node.moveUsedThisTurn
+        val movementSoFar = fullMovementFpm * node.turns + node.moveUsedThisTurn.coerceAtMost(fullMovementFpm)
         val minRemainingTiles = destination?.let { tile.aerialDistanceTo(it) } ?: 1
         val minRemainingCost = tileRoadCost(tile) + (minRemainingTiles - 1) * (FASTEST_ROAD_COST)
         val underestimatedTotal = movementSoFar + minRemainingCost
         return underestimatedTotal
     }
-    
-    private fun neighborNeedsCalcuating(currentNode: RouteNode, neighborTile: Tile): Boolean {
+    private fun neighborNeedsQueueing(currentNode: RouteNode, neighborTile: Tile): Boolean {
         val currentTile = currentNode.tile(tileMap)
         val startingPoint = cache.key.startingPoint
         val alreadyCalculatedNode = RouteNode(routeNodes[neighborTile.zeroBasedIndex])
@@ -130,6 +133,21 @@ internal class AStarPathfinder(
                 Log.debug("#calculateAndQueue ${currentTile.position} ignoring ${neighborTile.position} because it's already queued, for $debugMapType $debugId")
             return false// another tile already queued a route to that neighbor. skip it.
         }
+        if (!moveThroughPredicate(neighborTile)) { // can't move here.
+            val noPathingNode = RouteNode.noPathingNode(neighborTile)
+            routeNodes[neighborTile.zeroBasedIndex] = noPathingNode.bits
+            cache.addedNeighborNodes.set(neighborTile.zeroBasedIndex)
+            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
+                Log.debug("#calculateAndQueue ${currentTile.position} set ${neighborTile.position} as noPathingNode because cannot move there, for $debugMapType $debugId")
+            return false
+        }
+        return true        
+    }
+    
+    private fun neighborNeedsCalcuating(currentNode: RouteNode, neighborTile: Tile): Boolean {
+        val currentTile = currentNode.tile(tileMap)
+        val startingPoint = cache.key.startingPoint
+        val alreadyCalculatedNode = RouteNode(routeNodes[neighborTile.zeroBasedIndex])
         // If another thread already calculated the best route, then we can queue it and move on
         if (alreadyCalculatedNode.initialized && alreadyCalculatedNode.damagingTiles <= currentNode.damagingTiles) {
             if (alreadyCalculatedNode.turns < timeLimitTurns)
@@ -138,14 +156,6 @@ internal class AStarPathfinder(
             cache.nodesNeedingNeighbors.set(neighborTile.zeroBasedIndex)
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#calculateAndQueue ${currentTile.position} queueing ${alreadyCalculatedNode.tile(tileMap).position} because another thread calculated, for $debugMapType $debugId")
-            return false
-        }
-        if (!moveThroughPredicate(neighborTile)) { // can't move here.
-            val noPathingNode = RouteNode.noPathingNode(neighborTile)
-            routeNodes[neighborTile.zeroBasedIndex] = noPathingNode.bits
-            cache.addedNeighborNodes.set(neighborTile.zeroBasedIndex)
-            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} set ${neighborTile.position} as noPathingNode because cannot move there, for $debugMapType $debugId")
             return false
         }
         return true
@@ -157,34 +167,34 @@ internal class AStarPathfinder(
         val damagingTiles = currentNode.damagingTiles
         val cost = cost(currentTile, neighborTile).coerceAtMost(MAX_MOVE_THIS_TURN)
         val newUsedMovement = (currentNode.moveUsedThisTurn + cost).coerceAtMost(MAX_MOVE_THIS_TURN)
-        val fullMovement = cache.key.fullMove
         val endTurnThereDamage = endTurnDamage(neighborTile).coerceAtMost(1)
         val newMountainMovement =
             (if (currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0) cost // first entering mountains
             else if (!currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0) currentNode.pbmMoveThisTurn + cost
             else FPM_ZERO // ignored in this case
                 ).coerceAtMost(MAX_MOVE_THIS_TURN)
-        val canEndTurnOrProbablyMoveAway = endTurnThereDamage == 0 || (newUsedMovement < fullMovement)
+        val canEndTurnOrProbablyMoveAway = endTurnThereDamage == 0 || (newUsedMovement < fullMovementFpm)
         val relationship = relationshipLevel(neighborTile)
+        val tileBeyondTurnForNextTurn = (currentNode.tilesBeyondTurn + 1).coerceAtMost(MAX_TILES_BEYOND_TURN_RANGE)
+        val tileBeyondTurnForSameTurn = if (currentNode.turns == 0) 0 else tileBeyondTurnForNextTurn
         
-        val newNode: RouteNode
         // This can use more than the remaining movement, but that's correct behavior.
         // https://yairm210.medium.com/multi-turn-pathfinding-7136bd0bdaf0
-        if (currentNode.moveUsedThisTurn < fullMovement  && canEndTurnOrProbablyMoveAway) {
+        if (currentNode.moveUsedThisTurn < fullMovementFpm  && canEndTurnOrProbablyMoveAway) {
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} for same turn, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, newMountainMovement, newUsedMovement, currentNode.turns,  currentTile, damagingTiles)
+            return RouteNode(neighborTile, relationship, newMountainMovement, newUsedMovement, currentNode.turns,  currentTile, tileBeyondTurnForSameTurn, damagingTiles)
         } else if (currentNode.endTurnWithoutMoreDamage && canEndTurnOrProbablyMoveAway) {
             // We have to move there next turn.
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} for next turn, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, newMountainMovement, cost, currentNode.turns + 1, currentTile, damagingTiles)
-        } else if (currentNode.pbmMoveThisTurn < fullMovement) {
+            return RouteNode(neighborTile, relationship, newMountainMovement, cost, currentNode.turns + 1, currentTile, tileBeyondTurnForNextTurn, damagingTiles)
+        } else if (currentNode.pbmMoveThisTurn < fullMovementFpm) {
             // If we could have moved here if we'd paused before entering mountains, then
             // pretend we paused before entering the mountains.
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with retroactive pause before mountains, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, newMountainMovement, newMountainMovement, currentNode.turns + 1, currentTile, damagingTiles)
+            return RouteNode(neighborTile, relationship, newMountainMovement, newMountainMovement, currentNode.turns + 1, currentTile, tileBeyondTurnForSameTurn, damagingTiles)
         } else {
             // Ending our turn here takes damage. We'll add the neighbor tile, but the damage
             // means it's neighbors will be calculated at a super low priority.
@@ -193,24 +203,42 @@ internal class AStarPathfinder(
             val newDamageTiles = (damagingTiles + endTurnThereDamage).coerceAtMost(MAX_DAMAGING_TILES)
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with taking damage, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, cost, cost, currentNode.turns + 1, currentTile, newDamageTiles)
+            return RouteNode(neighborTile, relationship, cost, cost, currentNode.turns + 1, currentTile, tileBeyondTurnForNextTurn, newDamageTiles)
         }
     }
 
-    // returns target node. If timed out 
-    internal fun stepUntilDestination() {
-        while (todo.isNotEmpty()) {
-            val currentPrioritizedNode = PrioritizedNode(todo.poll())
-            val currentNode = RouteNode(routeNodes[currentPrioritizedNode.tileIdx])
-            val currentTile = currentNode.tile(tileMap)
-            for (neighborTile in currentTile.neighbors) { // calculate each neighbor               
-                if (!neighborNeedsCalcuating(currentNode, neighborTile)) continue
+    private fun considerNeighbor(
+        currentNode: RouteNode,
+        neighborTile: Tile
+    ): Tile? {
+        if (!neighborNeedsQueueing(currentNode, neighborTile)) return null
+        val neighborNode =
+            if (!neighborNeedsCalcuating(currentNode, neighborTile)) {
+                RouteNode(routeNodes[neighborTile.zeroBasedIndex])
+            } else {
                 val newNode = calculateNeighborNode(currentNode, neighborTile) // calculate each neighbor
                 routeNodes[neighborTile.zeroBasedIndex] = newNode.bits
                 if (newNode.turns < timeLimitTurns)
                     todo.add(PrioritizedNode(newNode, calculateUnderestimatedMovement(newNode)).bits)
                 tilesInTodo.put(neighborTile.zeroBasedIndex, newNode.damagingTiles)
                 cache.nodesNeedingNeighbors.set(neighborTile.zeroBasedIndex)
+                newNode
+            }
+        if (endSearchPredicate(neighborTile, neighborNode.tilesBeyondTurn))
+            return neighborTile
+        return null
+    }
+
+    internal fun stepUntilDestination(): Tile? {
+        val startTile = tileMap[cache.key.startingPoint]
+        if (endSearchPredicate(startTile, 0)) return startTile
+        while (todo.isNotEmpty()) {
+            val currentPrioritizedNode = PrioritizedNode(todo.poll())
+            val currentNode = RouteNode(routeNodes[currentPrioritizedNode.tileIdx])
+            val currentTile = currentNode.tile(tileMap)
+            for (neighborTile in currentTile.neighbors) { // calculate each neighbor       
+                val foundTargetTile = considerNeighbor(currentNode, neighborTile)
+                if (foundTargetTile != null) return foundTargetTile
             }
             // mark this tile as having its neighbors added
             tilesInTodo.remove(currentTile.zeroBasedIndex, 0)
@@ -218,15 +246,20 @@ internal class AStarPathfinder(
             cache.addedNeighborNodes.set(currentTile.zeroBasedIndex)
             // if we reached the destination, (or if another thread did), then we stop
             if (destination != null && RouteNode(routeNodes[destination.zeroBasedIndex]).initialized)
-                return
+                return destination
         }
+        return null
     }
 
     override fun toString() = "${javaClass.simpleName}[debugMapType=$debugMapType debugId=$debugId]"
     
     @VisibleForTesting
     @Suppress("unused")
-    fun toDebugString() = cache.toDebugString(UncivGame.Current.gameInfo!!.tileMap, destination)
+    fun cacheToDebugString() = cache.toDebugString(UncivGame.Current.gameInfo!!.tileMap, destination)
+
+    @VisibleForTesting
+    @Suppress("unused")
+    fun queueToDebugString() = buildString { todo.forEach { append(PrioritizedNode(it)).append('\n') } }
 
     companion object {
         // Setting this higher than the fastest speed (railroads at 0.1f) will cause the pathfinding

--- a/core/src/com/unciv/logic/map/PathingMapCache.kt
+++ b/core/src/com/unciv/logic/map/PathingMapCache.kt
@@ -72,6 +72,8 @@ import java.util.Locale
  *   use 14 to represent "no parent tile" (such as for the root node). Since the values are always
  *   even, we do not store the last bit, so this only takes 3 bits. This is never zero, which 
  *   guarantees that an initialized RouteNode is never zero.
+ * - tilesBeyondTurn: The number of tiles *past* where we can move this turn. This is one higher
+ *   than the unit's attack range, since attacking requires some movement. This takes 5 bits.
  * - padding: In a RouteNode, the other remaining 12 bits of underestimatedTotal just hold zeroes, 
  *   for now.
  * - damagingTiles: How many tiles that cause end-turn damage have been crossed to reach this tile.
@@ -96,6 +98,7 @@ value class RouteNode(val bits: Long=0L) {
         moveThisTurn: FixedPointMovement,
         turns: Int,
         parentTile: Tile,
+        tilesBeyondTurn: Int,
         damagingTiles: Int,
     ):
         this(
@@ -105,6 +108,7 @@ value class RouteNode(val bits: Long=0L) {
                 toMoveThisTurnBits(moveThisTurn) or
                 toTurnsBits(turns) or
                 toParentClockDirBits(tile, parentTile) or
+                toTilesBeyondTurnBits(tilesBeyondTurn) or 
                 toDamagingTilesBits(damagingTiles)
         ) {
         require(tile.zeroBasedIndex < tile.tileMap.tileList.size) { "tileList ${tile.zeroBasedIndex} exceeds max ${tile.tileMap.tileList.size}" }
@@ -116,6 +120,8 @@ value class RouteNode(val bits: Long=0L) {
         require(turns >= 0) { "turns $turns must be positive" }
         require(turns <= MAX_TURNS) { "turns $turns exceeds max $MAX_TURNS" }
         require(toParentClockDirBits(tile, parentTile) > 0) {"parentClockDir $parentClockDir must be positive"}
+        require(tilesBeyondTurn >= 0) { "tilesBeyondTurn $tilesBeyondTurn must be positive" }
+        require(tilesBeyondTurn <= MAX_TILES_BEYOND_TURN_RANGE) { "tilesBeyondTurn $tilesBeyondTurn exceeds max $MAX_TILES_BEYOND_TURN_RANGE" }
         require(damagingTiles >= 0) { "damagingTiles $damagingTiles must be positive" }
         require(damagingTiles <= DAMAGE_TILES_LO_MASK) { "damagingTiles $moveThisTurn exceeds max $DAMAGE_TILES_LO_MASK" }
     }
@@ -149,6 +155,8 @@ value class RouteNode(val bits: Long=0L) {
         if (idx == NO_PARENT_TILE_VALUE) return tile(tileMap)
         return tileMap.getClockPositionNeighborTile(tile(tileMap), idx)!!
     }
+    
+    val tilesBeyondTurn: Int get() { require(initialized); return ((bits shr TILES_BEYOND_TURN_OFFSET) and TILES_BEYOND_TURN_LO_MASK).toInt() }
 
     val damagingTiles: Int get() { require(initialized); return ((bits shr DAMAGE_TILES_OFFSET) and DAMAGE_TILES_LO_MASK).toInt() }
 
@@ -158,9 +166,9 @@ value class RouteNode(val bits: Long=0L) {
     val isNoPathingNode: Boolean get() = pbmMoveThisTurn.bits == PBM_MOVE_THIS_TURN_LO_MASK.toInt()
 
     @Readonly
-    override fun toString() = "RouteNode[tile=$tileIdx, turns=$turns, moveUsedThisTurn=$moveUsedThisTurn]"
+    override fun toString() = "RouteNode[tile=$tileIdx, turns=$turns, moveUsedThisTurn=$moveUsedThisTurn, tilesBeyondTurn=$tilesBeyondTurn]"
     @Readonly
-    fun toString(tileMap: TileMap) = "RouteNode[tile=${tile(tileMap)} turns=$turns, moveThisTurn=$moveUsedThisTurn]"
+    fun toString(tileMap: TileMap) = "RouteNode[tile=${tile(tileMap).position} turns=$turns, moveThisTurn=$moveUsedThisTurn, tilesBeyondTurn=$tilesBeyondTurn]"
 
     companion object {
         // bits 0-19 (20b = 1048576tiles) are the zeroBasedIndex of this tile (radius 500, or approx 1170x896) 
@@ -203,7 +211,13 @@ value class RouteNode(val bits: Long=0L) {
         private const val PARENT_TILE_LO_MASK = (0x1L shl PARENT_TILE_BIT_COUNT) - 1L
         private const val NO_PARENT_TILE_BITS = 7L
         private const val NO_PARENT_TILE_VALUE = 14
-        // [RouteNode] bits 50-60 (11b) are padding bits, only used by PrioritizedNode's underestimatedTotal field
+        // [RouteNode] bits 50-54 (5b = 31tiles) are the number of tiles further than can move right now. Used for attack ranges. Tiles can be moved to hold 0.
+        private const val TILES_BEYOND_TURN_OFFSET = PARENT_TILE_OFFSET + PARENT_TILE_BIT_COUNT
+        private const val TILES_BEYOND_TURN_BIT_COUNT = 5
+        private const val TILES_BEYOND_TURN_LO_MASK = (0x1L shl TILES_BEYOND_TURN_BIT_COUNT) - 1L
+        internal const val MAX_TILES_BEYOND_TURN_RANGE = TILES_BEYOND_TURN_LO_MASK.toInt()
+        // [RouteNode] bits 55-60 (6b) are padding bits, only used by PrioritizedNode's underestimatedTotal field
+        // no constsants for [RouteNode] padding bits 55-60
         // bits 61-62 (2b = 4turns) are the number of turns ended in damaging tiles.
         private const val DAMAGE_TILES_OFFSET = UNDERESTIMATED_TOTAL_OFFSET + UNDERESTIMATED_TOTAL_BIT_COUNT
         private const val DAMAGE_TILES_BIT_COUNT = 2
@@ -214,6 +228,9 @@ value class RouteNode(val bits: Long=0L) {
         @Readonly
         private fun toParentClockDirBits(tile: Tile, parentTile: Tile): Long
             = (if (tile == parentTile) NO_PARENT_TILE_BITS else tile.tileMap.getNeighborTileClockPosition(tile, parentTile)/2L) shl PARENT_TILE_OFFSET
+        @Readonly
+        private fun toTilesBeyondTurnBits(tilesBeyondTurn: Int): Long
+            = tilesBeyondTurn.toLong() shl TILES_BEYOND_TURN_OFFSET
         @Pure
         private fun toMoveThisTurnBits(moveThisTurn: FixedPointMovement): Long
             = moveThisTurn.bits.toLong() shl MOVE_THIS_TURN_OFFSET
@@ -241,6 +258,7 @@ value class RouteNode(val bits: Long=0L) {
             MAX_MOVE_THIS_TURN,
             MAX_TURNS,
             tile,
+            0,
             MAX_DAMAGING_TILES,
         )
         @Pure
@@ -250,8 +268,8 @@ value class RouteNode(val bits: Long=0L) {
             FPM_ZERO,
             moveThisTurn,
             0,
-
             tile,
+            0,
             0,
         )
     }
@@ -260,9 +278,16 @@ value class RouteNode(val bits: Long=0L) {
 @JvmInline
 value class FixedPointMovement private constructor(val bits: Int) {
     @Pure operator fun plus(other: FixedPointMovement) = FixedPointMovement(bits + other.bits)
+    @Pure operator fun plus(value: Int) = FixedPointMovement(bits + value * MOVE_SPEED_BASE)
+    @Pure operator fun plus(value: Float) = FixedPointMovement(bits + fpmFromMovement(value).bits)
     @Pure operator fun minus(other: FixedPointMovement) = FixedPointMovement(bits - other.bits)
-    @Pure operator fun plus(other: Float) = FixedPointMovement(bits + (other * MOVE_SPEED_BASE).toInt())
-    @Pure operator fun minus(other: Float) = FixedPointMovement(bits - (other * MOVE_SPEED_BASE).toInt())
+    @Pure operator fun minus(value: Int) = FixedPointMovement(bits - value * MOVE_SPEED_BASE)
+    @Pure operator fun minus(value: Float) = FixedPointMovement(bits - fpmFromMovement(value).bits)
+    @Pure operator fun times(multiplier: Int) = FixedPointMovement(bits * multiplier)
+    @Pure operator fun times(multiplier: Float) = fpmFromMovement(bits * multiplier)
+    @Pure operator fun div(multiplier: Int) = FixedPointMovement(bits / multiplier)
+    @Pure operator fun div(multiplier: Float) = fpmFromMovement(bits / multiplier)
+    
     @Pure operator fun compareTo(other: FixedPointMovement) = bits.compareTo(other.bits)
     @Pure operator fun compareTo(other: Int) = bits.compareTo((other * MOVE_SPEED_BASE))
 
@@ -346,7 +371,7 @@ internal class PathingMapCache private constructor(
      * 
      * This uses the same routeNodes, but copies of the frontier bitsets. It does not set tilesSameTurn.
      */
-    fun forkForPathfinding(): PathingMapCache {
+    fun forkForAStarPathfinding(): PathingMapCache {
         synchronized(addedNeighborNodes) {
             val codesNeedingNeighborsCopy: BitSet = nodesNeedingNeighbors.clone() as BitSet
             val addedNeighborNodesCopy: BitSet = addedNeighborNodes.clone() as BitSet
@@ -372,6 +397,16 @@ internal class PathingMapCache private constructor(
             update.nodesNeedingNeighbors.andNot(update.addedNeighborNodes)
             nodesNeedingNeighbors.or(update.nodesNeedingNeighbors)
         }
+    }
+    
+    fun forkForBfsPathfinding(tileMap: TileMap): PathingMapCache {
+        // BFS searches always start at the root note and work out, they can't start at search frontier.
+        // They do take movementCost into consideration, and so take advantage of the cached
+        // movementCost, relationshipLevel, and damage values for each RouteNode.
+        val forkedNodesNeedingNeighbors = BitSet(nodesNeedingNeighbors.size())
+        forkedNodesNeedingNeighbors.set(tileMap[key.startingPoint].zeroBasedIndex)
+        val forkedAddedNeighborNodes = BitSet(nodesNeedingNeighbors.size())
+        return PathingMapCache(key, forkedNodesNeedingNeighbors, forkedAddedNeighborNodes, routeNodes)
     }
 
     fun clear() {

--- a/tests/src/com/unciv/logic/map/PathingMapTest.kt
+++ b/tests/src/com/unciv/logic/map/PathingMapTest.kt
@@ -10,6 +10,7 @@ import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -49,6 +50,7 @@ class PathingMapTest {
         val moveThisTurn = fpmFromFixedPointBits((1 shl 8) or 1) //9 bits. value is 257 aka 13.00
         val turns = (1 shl 5) or 1 // 6 bits. value is 33
         val parentTile = testGame.tileMap.getClockPositionNeighborTile(tile, 12)!!
+        val attackRange = (1 shl 4) or 1 // 5 bits. value is 17
         val damagingTiles = 3
         val underestimatedTotal = fpmFromFixedPointBits((1 shl 13) or 1) //15 bits. value is 8193 aka 409.65move
         
@@ -60,6 +62,7 @@ class PathingMapTest {
             moveThisTurn,
             turns,
             parentTile,
+            attackRange,
             damagingTiles
         )
 
@@ -67,6 +70,7 @@ class PathingMapTest {
         assertEquals(tile, node.tile(testGame.tileMap))
         assertEquals(12, node.parentClockDir)
         assertEquals(parentTile, node.parentTile(testGame.tileMap))
+        assertEquals(attackRange, node.tilesBeyondTurn)
         assertEquals(moveThisTurn, node.moveUsedThisTurn)
         assertEquals(pbmMoveThisTurn, node.pbmMoveThisTurn)
         assertEquals(turns, node.turns)
@@ -81,8 +85,7 @@ class PathingMapTest {
         val reRouteNode = RouteNode(prioritized.bits)
         assertEquals(tile.zeroBasedIndex, reRouteNode.tileIdx)
         assertEquals(tile, reRouteNode.tile(testGame.tileMap))
-        // PrioritizedNode drops parentTile bits
-        //assertEquals(parentTile, reRouteNode.parentTile(testGame.tileMap))
+        // PrioritizedNode drops parentTile and attackRange
         assertEquals(moveThisTurn, reRouteNode.moveUsedThisTurn)
         assertEquals(pbmMoveThisTurn, reRouteNode.pbmMoveThisTurn)
         assertEquals(turns, reRouteNode.turns)
@@ -212,14 +215,12 @@ class PathingMapTest {
         assertEquals(path.toString(), 18, path.size)
         assertNotEquals(path.toString(), path.firstEntry(), path.lastEntry())
         assertEquals("""
-        -3     -2     -1     +0     +1     +2     +3    
-  +3     /      /      /      /     1/1.0  1/1.0  1/1.0 
-  +2     /      /     1/1.0  1/1.0  0/2.0  0/2.0  1/1.0 
-  +1     /     1/1.0  0/2.0  0/2.0  0/1.0  0/2.0  1/1.0 
-  +0    1/1.0  0/2.0  0/1.0  0/0.0S 0/1.0  0/2.0  1/1.0 
-  -1    1/1.0  0/2.0  0/1.0  0/1.0  0/2.0  1/1.0   /    
-  -2    1/1.0  0/2.0  0/2.0  0/2.0  1/1.0   /      /    
-  -3    1/1.0  1/1.0  1/1.0  1/1.0   /      /      /    
+        -2     -1     +0     +1     +2    
+  +2     /      /     1/1.0  0/2.0  0/2.0 
+  +1     /     0/2.0  0/2.0  0/1.0  0/2.0 
+  +0    0/2.0  0/1.0  0/0.0S 0/1.0  0/2.0 
+  -1    0/2.0  0/1.0  0/1.0  0/2.0   /    
+  -2    0/2.0  0/2.0  0/2.0   /      /    
 """, pathing.toDebugString())
         // And affirm cache
         assertEquals(path, pathing.getMovementToTilesAtPosition())
@@ -258,5 +259,93 @@ class PathingMapTest {
         assertNull(path)
         // And affirm cache
         assertEquals(path, pathing.getShortestPath(targetTile))
+    }
+
+    @Test
+    fun getShortestPath_toEveryTile_usesCacheCorrectly() {
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 4
+        val unit = testGame.addUnit(baseUnit.name, civInfo, originTile)
+        unit.currentMovement = 4f
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        for (targetTile in testGame.tileMap.tileList) {
+            val aerialDistance = originTile.aerialDistanceTo(targetTile)
+            
+            val path = pathing.getShortestPath(targetTile)
+            
+            if (aerialDistance <= 4) {
+                assertEquals(listOf(targetTile), path)
+            } else {
+                assertEquals(2, path!!.size)
+                assertEquals(targetTile, path[1])                
+            }
+        }
+    }
+    
+    @Test
+    fun findMatchingTilesInAttackRange_considersAttackRange() {
+        val evemyCiv = testGame.addCiv()
+        // Right side all hills, left side all roads.  A line of enemy warriors just north.
+        for (tile in testGame.tileMap.tileList) {
+            if (tile.position.x > 0) tile.addTerrainFeature("Hill")
+            if (tile.position.x < 0) tile.setRoadStatus(RoadStatus.Road, civInfo)
+            if (tile.position.y == 2) testGame.addUnit("Warrior", evemyCiv, tile)
+        }
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 3
+        baseUnit.range = 2
+        val unit = testGame.addUnit(baseUnit.name, civInfo, originTile)
+        unit.currentMovement = 3f
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val attackableTiles = pathing.bfsAllTilesInAttackRange(2) { tile, _ -> tile.militaryUnit?.civ == evemyCiv}
+        
+        // cant hit enemy at -5,2 because unit would have no movement left.
+        val expected = listOf(
+            HexCoord(1,2),
+            HexCoord(0,2),
+            HexCoord(-1,2),
+            HexCoord(-2,2),
+            HexCoord(2,2),
+            HexCoord(-3,2),
+            HexCoord(-4,2),
+            HexCoord(3,2),
+        )
+        assertEquals(expected, attackableTiles.map {it.position})
+        assertEquals("""
+        -7     -6     -5     -4     -3     -2     -1     +0     +1     +2     +3    
+  +5                                 /      /     1/0.5  1/1.0  1/2.0   /      /    
+  +4                          /      /     1/0.5  0/3.0  0/3.5  1/2.0  1/2.0   /    
+  +3                   /      /     1/0.5  0/3.0  0/2.5  0/3.0  0/4.0  1/2.0  1/2.0 
+  +2            /      /     1/0.5  0/3.0  0/2.5  0/2.0  0/2.0  0/3.0  0/4.0  1/2.0 
+  +1     /      /     1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/2.0  0/4.0  1/2.0 
+  +0     /     1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/0.0S 0/2.0  0/4.0  1/2.0 
+  -1     /     1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/1.0  0/3.0  1/2.0   /    
+  -2     /     1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.5  0/2.0  0/4.0  1/2.0   /    
+  -3     /     1/0.5  0/3.0  0/2.5  0/2.0  0/2.0  0/2.0  0/3.0  1/2.0   /      /    
+  -4     /     1/0.5  0/3.0  0/2.5  0/2.5  0/2.5  0/2.5  0/3.5  1/2.0   /      /    
+  -5     /     1/0.5  0/3.0  0/3.0  0/3.0  0/3.0  0/3.0  1/1.0   /      /      /    
+  -6     /     1/0.5  1/0.5  1/0.5  1/0.5  1/0.5  1/0.5   /      /      /           
+  -7    1/1.0   /      /      /      /      /      /      /      /                  
+""", pathing.toDebugString())
+        // And affirm full recalculation using cached tiles has same result.
+        assertEquals(expected, pathing.bfsAllTilesInAttackRange(2) { tile, _ -> tile.militaryUnit?.civ == evemyCiv}.map {it.position})
+    }
+
+    @Test
+    fun findMatchingTilesInAttackRange_considersSelf() {
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 1
+        val unit = testGame.addUnit(baseUnit.name, civInfo, originTile)
+        unit.currentMovement = 1f
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val attackableTiles = pathing.bfsAllTilesInAttackRange(1) { tile, _ -> tile.civilianUnit?.civ == civInfo}
+
+        val expected = listOf(HexCoord(0,0))
+        assertEquals(expected, attackableTiles.map {it.position})
+        // And affirm full recalculation using cached tiles has same result.
+        assertEquals(expected, pathing.bfsAllTilesInAttackRange(1) { tile, _ -> tile.civilianUnit?.civ == civInfo}.map {it.position})
     }
 }


### PR DESCRIPTION
### PathingMap can BFS

- bfsForTurns
- bfsInAttackRange
- bfsAllTilesInTurns
- bfsAllTilesInAttackRange

These can replace *some* uses of existing BFS class, if they would benefit from taking movement cost into considerations, but not all uses, since most are just checking if a path exists, and don't care about movement cost.  This functionality will be more relevant for modded UnitActions that will need to search for targets.


### Capital connection road pathing considers move cost

- RoadBetweenCitiesAutomation#getRoadToConnectCityToCapital uses a new city.getRoadPathToAny, which uses the existing potentialRoadPathing PathingMap.

This should have little to no impact at all, other than that getRoadToConnectCityToCapital and addWorkBoatChoice$findTileWorthImproving now take movementCost at least partially into consideration.

Automation#chooseMilitaryUnit$isNavalMeleeUnit, UseGoldAutomation#maybeBuyCityTiles, TileMap#assignContinents, UnitMovement#teleportToClosestMoveableTile,  MapEditorEditTab#paintTilesWithBrush, and ConstructionAutomation#addWorkBoatChoice are not converted from BFS, because those only care IF there's a path, but don't care about movement costs.

CapitalConnectionsFinder#check not converted from BFS because that looks complicated and requires more thought.