### PR TITLE
flat earth hexigonal no longer crashes

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -112,7 +112,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
 
         fun maybeSnow() = terrain.type == TerrainType.Land 
             && tempFrom <= -1 && tempTo <= -.5 
-            && humidFrom >= 0.2 && humidTo >= 1 
+            && humidFrom >= -.1 && humidTo >= 1 
             && !rareFeature
 
         override fun toString(): String {
@@ -741,8 +741,9 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             if (!ice.matchesTempAndTerrain(tile, -1.0)) {
                 val fallbackBase = oceanTerrains.filter { ice.terrain.occursOn.contains (it.name) }
                     .ifEmpty { oceanTerrains.filter {it.isOcean} }
-                    .random(randomness.RNG)
-                tile.baseTerrain = fallbackBase.name          
+                    .randomOrNull(randomness.RNG)
+                if (fallbackBase != null)
+                    tile.baseTerrain = fallbackBase.name          
             }
             tile.removeTerrainFeatures()
             tile.addTerrainFeature(ice.terrain.name)


### PR DESCRIPTION
#maybeSnow now includes humidities down to -.1, so it now matches the default snows correctly.  Also, spawnFlatEarthIceWalls now includes all snow terrains, not just the first, which is more flexible, but also means it doesn't crash if there's no snow terrains.
Fixed https://github.com/yairm210/Unciv/issues/14661 

Also, spawnBestIce no longer requires a matching terrain, and just silently ignores if there's no matching base terrain.

Manually tested mapgen, but I didn't make automated tests yet since this is a production crash.

Signed-off-by: MPD <mooing_psycho_duck@hotmail.com>