### PR TITLE
Fix unavailable unique being ignored in unexpected places

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -491,7 +491,8 @@ object ReligionAutomation {
                     && !additionalBeliefsToExclude.contains(it)
                     && civInfo.religionManager.getReligionWithBelief(it) == null
                     && it.getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals)
-                    .none { unique -> !unique.conditionalsApply(civInfo.state) }
+                        .none { unique -> !unique.conditionalsApply(civInfo.state) }
+                    && it.getMatchingUniques(UniqueType.Unavailable, civInfo.state).none()
             }
             .maxByOrNull { rateBelief(civInfo, it) }
     }

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -249,8 +249,12 @@ object UnitAutomation {
                 return true
             if (unit.civ.isBarbarian && baseUnit.hasUnique(UniqueType.CannotBeBarbarian))
                 return true
-            return baseUnit.getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals)
-                .any { !it.conditionalsApply(unit.cache.state) }
+            if (baseUnit.getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals)
+                    .any { !it.conditionalsApply(unit.cache.state) })
+                return true
+            if (baseUnit.getMatchingUniques(UniqueType.Unavailable, unit.cache.state).any())
+                return true
+            return false
         }
 
         return unit.baseUnit.getRulesetUpgradeUnits(unit.cache.state)

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -207,6 +207,10 @@ interface IHasUniques : INamed {
             if (unique.hasModifier(enabler)) return !hasFeature
             if (unique.hasModifier(disabler)) return hasFeature
         }
+        for (unique in getMatchingUniques(UniqueType.Unavailable, GameContext.IgnoreConditionals)) {
+            if (unique.hasModifier(enabler)) return hasFeature
+            if (unique.hasModifier(disabler)) return !hasFeature
+        }
         return false
     }
 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -325,7 +325,7 @@ enum class UniqueType(
         docDescription = "Meant to be used together with conditionals, like \"Only available <after adopting [policy]> <while the empire is happy>\". Only allows Building when ALL conditionals are met. Will also block Upgrade and Transform actions. See also CanOnlyBeBuiltWhen"),
     Unavailable("Unavailable", UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Improvement,
         UniqueTarget.Policy, UniqueTarget.Tech, UniqueTarget.Promotion, UniqueTarget.Ruins,
-        UniqueTarget.Event, UniqueTarget.EventChoice,
+        UniqueTarget.FollowerBelief, UniqueTarget.FounderBelief, UniqueTarget.Event, UniqueTarget.EventChoice,
         docDescription = "Meant to be used together with conditionals, like \"Unavailable <after generating a Great Prophet>\"."),
 
     ConvertFoodToProductionWhenConstructed("Excess Food converted to Production when under construction", UniqueTarget.Building, UniqueTarget.Unit),

--- a/core/src/com/unciv/ui/screens/pickerscreens/PantheonPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PantheonPickerScreen.kt
@@ -19,9 +19,7 @@ class PantheonPickerScreen(
         for (belief in ruleset.beliefs.values) {
             if (belief.type != BeliefType.Pantheon) continue
             val beliefButton = getBeliefButton(belief, withTypeLabel = false)
-            if (choosingCiv.religionManager.getReligionWithBelief(belief) == null
-                && belief.getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals)
-                    .none { !it.conditionalsApply(choosingCiv.state) }) {
+            if (choosingCiv.religionManager.getReligionWithBelief(belief) == null && beliefIsAllowed(belief, choosingCiv)) {
                 beliefButton.onClickSelect(selection, belief) {
                     selectedPantheon = belief
                     pick("Follow [${belief.name}]".tr())
@@ -35,5 +33,13 @@ class PantheonPickerScreen(
         setOKAction("Choose a pantheon") {
             chooseBeliefs(listOf(selectedPantheon!!), useFreeBeliefs = usingFreeBeliefs())
         }
+    }
+    fun beliefIsAllowed(belief: Belief, choosingCiv: Civilization): Boolean {
+        if (belief.getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals)
+                .any { !it.conditionalsApply(choosingCiv.state) })
+            return false
+        if (belief.getMatchingUniques(UniqueType.Unavailable, choosingCiv.state).any())
+            return false
+        return true
     }
 }

--- a/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
@@ -224,6 +224,9 @@ class ReligiousBeliefsPickerScreen (
                     .any { !it.conditionalsApply(choosingCiv.state) } ->
                     // The Belief is blocked
                     beliefButton.disable(redDisableColor)
+                belief.getMatchingUniques(UniqueType.Unavailable, choosingCiv.state).any() ->
+                    // The Belief is blocked
+                    beliefButton.disable(redDisableColor)
 
                 else ->
                     beliefButton.onClickSelect(rightSelection, belief) {

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -412,8 +412,11 @@ class TechPickerScreen(
 
         val pathToTech = civTech.getRequiredTechsToDestination(tech)
         for (requiredTech in pathToTech) {
-            for (unique in requiredTech.uniqueObjects
-                .filter { it.type == UniqueType.OnlyAvailable && !it.conditionalsApply(civInfo.state) }) {
+            val unavailableUniques = requiredTech.uniqueObjects.filter {
+                it.type == UniqueType.OnlyAvailable && !it.conditionalsApply(civInfo.state) ||
+                    it.type == UniqueType.Unavailable && it.conditionalsApply(civInfo.state)
+            }
+            for (unique in unavailableUniques) {
                 rightSideButton.setText(unique.getDisplayText().tr())
                 rightSideButton.disable()
                 return

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -412,6 +412,10 @@ object UnitActionsFromUniques {
                 ).any { !it.conditionalsApply(stateForConditionals) }
             ) continue
 
+            // Respect Unavailable criteria
+            if (unitToTransformTo.getMatchingUniques(UniqueType.Unavailable, stateForConditionals).any())
+                continue
+
             // Check _new_ resource requirements
             // Using Counter to aggregate is a bit exaggerated, but - respect the mad modder.
             val resourceRequirementsDelta = Counter<String>()


### PR DESCRIPTION
Ran into this by accident while adding the unique to beliefs. Surprised this is a thing

Note: ``Only Available`` typically gets special treatment in object texts while ``Unavailable`` does not. I lazily decided not to fix that (although there's an argument that maybe I should). I really only targeted mechanical differences here