### PR TITLE
Fix embassy trade logic bug

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -356,10 +356,12 @@ class TradeEvaluation {
         when (offer.type) {
             TradeOfferType.Embassy -> {
                 val tradePartnerDiplo = civInfo.getDiplomacyManager(tradePartner)!!
-                if (tradePartnerDiplo.isRelationshipLevelLE(RelationshipLevel.Enemy)) return Int.MIN_VALUE
-                else if (tradePartnerDiplo.isRelationshipLevelLE(RelationshipLevel.Competitor))
-                    return (60 * civInfo.gameInfo.speed.goldCostModifier).toInt()
-                return (30 * civInfo.gameInfo.speed.goldCostModifier).toInt() // 30 is Civ V default (on standard only?)
+                val baseSellCost = when {
+                    tradePartnerDiplo.isRelationshipLevelLE(RelationshipLevel.Enemy) -> 300 // arbitrarily chosen
+                    tradePartnerDiplo.isRelationshipLevelLE(RelationshipLevel.Competitor) -> 60
+                    else -> 30 // 30 is Civ V default (on standard only?)
+                }
+                return (baseSellCost * civInfo.gameInfo.speed.goldCostModifier).toInt()
             }
             TradeOfferType.Gold -> return offer.amount
             TradeOfferType.Gold_Per_Turn -> return offer.amount * offer.duration * 4/5


### PR DESCRIPTION
AI always offers to establish mutual embassies with 30% chance (suggest changing because not seeded + should maybe consider trade value).
When relationship was <= Enemy, AI incorrectly placed a deeply negative value on allowing the other party to establish an embassy, therefore considering it a tremendous gift when you accepted their seemingly balanced offer.


Changed the value from `Int.MIN_VALUE` to `300`.

Before:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/806eab64-af50-4aad-9c98-1e5de259fe7f" />

After:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/9da7a2cc-d07c-4d26-ad35-cbc56dc5ff8e" />
