### PR TITLE
AStar paths through and moves to same tiles as Classic pathing.

### DIFF
--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -11,7 +11,6 @@ import com.unciv.logic.map.RouteNode.Companion.MAX_MOVE_THIS_TURN
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.movement.MovementCost
 import com.unciv.logic.map.mapunit.movement.PathsToTilesWithinTurn
-import com.unciv.logic.map.mapunit.movement.UnitMovement.CannotMoveToReason
 import com.unciv.logic.map.mapunit.movement.UnitMovement.ParentTileAndTotalMovement
 import com.unciv.logic.map.tile.Tile
 import com.unciv.utils.Log
@@ -65,7 +64,8 @@ class PathingMap(
     private val debugId: Any,
     private val debugMapType: String,
     private val getCurrentCacheKey: () -> PathingMapCacheKey,
-    private val moveThroughPredicate: MoveThroughPredicate,
+    private val passThroughPredicate: TilePredicate,
+    private val moveToPredicate: TilePredicate,
     private val endTurnDamage: EndTurnDamageLookup,
     private val cost: TileMovementCost,
     private val tileRoadCost: TileRoadCost,
@@ -171,7 +171,7 @@ class PathingMap(
             val parentTile = currentNode.parentTile(tileMap)
             val parentNode = RouteNode(cache.routeNodes[parentTile.zeroBasedIndex])
             if (parentTile.position == cache.key.startingPoint) break
-            if (parentNode.turns < turns && parentNode.endTurnWithoutMoreDamage) {
+            if (parentNode.turns < turns && parentNode.endTurnWithoutMoreDamage && parentNode.canMoveTo) {
                 result.add(parentTile)
                 turns = parentNode.turns
             }
@@ -211,14 +211,15 @@ class PathingMap(
         val tilesSameTurn = cache.tilesSameTurn
         // accumulate all the results
         synchronized(tilesSameTurn) {
-            if (tilesSameTurn.isNotEmpty()) {
+            if (tilesSameTurn.isNotEmpty()) { // if we've already calculated the results, return that
                 if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                     Log.debug("#getMovementToTilesAtPosition returning cached tilesSameTurn[len=${tilesSameTurn.size}] which was calculated by another thread for $debugMapType $debugId")
                 return
-            } // if we've already calculated the results, return that
+            }
+            // otherwise, add the tiles in turn 0, (or would be if unoccupied, and we can swap/attack in)
             cache.addedNeighborNodes.forEachSetBit {
                 val node = RouteNode(cache.routeNodes[it])
-                if (node.initialized && node.turns == 0) {
+                if (node.initialized && (node.turns == 0 || !node.canMoveTo)) {
                     val tile = node.tile(tileMap)
                     tilesSameTurn[tile] =
                         ParentTileAndTotalMovement(
@@ -228,7 +229,7 @@ class PathingMap(
             }
             cache.nodesNeedingNeighbors.forEachSetBit {
                 val node = RouteNode(cache.routeNodes[it])
-                if (node.initialized && node.turns == 0) {
+                if (node.initialized && (node.turns == 0 || !node.canMoveTo)) {
                     val tile = node.tile(tileMap)
                     tilesSameTurn[tile] =
                         ParentTileAndTotalMovement(tile, node.parentTile(tileMap), node.moveUsedThisTurn.toFloat())
@@ -253,7 +254,8 @@ class PathingMap(
             debugId,
             debugMapType,
             destination,
-            moveThroughPredicate,
+            passThroughPredicate,
+            moveToPredicate,
             endTurnDamage,
             cost,
             tileRoadCost,
@@ -281,7 +283,7 @@ class PathingMap(
         
         // Functional interfaces used here to prevent Kotlin from Boxing the return values
         @FunctionalInterface
-        fun interface MoveThroughPredicate {
+        fun interface TilePredicate {
             @Readonly
             operator fun invoke(it: Tile): Boolean
         }
@@ -326,16 +328,13 @@ class PathingMap(
                     fpmFromMovement(selfFullMove.coerceAtMost(if (escort != null) otherUntilFullMove else MAX_VALID_TURNS)),
                     )
             }
-            val moveThroughPredicate = MoveThroughPredicate {
-                val cannotMoveThroughReason = unit.movement.cannotPassThroughReason(it, includeEscortUnit)
-                cannotMoveThroughReason == null || cannotMoveThroughReason == CannotMoveToReason.TileIsNotEmpty
-            }
             return PathingMap(
                 unit.currentTile.tileMap,
                 unit,
                 name,
                 getCurrentCacheKey,
-                moveThroughPredicate,
+                { unit.movement.cannotPassThroughReason(it, includeEscortUnit) == null },
+                { unit.movement.canMoveTo(it, assumeCanPassThrough = true, allowSwap = false, includeOtherEscortUnit = includeEscortUnit) },
                 { unit.getDamageFromTerrain(it) },
                 { from, to -> fpmFromMovement(MovementCost.getMovementCostBetweenAdjacentTilesEscort(unit, from, to, considerZoneOfControl, includeEscortUnit)) },
                 { fpmFromMovement(it.getConnectionStatus(unit.civ).movement) },
@@ -351,6 +350,7 @@ class PathingMap(
                 "createLandAttackPathingMap",
                 { civPathExistCacheKey(startingPoint.position)},
                 { isLandTileCanAttackThrough(civ, it, targetCiv) },
+                { true },
                 { 0 },
                 { from, to -> fpmFromMovement(roadPreferredMovementCost(civ, from, to)) },
                 { fpmFromMovement(it.getConnectionStatus(civ).movement) },
@@ -366,6 +366,7 @@ class PathingMap(
                 "createAmphibiousAttackPathingMap",
                 { civPathExistCacheKey(startingPoint.position)},
                 { isTileCanAttackThrough(civ, it, targetCiv) },
+                { true },
                 { 0 },
                 { from, to -> fpmFromMovement(roadPreferredMovementCost(civ, from, to)) },
                 { fpmFromMovement(it.getConnectionStatus(civ).movement) },
@@ -385,6 +386,7 @@ class PathingMap(
                 "createRoadPathingMap",
                 { PathingMapCacheKey(startingPoint.position,  FPM_POINT_FIVE, FPM_POINT_FIVE) },
                 {MapPathing.isValidRoadPathTile(civ, it) },
+                { true },
                 { 0 },
                 { _, to -> if ((to.hasRoadConnection(civ, false) || to.hasRailroadConnection(false))) FPM_POINT_FIVE else FPM_ONE },
                 { FPM_ONE },

--- a/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
+++ b/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
@@ -7,7 +7,7 @@ import com.unciv.logic.map.FixedPointMovement.Companion.FPM_ZERO
 import com.unciv.logic.map.PathingMap.Companion.ALWAYS_LOG
 import com.unciv.logic.map.PathingMap.Companion.VERBOSE_PATHFINDING_LOGS
 import com.unciv.logic.map.PathingMap.Companion.EndTurnDamageLookup
-import com.unciv.logic.map.PathingMap.Companion.MoveThroughPredicate
+import com.unciv.logic.map.PathingMap.Companion.TilePredicate
 import com.unciv.logic.map.PathingMap.Companion.TileMovementCost
 import com.unciv.logic.map.PathingMap.Companion.TileRoadCost
 import com.unciv.logic.map.RouteNode.Companion.MAX_DAMAGING_TILES
@@ -66,7 +66,8 @@ internal class AStarPathfinder(
     private val debugId: Any,
     private val debugMapType: String,
     private val destination: Tile?,
-    private val moveThroughPredicate: MoveThroughPredicate,
+    private val passThroughPredicate: TilePredicate,
+    private val moveToPredicate: TilePredicate,
     private val endTurnDamage: EndTurnDamageLookup,
     private val cost: TileMovementCost,
     private val tileRoadCost: TileRoadCost,
@@ -105,7 +106,7 @@ internal class AStarPathfinder(
     @Readonly
     private fun calculateUnderestimatedMovement(node: RouteNode): FixedPointMovement {
         val tile = node.tile(tileMap)
-        val movementSoFar = cache.key.fullMove * node.turns + node.moveUsedThisTurn
+        val movementSoFar = cache.key.fullMove * node.turns + node.moveUsedThisTurn.coerceAtMost(cache.key.fullMove)
         val minRemainingTiles = destination?.let { tile.aerialDistanceTo(it) } ?: 1
         val minRemainingCost = tileRoadCost(tile) + (minRemainingTiles - 1) * (FASTEST_ROAD_COST)
         val underestimatedTotal = movementSoFar + minRemainingCost
@@ -138,7 +139,7 @@ internal class AStarPathfinder(
                 Log.debug("#calculateAndQueue ${currentTile.position} queueing ${alreadyCalculatedNode.tile(tileMap).position} because another thread calculated, for $debugMapType $debugId")
             return false
         }
-        if (!moveThroughPredicate(neighborTile)) { // can't move here.
+        if (!passThroughPredicate(neighborTile)) { // can't pass through.
             val noPathingNode = RouteNode.noPathingNode(neighborTile)
             routeNodes[neighborTile.zeroBasedIndex] = noPathingNode.bits
             cache.addedNeighborNodes.set(neighborTile.zeroBasedIndex)
@@ -149,39 +150,49 @@ internal class AStarPathfinder(
         return true
     }
 
-    private fun calculateNeighborNode(currentNode: RouteNode, neighborTile: Tile): RouteNode {
+    private fun calculateNeighborNode(currentNode: RouteNode, neighborTile: Tile): RouteNode? {
         val currentTile = currentNode.tile(tileMap)
         val startingPoint = cache.key.startingPoint
         val damagingTiles = currentNode.damagingTiles
         val cost = cost(currentTile, neighborTile).coerceAtMost(MAX_MOVE_THIS_TURN)
         val newUsedMovement = (currentNode.moveUsedThisTurn + cost).coerceAtMost(MAX_MOVE_THIS_TURN)
         val fullMovement = cache.key.fullMove
+        val canMoveTo = currentNode.turns > 0 || moveToPredicate(neighborTile)
         val endTurnThereDamage = endTurnDamage(neighborTile).coerceAtMost(1)
         val newMountainMovement =
             (if (currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0) cost // first entering mountains
             else if (!currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0) currentNode.pbmMoveThisTurn + cost
             else FPM_ZERO // ignored in this case
                 ).coerceAtMost(MAX_MOVE_THIS_TURN)
-        val canEndTurnOrProbablyMoveAway = endTurnThereDamage == 0 || (newUsedMovement < fullMovement)
+        val passThroughOrSafeEndTurn = (newUsedMovement < fullMovement) || (canMoveTo && endTurnThereDamage == 0)
+        val passThroughOrEndTurn = (newUsedMovement < fullMovement) || canMoveTo
         val relationship = relationshipLevel(neighborTile)
         
         // This can use more than the remaining movement, but that's correct behavior.
         // https://yairm210.medium.com/multi-turn-pathfinding-7136bd0bdaf0
-        if (currentNode.moveUsedThisTurn < fullMovement  && canEndTurnOrProbablyMoveAway) {
+        if (currentNode.moveUsedThisTurn < fullMovement  && passThroughOrSafeEndTurn) {
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} for same turn, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, newMountainMovement, newUsedMovement, currentNode.turns,  currentTile, damagingTiles)
-        } else if (currentNode.endTurnWithoutMoreDamage && canEndTurnOrProbablyMoveAway) {
+            return RouteNode(neighborTile, relationship, newMountainMovement, newUsedMovement, currentNode.turns,  currentTile, canMoveTo, damagingTiles)
+        } else if (currentNode.endTurnWithoutMoreDamage && currentNode.canMoveTo && passThroughOrEndTurn) {
             // We have to move there next turn.
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} for next turn, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, newMountainMovement, cost, currentNode.turns + 1, currentTile, damagingTiles)
+                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} for next turn, for $debugMapType $debugId ($canMoveTo)")
+            return RouteNode(neighborTile, relationship, newMountainMovement, cost, currentNode.turns + 1, currentTile, canMoveTo, damagingTiles)
+        } else if (currentNode.endTurnWithoutMoreDamage && currentNode.canMoveTo && !canMoveTo) {
+            // Cannot end our turn on the next tile, nor pass through it. Possibly because it's occupied by a unit.
+            // Classic #getDistanceToTiles requires we populate the node, so populate it, but do not return it.
+            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
+                Log.debug("#calculateAndQueue ${currentTile.position} stubbing ${neighborTile.position} as occupied, for $debugMapType $debugId (false)")
+            val occupiedNode =  RouteNode(neighborTile, relationship, newMountainMovement, cost, currentNode.turns+1, currentTile, canMoveTo, damagingTiles)
+            routeNodes[neighborTile.zeroBasedIndex] = occupiedNode.bits
+            return null
         } else if (currentNode.pbmMoveThisTurn < fullMovement) {
             // If we could have moved here if we'd paused before entering mountains, then
             // pretend we paused before entering the mountains.
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with retroactive pause before mountains, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, newMountainMovement, newMountainMovement, currentNode.turns + 1, currentTile, damagingTiles)
+                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with retroactive pause before mountains, for $debugMapType $debugId ($canMoveTo)")
+            return RouteNode(neighborTile, relationship, newMountainMovement, newMountainMovement, currentNode.turns + 1, currentTile, canMoveTo, damagingTiles)
         } else {
             // Ending our turn here takes damage. We'll add the neighbor tile, but the damage
             // means it's neighbors will be calculated at a super low priority.
@@ -189,8 +200,8 @@ internal class AStarPathfinder(
             // which is the ONLY scenario where a tile can get recalculated.
             val newDamageTiles = (damagingTiles + endTurnThereDamage).coerceAtMost(MAX_DAMAGING_TILES)
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with taking damage, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, cost, cost, currentNode.turns + 1, currentTile, newDamageTiles)
+                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with taking damage, for $debugMapType $debugId ($canMoveTo)")
+            return RouteNode(neighborTile, relationship, cost, cost, currentNode.turns + 1, currentTile, canMoveTo, newDamageTiles)
         }
     }
 
@@ -202,7 +213,7 @@ internal class AStarPathfinder(
             val currentTile = currentNode.tile(tileMap)
             for (neighborTile in currentTile.neighbors) { // calculate each neighbor               
                 if (!neighborNeedsCalcuating(currentNode, neighborTile)) continue
-                val newNode = calculateNeighborNode(currentNode, neighborTile) // calculate each neighbor
+                val newNode = calculateNeighborNode(currentNode, neighborTile) ?: continue // calculate each neighbor
                 routeNodes[neighborTile.zeroBasedIndex] = newNode.bits
                 if (newNode.turns < timeLimitTurns)
                     todo.add(PrioritizedNode(newNode, calculateUnderestimatedMovement(newNode)).bits)

--- a/core/src/com/unciv/logic/map/PathingMapCache.kt
+++ b/core/src/com/unciv/logic/map/PathingMapCache.kt
@@ -96,6 +96,7 @@ value class RouteNode(val bits: Long=0L) {
         moveThisTurn: FixedPointMovement,
         turns: Int,
         parentTile: Tile,
+        moveTo: Boolean,
         damagingTiles: Int,
     ):
         this(
@@ -105,6 +106,7 @@ value class RouteNode(val bits: Long=0L) {
                 toMoveThisTurnBits(moveThisTurn) or
                 toTurnsBits(turns) or
                 toParentClockDirBits(tile, parentTile) or
+                toMoveToBits(moveTo) or
                 toDamagingTilesBits(damagingTiles)
         ) {
         require(tile.zeroBasedIndex < tile.tileMap.tileList.size) { "tileList ${tile.zeroBasedIndex} exceeds max ${tile.tileMap.tileList.size}" }
@@ -149,6 +151,8 @@ value class RouteNode(val bits: Long=0L) {
         if (idx == NO_PARENT_TILE_VALUE) return tile(tileMap)
         return tileMap.getClockPositionNeighborTile(tile(tileMap), idx)!!
     }
+    
+    val canMoveTo: Boolean get() { require(initialized); return (bits and MOVE_TO_HI_MASK) == MOVE_TO_HI_MASK}
 
     val damagingTiles: Int get() { require(initialized); return ((bits shr DAMAGE_TILES_OFFSET) and DAMAGE_TILES_LO_MASK).toInt() }
 
@@ -203,7 +207,13 @@ value class RouteNode(val bits: Long=0L) {
         private const val PARENT_TILE_LO_MASK = (0x1L shl PARENT_TILE_BIT_COUNT) - 1L
         private const val NO_PARENT_TILE_BITS = 7L
         private const val NO_PARENT_TILE_VALUE = 14
-        // [RouteNode] bits 50-60 (11b) are padding bits, only used by PrioritizedNode's underestimatedTotal field
+        // [RouteNode] bit 50 (1b = 2values) tracks if we can we can "move to" a tile.
+        // Aka either we can path through it, or it contains an enemy.
+        private const val MOVE_TO_OFFSET = PARENT_TILE_OFFSET + PARENT_TILE_BIT_COUNT
+        private const val MOVE_TO_BIT_COUNT = 1
+        private const val MOVE_TO_LO_MASK = (0x1L shl MOVE_TO_BIT_COUNT) - 1L
+        private const val MOVE_TO_HI_MASK = MOVE_TO_LO_MASK shl MOVE_TO_OFFSET
+        // [RouteNode] bits 52-60 (10b) are padding bits, only used by PrioritizedNode's underestimatedTotal field
         // bits 61-62 (2b = 4turns) are the number of turns ended in damaging tiles.
         private const val DAMAGE_TILES_OFFSET = UNDERESTIMATED_TOTAL_OFFSET + UNDERESTIMATED_TOTAL_BIT_COUNT
         private const val DAMAGE_TILES_BIT_COUNT = 2
@@ -214,6 +224,9 @@ value class RouteNode(val bits: Long=0L) {
         @Readonly
         private fun toParentClockDirBits(tile: Tile, parentTile: Tile): Long
             = (if (tile == parentTile) NO_PARENT_TILE_BITS else tile.tileMap.getNeighborTileClockPosition(tile, parentTile)/2L) shl PARENT_TILE_OFFSET
+        @Pure
+        private fun toMoveToBits(canMoveTo: Boolean): Long
+            = if (canMoveTo) MOVE_TO_HI_MASK else 0L
         @Pure
         private fun toMoveThisTurnBits(moveThisTurn: FixedPointMovement): Long
             = moveThisTurn.bits.toLong() shl MOVE_THIS_TURN_OFFSET
@@ -241,6 +254,7 @@ value class RouteNode(val bits: Long=0L) {
             MAX_MOVE_THIS_TURN,
             MAX_TURNS,
             tile,
+            false,
             MAX_DAMAGING_TILES,
         )
         @Pure
@@ -250,8 +264,8 @@ value class RouteNode(val bits: Long=0L) {
             FPM_ZERO,
             moveThisTurn,
             0,
-
             tile,
+            true,
             0,
         )
     }

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -975,10 +975,10 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     fun putInTile(tile: Tile) {
         when {
-            !movement.canMoveTo(tile) ->
-                throw IllegalStateException("Unit $name of ${civ.civID} at $currentTile can't be put in tile $tile," +
-                        " reason: ${movement.getCannotMoveToReason(tile)}")
-
+            !movement.canMoveTo(tile) -> {
+                val currentTile = if (hasTile()) currentTile else null
+                throw IllegalStateException("Unit $name of ${civ.civID} at $currentTile can't be put in tile $tile, reason: ${movement.getCannotMoveToReason(tile)}")
+            }
             baseUnit.movesLikeAirUnits -> tile.airUnits.add(this)
             isCivilian() -> tile.civilianUnit = this
             else -> tile.militaryUnit = this

--- a/tests/src/com/unciv/logic/automation/civilization/NextTurnAutomationTest.kt
+++ b/tests/src/com/unciv/logic/automation/civilization/NextTurnAutomationTest.kt
@@ -2,8 +2,10 @@ package com.unciv.logic.automation.civilization
 
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
-import com.unciv.logic.automation.civilization.NextTurnAutomationTest.Companion.PathfindingAlgorithm.Classic
-import com.unciv.logic.automation.civilization.NextTurnAutomationTest.Companion.PathfindingAlgorithm.AStar
+import com.unciv.logic.map.AStar
+import com.unciv.models.metadata.GameSettings.PathfindingAlgorithm
+import com.unciv.models.metadata.GameSettings.PathfindingAlgorithm.ClassicPathfinding
+import com.unciv.models.metadata.GameSettings.PathfindingAlgorithm.AStarPathfinding
 import com.unciv.testing.GdxTestRunnerFactory
 import com.unciv.testing.TestGame
 import org.junit.Assert.assertEquals
@@ -25,7 +27,7 @@ class NextTurnAutomationTest(private val algorithm: PathfindingAlgorithm) {
 
     @Before
     fun setUp() {
-        UncivGame.Current.settings.useAStarPathfinding = (algorithm == AStar)
+        UncivGame.Current.settings.useAStarPathfinding = (algorithm == AStarPathfinding)
         testGame.makeHexagonalMap(7)
         civInfo = testGame.addCiv()
         val capital = testGame.addCity(civInfo, testGame.tileMap[0,0])
@@ -84,16 +86,11 @@ class NextTurnAutomationTest(private val algorithm: PathfindingAlgorithm) {
     }
 
     companion object {
-        enum class PathfindingAlgorithm {
-            Classic,
-            AStar
-        }
-
         @Suppress("unused")
         @Parameters
         @JvmStatic
         fun parameters(): Collection<Array<Any?>?> {
-            return listOf( arrayOf(Classic), arrayOf(AStar))
+            return listOf( arrayOf(ClassicPathfinding), arrayOf(AStarPathfinding))
         }
     }
 }

--- a/tests/src/com/unciv/logic/map/PathfindingTests.kt
+++ b/tests/src/com/unciv/logic/map/PathfindingTests.kt
@@ -16,9 +16,9 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeThat
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,9 +33,13 @@ class PathfindingTests(
     // parameters come from the Compantion#parameters method
     private val pathfindingAlgorithm: PathfindingAlgorithm,
 ) {
-    private lateinit var originTile: Tile
-    private lateinit var civInfo: Civilization
     private var testGame = TestGame()
+    private lateinit var civInfo: Civilization
+    private lateinit var originTile: Tile
+    private lateinit var barbarianNation: Nation
+    private lateinit var neutralNation: Nation
+    private lateinit var barbarianCiv: Civilization
+    private lateinit var neutralCiv: Civilization
 
     @Before
     fun initTheWorld() {
@@ -45,6 +49,19 @@ class PathfindingTests(
         civInfo = testGame.addCiv()
         for (tile in testGame.tileMap.values)
             tile.setExplored(civInfo, true)
+
+        barbarianNation = Nation().apply { name = Constants.barbarians } // they are always enemies
+        neutralNation = Nation().apply { name = "Huns" }
+        barbarianCiv = Civilization(barbarianNation)
+        neutralCiv = Civilization(neutralNation)
+        testGame.addCiv(barbarianNation)
+        testGame.addCiv(neutralNation)
+        barbarianCiv.gameInfo = testGame.gameInfo
+        neutralCiv.gameInfo = testGame.gameInfo
+        barbarianCiv.cache.updateState()
+        neutralCiv.cache.updateState()
+        barbarianCiv.setTransients()
+        neutralCiv.setTransients()
     }
 
     // These are interesting use-cases because it shows that for the *exact same map* for units with *no special uniques*
@@ -195,69 +212,327 @@ class PathfindingTests(
     }
 
     @Test
-    fun getMovementToTilesAtPosition_returnsRightTiles() {
-        // first, we encircle the moving unit with weird conditions to check which it can move through
-        val barbNation = Nation().apply { name = Constants.barbarians } // they are always enemies
-        val neutrNation = Nation().apply { name = "Huns" }
-        val barbCiv = Civilization(barbNation)
-        val neutrCiv = Civilization(neutrNation)
-        testGame.addCiv(barbNation)
-        testGame.addCiv(neutrNation)
-        barbCiv.gameInfo = testGame.gameInfo
-        neutrCiv.gameInfo = testGame.gameInfo
-        barbCiv.cache.updateState()
-        neutrCiv.cache.updateState()
-        barbCiv.setTransients()
-        neutrCiv.setTransients()
-        val barbCity = barbCiv.addCity(HexCoord(-4,4))
-        val neutrCity = barbCiv.addCity(HexCoord(-4,-4))
-        testGame.gameInfo.civilizations.add(barbCiv)
-        testGame.gameInfo.civilizations.add(neutrCiv)
-                
-        // If a pathing goes to -1,3, then it's going through enemy warriors when it shouldn't
-        testGame.addUnit("Warrior", barbCiv, testGame.tileMap[HexCoord(-2,2)])
-        testGame.addUnit("Warrior", barbCiv, testGame.tileMap[HexCoord(-1,2)])
-        // If a pathing goes to 0,3, then it's going through hills when it shouldn't
-        testGame.setTileFeatures(HexCoord(0, 2), "Hill")
-        testGame.setTileFeatures(HexCoord(1, 2), "Hill")
-        // If a pathing goes to 3,2, then it's going through mountains when it shouldn't
-        testGame.setTileTerrain(HexCoord(2, 2), "Mountain")
-        testGame.setTileTerrain(HexCoord(2, 1), "Mountain")
-        // Classic pathing pathed to 3,0, so apparently AStar should as well
-        testGame.setTileTerrain(HexCoord(2, 0), "Ocean")
-        testGame.setTileTerrain(HexCoord(2, -1), "Ocean")
-        // Classic pathing pathed to -3,0, so apparently AStar should as well
-        testGame.tileMap[HexCoord(-2, 1)].setOwningCity(barbCity)
-        testGame.tileMap[HexCoord(-2, 0)].setOwningCity(barbCity)
-        // If a pathing goes to -3,-2, then it's going through neutral tiles when it shouldn't
-        testGame.tileMap[HexCoord(-2, -1)].setOwningCity(neutrCity)
-        testGame.tileMap[HexCoord(-2, -2)].setOwningCity(neutrCity)
-        // If a pathing goes to -1,-3, then it's going through neutral warriors when it shouldn't
-        testGame.addUnit("Warrior", neutrCiv, testGame.tileMap[HexCoord(-1,-2)])
-        testGame.addUnit("Warrior", neutrCiv, testGame.tileMap[HexCoord(0,-2)])
-        
-        val baseUnit = testGame.createBaseUnit()
-        baseUnit.movement = 3
-        val unit = testGame.addUnit(baseUnit.name, civInfo, originTile)
-        unit.currentMovement = 3f
-
-        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 3f)
-        assertTrue("Classic getMovementToTilesAtPosition includes enemy warriors", paths.containsKey(testGame.tileMap[-1,2]))
-        assertFalse("getMovementToTilesAtPosition should not path beyond enemy warriors", paths.containsKey(testGame.tileMap[-1,3]))
-        if (pathfindingAlgorithm == ClassicPathfinding) // This is a known and accepted difference between classic and AStar pathfinding
-            assertTrue("Classic getMovementToTilesAtPosition includes mountains", paths.containsKey(testGame.tileMap[2,2]))
-        assertFalse("getMovementToTilesAtPosition should not pass beyond mountains", paths.containsKey(testGame.tileMap[3,2]))
-        assertFalse("getMovementToTilesAtPosition should not ignore hill move cost", paths.containsKey(testGame.tileMap[0,3]))
-        assertTrue("Classic getMovementToTilesAtPosition includes Ocean tiles", paths.containsKey(testGame.tileMap[2,0]))
-        assertTrue("Classic getMovementToTilesAtPosition paths beyond Ocean tiles", paths.containsKey(testGame.tileMap[3,0]))
-        assertTrue("Classic getMovementToTilesAtPosition includes Enemy cities", paths.containsKey(testGame.tileMap[-2,0]))
-        assertTrue("Classic getMovementToTilesAtPosition paths beyond Enemy cities", paths.containsKey(testGame.tileMap[-3,0]))
-        assertTrue("Classic getMovementToTilesAtPosition includes Neutral cities", paths.containsKey(testGame.tileMap[-3,-2]))
-        assertTrue("Classic getMovementToTilesAtPosition paths beyond Neutral cities", paths.containsKey(testGame.tileMap[-2,-2]))
-        assertTrue("Classic getMovementToTilesAtPosition includes Neutral warriors", paths.containsKey(testGame.tileMap[-1,-2]))
-        assertTrue("Classic getMovementToTilesAtPosition paths beyond Neutral warriors", paths.containsKey(testGame.tileMap[-1,-3]))
+    fun getMovementToTilesAtPosition_mountains_movesTo() {
+        assumeTrue(pathfindingAlgorithm == ClassicPathfinding) // AStar deliberately does not include mountains
+        verticalWall(1, {tile -> tile.baseTerrain = "Mountain"; tile.setTransients()})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to mountains", paths.containsKey(testGame.tileMap[1,0]))
+        assertFalse("getMovementToTilesAtPosition should not pass through mountains", paths.containsKey(testGame.tileMap[2,0]))
     }
 
+    @Test
+    fun getMovementToTilesAtPosition_ocean_movesTo() {
+        assumeTrue(pathfindingAlgorithm == ClassicPathfinding) // AStar deliberately does not include ocean (that we can't move into)
+        verticalWall(1, {tile -> tile.baseTerrain = "Ocean"; tile.setTransients()})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to ocean", paths.containsKey(testGame.tileMap[1,0]))
+        assertFalse("getMovementToTilesAtPosition should not pass through ocean", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_alliedCivilians_pathsThrough() {
+        verticalWall(1, {tile -> testGame.addUnit("Worker", civInfo, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should path through allied civilians", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_alliedCivilianAtEndOfTurn_doesEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Worker", civInfo, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_neutralCivilians_doesNotPathThrough() {
+        verticalWall(1, {tile -> testGame.addUnit("Worker", neutralCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to neutral civilians", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition passes through neutral civilians", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_neutralCivilianAtEndOfTurn_doesNotEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Worker", neutralCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_enemyCivilians_canMoveTo() {
+        verticalWall(1, {tile -> testGame.addUnit("Worker", barbarianCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to enemy civilians", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition passes through enemy civilians", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_enemyCivilianAtEndOfTurn_doesEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Worker", barbarianCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_alliedMilitary_pathsThrough() {
+        verticalWall(1, {tile -> testGame.addUnit("Warrior", civInfo, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should path through allied military", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_alliedMilitaryAtEndOfTurn_doesNotEndTurnOnMilitary() {
+        verticalWall(2, {tile -> testGame.addUnit("Warrior", civInfo, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_neutralMilitary_doesNotPathThrough() {
+        verticalWall(1, {tile -> testGame.addUnit("Warrior", neutralCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to neutral military", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition passes through neutral military", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_neutralMilitaryAtEndOfTurn_doesNotEndTurnOnMilitary() {
+        verticalWall(2, {tile -> testGame.addUnit("Warrior", neutralCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_enemyMilitary_canMoveTo() {
+        verticalWall(1, {tile -> testGame.addUnit("Warrior", barbarianCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to enemy military", paths.containsKey(testGame.tileMap[1,0]))
+        assertFalse("getMovementToTilesAtPosition should not pass through enemy military", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_enemyMilitaryAtEndOfTurn_cannotPathThrough() {
+        verticalWall(2, {tile -> testGame.addUnit("Warrior", barbarianCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf<Tile>(), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_alliedCity_pathsThrough() {
+        verticalWall(2, {tile -> testGame.addCity(civInfo, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should path through allied tiles", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("getMovementToTilesAtPosition should path through allied cities", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_alliedCityAtEndOfTurn_doesEndTurnOnCity() {
+        verticalWall(2, {tile -> testGame.addCity(civInfo, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_neutralCity_doesNotPathThrough() {
+        verticalWall(2, {tile -> testGame.addCity(neutralCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should path through neutral tiles", paths.containsKey(testGame.tileMap[1,0]))
+        assertFalse("getMovementToTilesAtPosition should not move to neutral cities", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_neutralCityAtEndOfTurn_cannotPathThrough() {
+        verticalWall(2, {tile -> testGame.addCity(neutralCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf<Tile>(), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_military_enemyCity_canMoveTo() {
+        verticalWall(2, {tile -> testGame.addCity(barbarianCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should path through enemy tiles", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("getMovementToTilesAtPosition should move to enemy cities", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_military_enemyCityAtEndOfTurn_cannotPathThrough() {
+        verticalWall(2, {tile -> testGame.addCity(barbarianCiv, tile)})
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf<Tile>(), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_alliedCivilians_pathsThrough() {
+        verticalWall(2, {tile -> testGame.addUnit("Worker", civInfo, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should path through allied civilians", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_alliedCivilivanAtEndOfTurn_doesNotEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Worker", civInfo, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_neutralCivilians_doesNotPathThrough() {
+        verticalWall(1, {tile -> testGame.addUnit("Worker", neutralCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to neutral civilians", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition passes through neutral civilians", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_neutralCivilivanAtEndOfTurn_doesNotEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Worker", neutralCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_enemyCivilians_canMoveTo() {
+        verticalWall(1, {tile -> testGame.addUnit("Worker", barbarianCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to enemy civilians", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition passes through enemy civilians", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_enemyCivilivanAtEndOfTurn_doesNotEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Worker", barbarianCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_alliedMilitary_pathsThrough() {
+        verticalWall(1, {tile -> testGame.addUnit("Worker", civInfo, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should path through allied military", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_alliedMilitaryAtEndOfTurn_doesEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Warrior", civInfo, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_neutralMilitary_doesNotPathThrough() {
+        verticalWall(1, {tile -> testGame.addUnit("Warrior", neutralCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to neutral military", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition passes through neutral military", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_neutralMilitaryAtEndOfTurn_doesNotEndTurnOnCivilian() {
+        verticalWall(2, {tile -> testGame.addUnit("Warrior", neutralCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civlian_enemyMilitary_canMoveTo() {
+        verticalWall(1, {tile -> testGame.addUnit("Warrior", neutralCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to enemy military", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition passes through enemy military", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_enemyMilitaryAtEndOfTurn_cannotPathThrough() {
+        verticalWall(2, {tile -> testGame.addUnit("Warrior", barbarianCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf<Tile>(), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_alliedCity_pathsThrough() {
+        verticalWall(2, {tile -> testGame.addCity(civInfo, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should move to allied tiles", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("getMovementToTilesAtPosition should move to allied cities", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_alliedCityAtEndOfTurn_doesEndTurnOnCity() {
+        verticalWall(2, {tile -> testGame.addCity(civInfo, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_neutralCity_doesNotPathThrough() {
+        verticalWall(2, {tile -> testGame.addCity(neutralCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should pass through neutral cities", paths.containsKey(testGame.tileMap[1,0]))
+        assertFalse("getMovementToTilesAtPosition should not move to neutral cities", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_neutralCityAtEndOfTurn_cannotPathThrough() {
+        verticalWall(2, {tile -> testGame.addCity(neutralCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf<Tile>(), paths)
+    }
+
+    @Test
+    fun getMovementToTilesAtPosition_civilian_enemyCity_canMoveTo() {
+        verticalWall(2, {tile -> testGame.addCity(barbarianCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getMovementToTilesAtPosition(originTile.position, 2f)
+        assertTrue("getMovementToTilesAtPosition should pass through enemy cities", paths.containsKey(testGame.tileMap[1,0]))
+        assertTrue("Classic getMovementToTilesAtPosition moves to enemy cities", paths.containsKey(testGame.tileMap[2,0]))
+    }
+
+    @Test
+    fun getShortestPath_civilian_enemyCityAtEndOfTurn_cannotPathThrough() {
+        verticalWall(2, {tile -> testGame.addCity(barbarianCiv, tile)})
+        val unit = testGame.addUnit("Worker", civInfo, originTile)
+        val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
+        assertEquals(listOf<Tile>(), paths)
+    }
+    
     @Test
     fun getMovementToTilesAtPosition_withFractionalMovementGreaterThanOne_ReturnsRightTiles() {
         testGame.setTileTerrain(HexCoord(0, 1), "Hill")
@@ -446,6 +721,13 @@ class PathfindingTests(
         // make sure the path changed
         assertEquals(path2.toString(), 2, path1.size)
         assertEquals(path1[0], path2[0])
+    }
+    
+    private fun verticalWall(x: Int, apply: (Tile)->Unit) {
+        for (tile in testGame.tileMap.tileList) {
+            if (tile.position.x == x)
+                apply(tile)
+        }
     }
     
     companion object {

--- a/tests/src/com/unciv/logic/map/PathingMapTest.kt
+++ b/tests/src/com/unciv/logic/map/PathingMapTest.kt
@@ -51,7 +51,7 @@ class PathingMapTest {
         val parentTile = testGame.tileMap.getClockPositionNeighborTile(tile, 12)!!
         val damagingTiles = 3
         val underestimatedTotal = fpmFromFixedPointBits((1 shl 13) or 1) //15 bits. value is 8193 aka 409.65move
-        
+        val canMoveTo = true       
 
         val node = RouteNode(
             tile,
@@ -60,6 +60,7 @@ class PathingMapTest {
             moveThisTurn,
             turns,
             parentTile,
+            canMoveTo,
             damagingTiles
         )
 
@@ -67,6 +68,7 @@ class PathingMapTest {
         assertEquals(tile, node.tile(testGame.tileMap))
         assertEquals(12, node.parentClockDir)
         assertEquals(parentTile, node.parentTile(testGame.tileMap))
+        assertEquals(true, node.canMoveTo)
         assertEquals(moveThisTurn, node.moveUsedThisTurn)
         assertEquals(pbmMoveThisTurn, node.pbmMoveThisTurn)
         assertEquals(turns, node.turns)

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -352,8 +352,18 @@ class UnitMovementTests(
         assertEquals(warrior2, settler2.getOtherEscortUnit())
         settler1.currentMovement = 0f
 
+        assertFalse(warrior1.movement.canReachInCurrentTurn(testGame.tileMap[2,2]))
+        assertTrue(warrior2.movement.canReachInCurrentTurn(testGame.tileMap[1,1]))
+        assertFalse(settler1.movement.canReachInCurrentTurn(testGame.tileMap[2,2]))
+        assertTrue(settler2.movement.canReachInCurrentTurn(testGame.tileMap[1,1]))
+        assertTrue(warrior1.movement.canMoveTo(testGame.tileMap[2,2], allowSwap = true))
+        assertTrue(warrior2.movement.canMoveTo(testGame.tileMap[1,1], allowSwap = true))
+        assertTrue(settler1.movement.canMoveTo(testGame.tileMap[2,2], allowSwap = true))
+        assertTrue(settler2.movement.canMoveTo(testGame.tileMap[1,1], allowSwap = true))
         assertFalse(warrior1.movement.canUnitSwapTo(testGame.tileMap[2,2]))
         assertFalse(warrior2.movement.canUnitSwapTo(testGame.tileMap[1,1]))
+        assertFalse(settler1.movement.canUnitSwapTo(testGame.tileMap[2,2]))
+        assertFalse(settler2.movement.canUnitSwapTo(testGame.tileMap[1,1]))
 
         warrior1.movement.swapMoveToTile(testGame.tileMap[2,2])
 


### PR DESCRIPTION
PathingMap now takes separate passThroughPredicate and moveToPredicate. Tiles where passThroughPredicate are false are still marked as noPathingNode, but tiles with moveToPredicate false on turn=0 are moved to on the next turn instead of this turn, and marked with a new canMoveTo=false bit. Moving on the next turn fixes bugs where units tried to path into the same tiles as each other, and failing. They now either go around, or pause right before and then go over.

#getTilesSameTurn now includes these canMoveTo=false tiles, so they're included in getMovementToTilesAtPosition, just like Classic pathing. This fixes the bugs where units couldn't attack or move to enemies, couldn't swap with allies.

Added significantly more test coverage around these weird edge cases.

This is a much more complete fix of https://github.com/yairm210/Unciv/issues/14607.