### PR TITLE
Timers can analyze performance of specified spans

### DIFF
--- a/android/src/com/unciv/app/AndroidGame.kt
+++ b/android/src/com/unciv/app/AndroidGame.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Intent
 import android.graphics.Rect
 import android.net.Uri
+import android.os.Build
+import android.os.Debug
 import android.view.View
 import android.view.ViewTreeObserver
 import com.badlogic.gdx.Gdx
@@ -79,4 +81,7 @@ class AndroidGame(private val activity: Activity) : UncivGame() {
     }
 
     fun isInitializedProxy() = super.isInitialized
+
+    override fun getGcCount(): Int = 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) Debug.getRuntimeStat("art.gc.gc-count").toInt() else 0
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,8 @@ allprojects {
             "com.badlogic.gdx.files.FileHandle.isFile",
             "com.badlogic.gdx.files.FileHandle.name",
 
+            "com.badlogic.gdx.utils.IntArray.get",
+
             "java.util.stream.StreamSupport.longStream",
             "java.util.stream.LongStream.parallel",
             "kotlin.sequences.shuffled",

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -37,6 +37,7 @@ import com.unciv.utils.*
 import kotlinx.coroutines.CancellationException
 import yairm210.purity.annotations.Readonly
 import java.io.PrintWriter
+import java.lang.management.ManagementFactory
 import java.util.*
 import kotlin.collections.ArrayDeque
 import kotlin.collections.asSequence
@@ -463,6 +464,8 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         pushScreen(mainMenuScreen)
         return mainMenuScreen
     }
+
+    override fun getGcCount(): Int = ManagementFactory.getGarbageCollectorMXBeans().sumOf { it.collectionCount }.toInt()
 
     companion object {
         //region AUTOMATICALLY GENERATED VERSION DATA - DO NOT CHANGE THIS REGION, INCLUDING THIS COMMENT

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.BackwardCompatibility.guaranteeUnitPromotions
 import com.unciv.logic.BackwardCompatibility.migrateGreatGeneralPools
 import com.unciv.logic.BackwardCompatibility.migrateToTileHistory
 import com.unciv.logic.BackwardCompatibility.removeMissingModReferences
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.automation.civilization.BarbarianManager
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.*
@@ -341,8 +342,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
      *  @param progressBar Optional reference to UI widget either provided by [WorldScreen.nextTurn][com.unciv.ui.screens.worldscreen.WorldScreen.nextTurn] or `null` when simulating
      *  @param shouldGainTime on a multiplayer game, if true, makes the player who's turn is ended recover time to play before risking to get forced to resign, 'false' by default 
      */
-    fun nextTurn(progressBar: NextTurnProgress? = null, shouldGainTime: Boolean = false) {
-
+    fun nextTurn(progressBar: NextTurnProgress? = null, shouldGainTime: Boolean = false) = timeThis("GameInfo.nextTurn") {
         var player = currentPlayerCiv
         var playerIndex = civilizations.indexOf(player)
 
@@ -661,7 +661,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
     // All cross-game data which needs to be altered (e.g. when removing or changing a name of a building/tech)
     // will be done here, and not in Civilization.setTransients or City
-    fun setTransients() {
+    fun setTransients()  {
         tileMap.gameInfo = this
 
         // [TEMPORARY] Convert old saves to newer ones by moving base rulesets from the mod list to the base ruleset field
@@ -772,7 +772,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         combinedGlobalUniques = GlobalUniques.combine(ruleset.globalUniques, speed, difficultyObject)
     }
 
-    private fun updateCivilizationState() {
+    private fun updateCivilizationState() = timeThis("GameInfo.updateCivilizationState") {
         for (civInfo in civilizations.asSequence()
             // update city-state resource first since the happiness of major civ depends on it.
             // See issue: https://github.com/yairm210/Unciv/issues/7781

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.automation
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityFocus
 import com.unciv.logic.city.CityStats
@@ -71,7 +72,8 @@ object Automation {
     }
 
     @Readonly
-    fun rankStatsForCityWork(stats: Stats, city: City, areWeRankingSpecialist: Boolean, localUniqueCache: LocalUniqueCache): Float {
+    fun rankStatsForCityWork(stats: Stats, city: City, areWeRankingSpecialist: Boolean, localUniqueCache: LocalUniqueCache): Float
+        = timeThis("Automation.rankStatsForCityWork") {
         val cityAIFocus = city.getCityFocus()
         @LocalState val yieldStats = stats.clone()
         val cityStatsObj = city.cityStats

--- a/core/src/com/unciv/logic/automation/Timers.kt
+++ b/core/src/com/unciv/logic/automation/Timers.kt
@@ -1,0 +1,109 @@
+package com.unciv.logic.automation
+
+import com.unciv.UncivGame
+import com.unciv.utils.Log
+import com.badlogic.gdx.utils.IntArray as GdxIntArray
+import com.unciv.utils.fold
+import yairm210.purity.annotations.Pure
+import yairm210.purity.annotations.Readonly
+import kotlin.math.sqrt
+import kotlin.time.TimeSource.Monotonic.markNow
+
+class Timers {
+    val spanTimesInMicroseconds = HashMap<String, GdxIntArray>()
+    var timingEnabledTimestamp = NO_TIME_POINT
+    var startGcCount = 0
+
+    @Pure
+    @Suppress("purity")
+    fun startTiming() {
+        if (!Log.shouldLog()) return
+        synchronized (spanTimesInMicroseconds) {
+            for (times in spanTimesInMicroseconds.values)
+                times.clear()
+        }
+        startGcCount = UncivGame.Current?.getGcCount() ?: 0
+        timingEnabledTimestamp = markNow()
+    }
+
+    @Readonly
+    @Suppress("purity")
+    fun endTiming() {
+        if (timingEnabledTimestamp == TIMING_DISABLED) return
+        val automationEndTime = markNow()
+        val totalTimingDuration = (automationEndTime - timingEnabledTimestamp).inWholeMicroseconds
+        synchronized(spanTimesInMicroseconds) {
+            if (spanTimesInMicroseconds.isEmpty()) return
+            val gcCount = (UncivGame.Current?.getGcCount() ?: 0) - startGcCount
+            val gcCountPerTurn = gcCount.toDouble() / (spanTimesInMicroseconds["GameInfo.nextTurn"]?.size ?: 1)
+            Log.debug("Timing took $totalTimingDuration, with $gcCountPerTurn GCs per turn on average")
+            Log.debug("Span Timing:\tname\tcount\tmean\t95CiMin\t95CiMax\tsum\tpercent\tstddev\tstderr\tvariance\tmin\tp50\tp90\tp95\tp99\tmax")
+            val order = spanTimesInMicroseconds.keys.sorted()
+            for (name in order) {
+                val times = spanTimesInMicroseconds[name]!!
+                synchronized(times) {
+                    if (times.isEmpty) continue
+                    times.sort()
+                    val sqrtCount = sqrt(times.size.toDouble())
+                    // Long can sum up to 584,000 years as microseconds, so no risk of overflow
+                    val sum = times.fold(0L, Long::plus)
+                    val percent = sum.toDouble() / totalTimingDuration
+                    val avg = sum.toDouble() / times.size
+                    val sumOfSquaredDifferences = times.fold(0.0) { acc, value ->
+                        val deltaMean = value - avg
+                        acc + deltaMean * deltaMean
+                    }
+                    val variance = sumOfSquaredDifferences / times.size
+                    val stdDev = sqrt(variance)
+                    val stdErrMean = stdDev / sqrtCount;
+                    val confidence95 = 1.96 * stdDev / sqrtCount;
+                    val min = times[0]
+                    val p50 = interpolate(times, 0.50)
+                    val p90 = interpolate(times, 0.90)
+                    val p95 = interpolate(times, 0.95)
+                    val p99 = interpolate(times, 0.99)
+                    val max = times[times.size - 1]
+                    Log.debug("Span Timing(µs):\t$name\t${times.size}\t$avg\t${avg - confidence95}\t${avg + confidence95}\t$sum\t$percent\t$stdDev\t$stdErrMean\t$variance\t$min\t$p50\t$p90\t$p95\t$p99\t$max")
+                }
+            }
+            timingEnabledTimestamp = TIMING_DISABLED
+        }
+    }
+
+    @Readonly
+    private fun interpolate(times: GdxIntArray, percentile: Double): Double {
+        val percentileIdxDbl = percentile * times.size 
+        val percentileInterpolationPercent = percentileIdxDbl.rem(1.0)
+        val leftIdx = percentileIdxDbl.toInt()
+        if (leftIdx >= times.size - 1) return times[times.size - 1].toDouble()
+        val interpolation = (times[leftIdx + 1] - times[leftIdx]) * percentileInterpolationPercent
+        return times[leftIdx] + interpolation        
+    }
+
+    @Pure
+    @Suppress("purity")
+    inline fun <T> timeThis(name:String, block: ()->T): T {
+        val times = if (timingEnabledTimestamp == TIMING_DISABLED) NO_TIME_DATA
+            else synchronized (spanTimesInMicroseconds) { spanTimesInMicroseconds.getOrPut(name) { GdxIntArray(1024) } }
+        val spanStartTime = if (timingEnabledTimestamp == TIMING_DISABLED) NO_TIME_POINT else markNow() // occurs outside of synchronized block
+        val r = block()
+        if (timingEnabledTimestamp != TIMING_DISABLED) {
+            val endTime = markNow() // occurs outside of synchronized block
+            // up to 35 minutes per span
+            synchronized(times) { times.add((endTime - spanStartTime).inWholeMicroseconds.toInt()) }
+        }
+        return r
+    }
+        
+    companion object {
+        val NO_TIME_POINT = markNow()
+        val TIMING_DISABLED = NO_TIME_POINT
+        val NO_TIME_DATA = GdxIntArray(0)
+        val NO_SPAN = AutoCloseable { }
+        
+        val singleton = Timers()
+
+        @Pure
+        inline fun <T> timeThis(name:String, block: ()->T) = singleton.timeThis(name, block) 
+    }
+}

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -29,6 +29,7 @@ import com.unciv.ui.screens.victoryscreen.RankingType
 import yairm210.purity.annotations.Readonly
 import kotlin.math.max
 import kotlin.math.sqrt
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 class ConstructionAutomation(val cityConstructions: CityConstructions) {
 
@@ -113,7 +114,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
     }
 
 
-    fun chooseNextConstruction() {
+    fun chooseNextConstruction() = timeThis("ConstructionAutomation.chooseNextConstruction") {
         if (cityConstructions.getCurrentConstruction() !is PerpetualConstruction) return  // don't want to be stuck on these forever
         
         addBuildingChoices()

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -3,6 +3,7 @@ package com.unciv.logic.automation.civilization
 import com.unciv.UncivGame
 import com.unciv.logic.automation.Automation
 import com.unciv.logic.automation.ThreatLevel
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.automation.unit.CivilianUnitAutomation
 import com.unciv.logic.automation.unit.EspionageAutomation
 import com.unciv.logic.automation.unit.UnitAutomation
@@ -38,7 +39,7 @@ object NextTurnAutomation {
     /** Top-level AI turn task list */
     fun automateCivMoves(civInfo: Civilization,
                          /** set false for 'forced' automation, such as skip turn */
-                         tradeAndChangeState: Boolean = true) {
+                         tradeAndChangeState: Boolean = true) = timeThis("automateCivMoves") {
         if (civInfo.isBarbarian) return BarbarianAutomation(civInfo).automate()
         if (civInfo.isSpectator()) return // When there's a spectator in multiplayer games, it's processed automatically, but shouldn't be able to actually do anything
 

--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -12,6 +12,7 @@ import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionModifiers
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionModifiers.canUse
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import yairm210.purity.annotations.Readonly
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 object CivilianUnitAutomation {
 
@@ -21,7 +22,7 @@ object CivilianUnitAutomation {
         && !unit.hasUnique(UniqueType.AddInCapital)
         && unit.civ.units.getCivUnits().any { unit.hasUnique(UniqueType.AddInCapital) }
 
-    fun automateCivilianUnit(unit: MapUnit, dangerousTiles: HashSet<Tile>) {
+    fun automateCivilianUnit(unit: MapUnit, dangerousTiles: HashSet<Tile>) = timeThis<Unit>("automateCivilianUnit") {
         // To allow "found city" actions that can only trigger a limited number of times
         
         // Slightly modified getUsableUnitActionUniques() to allow for settlers with *conditional* settling uniques

--- a/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.automation.unit
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.battle.BattleDamage
 import com.unciv.logic.battle.CityCombatant
@@ -13,7 +14,7 @@ import yairm210.purity.annotations.Readonly
 object HeadTowardsEnemyCityAutomation {
 
     /** @returns whether the unit has taken this action */
-    fun tryHeadTowardsEnemyCity(unit: MapUnit): Boolean {
+    fun tryHeadTowardsEnemyCity(unit: MapUnit): Boolean = timeThis("tryHeadTowardsEnemyCity") {
         if (unit.civ.cities.isEmpty()) return false
 
         // only focus on *attacking* 1 enemy at a time otherwise you'll lose on both fronts

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -24,13 +24,14 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsPillage
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsUpgrade
 import yairm210.purity.annotations.Readonly
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 object UnitAutomation {
 
     private const val CLOSE_ENEMY_TILES_AWAY_LIMIT = 5
     private const val CLOSE_ENEMY_TURNS_AWAY_LIMIT = 3f
 
-    fun automateUnitMoves(unit: MapUnit) {
+    fun automateUnitMoves(unit: MapUnit) = timeThis("automateUnitMoves") {
         check(!unit.civ.isBarbarian) { "Barbarians is not allowed here." }
 
         // Might die next turn - move!
@@ -127,7 +128,7 @@ object UnitAutomation {
                 && unit.movement.canReach(tile) // expensive, evaluate last
     }
 
-    internal fun tryExplore(unit: MapUnit): Boolean {
+    internal fun tryExplore(unit: MapUnit): Boolean = timeThis("tryExplore") {
         if (tryGoToRuin(unit) && (!unit.hasMovement() || unit.isDestroyed)) return true
 
         val unitVisibilityRange = unit.getVisibilityRange()

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -24,6 +24,7 @@ import com.unciv.utils.debug
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 /**
  * Contains the logic for worker automation.
@@ -71,7 +72,8 @@ class WorkerAutomation(
     /**
      * Automate one Worker - decide what to do and where, move, start or continue work.
      */
-    fun automateWorkerAction(unit: MapUnit, dangerousTiles: HashSet<Tile>, localUniqueCache: LocalUniqueCache = LocalUniqueCache()) {
+    fun automateWorkerAction(unit: MapUnit, dangerousTiles: HashSet<Tile>, localUniqueCache: LocalUniqueCache = LocalUniqueCache())
+        = timeThis<Unit>("automateWorkerAction") {
         val currentTile = unit.getTile()
         // Must be called before any getPriority checks to guarantee the local road cache is processed
         val citiesToConnect = roadBetweenCitiesAutomation.getNearbyCitiesToConnect(unit)
@@ -113,7 +115,7 @@ class WorkerAutomation(
         unit: MapUnit,
         localUniqueCache: LocalUniqueCache,
         currentTile: Tile
-    ): Boolean {
+    ): Boolean = timeThis("WorkerAutomation.tryHeadTowardsUndevelopedCity") {
         // Note, however, that the closest city to a tile isn't necessarily the owning city
         val closestUndevelopedCity = unit.civ.cities
             .sortedBy { it.getCenterTile().aerialDistanceTo(currentTile) }
@@ -193,7 +195,7 @@ class WorkerAutomation(
      * @return Null if no tile to work was found
      */
     @Readonly
-    private fun findTileToWork(unit: MapUnit, tilesToAvoid: Set<Tile>, localUniqueCache: LocalUniqueCache): Tile? {
+    private fun findTileToWork(unit: MapUnit, tilesToAvoid: Set<Tile>, localUniqueCache: LocalUniqueCache): Tile? = timeThis("findTileToWork") {
         val currentTile = unit.getTile()
         
         if (isAutomationWorkableTile(currentTile, tilesToAvoid, currentTile, unit)
@@ -291,7 +293,7 @@ class WorkerAutomation(
      * Calculates the priority building the improvement on the tile
      */
     @Readonly
-    private fun getImprovementPriority(tile: Tile, unit: MapUnit, localUniqueCache: LocalUniqueCache): Float {
+    private fun getImprovementPriority(tile: Tile, unit: MapUnit, localUniqueCache: LocalUniqueCache): Float = timeThis("getImprovementPriority") {
         getBasePriority(tile, unit)
         @LocalState val rank = tileRankings[tile]
         if (rank!!.improvementPriority == null) {
@@ -341,7 +343,7 @@ class WorkerAutomation(
      * Returns the best improvement
      */
     @Readonly
-    private fun tileHasWorkToDo(tile: Tile, unit: MapUnit, localUniqueCache: LocalUniqueCache): Boolean {
+    private fun tileHasWorkToDo(tile: Tile, unit: MapUnit, localUniqueCache: LocalUniqueCache): Boolean = timeThis("tileHasWorkToDo") {
         if (getImprovementPriority(tile, unit, localUniqueCache) <= 0) return false
         if (!(tileRankings[tile]!!.bestImprovement != null || tileRankings[tile]!!.repairImprovment!!))
             throw IllegalStateException("There was an improvementPriority > 0 and nothing to do")
@@ -353,7 +355,11 @@ class WorkerAutomation(
      * Returns null if none is worth it
      * */
     @Readonly
-    private fun chooseImprovement(unit: MapUnit, tile: Tile, localUniqueCache: LocalUniqueCache, ignoreImprovements: Sequence<TileImprovement> = NO_IGNORED_IMPROVEMENTS): TileImprovement? {
+    private fun chooseImprovement(unit: MapUnit, 
+          tile: Tile, 
+          localUniqueCache: LocalUniqueCache, 
+          ignoreImprovements: Sequence<TileImprovement> = NO_IGNORED_IMPROVEMENTS
+    ): TileImprovement? = timeThis("chooseImprovement") {
         // You can keep working on half-built improvements, even if they're unique to another civ
         if (tile.improvementInProgress != null) return ruleSet.tileImprovements[tile.improvementInProgress]
 
@@ -539,7 +545,7 @@ class WorkerAutomation(
         improvementName: String,
         localUniqueCache: LocalUniqueCache,
         /** Provide for performance */ currentTileStats: Stats? = null
-    ): Float {
+    ): Float = timeThis("getImprovementRanking") {
         val improvement = ruleSet.tileImprovements[improvementName]!!
         return getImprovementRanking(tile, unit, improvement, localUniqueCache, currentTileStats)
     }

--- a/core/src/com/unciv/logic/battle/TargetHelper.kt
+++ b/core/src/com/unciv/logic/battle/TargetHelper.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.battle
 
 import com.unciv.Constants
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.movement.PathsToTilesWithinTurn
@@ -16,7 +17,7 @@ object TargetHelper {
         unitDistanceToTiles: PathsToTilesWithinTurn,
         tilesToCheck: List<Tile>? = null,
         stayOnTile: Boolean = false
-    ): ArrayList<AttackableTile> {
+    ): ArrayList<AttackableTile> = timeThis("getAttackableEnemies") {
         val rangeOfAttack = unit.getRange()
         val attackableTiles = ArrayList<AttackableTile>()
 

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -4,6 +4,7 @@ import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.MultiFilter
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.managers.CityConquestFunctions
 import com.unciv.logic.city.managers.CityEspionageManager
 import com.unciv.logic.city.managers.CityExpansionManager
@@ -416,7 +417,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
      *
      *  If the next City.startTurn is soon enough, then use [reassignPopulationDeferred] instead.
      */
-    fun reassignPopulation(resetLocked: Boolean = false) {
+    fun reassignPopulation(resetLocked: Boolean = false) = timeThis("reassignPopulation") {
         if (resetLocked) {
             workedTiles = hashSetOf()
             lockedTiles = hashSetOf()

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.city
 
 import com.unciv.GUI
 import com.unciv.UncivGame
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.automation.Automation
 import com.unciv.logic.automation.city.ConstructionAutomation
@@ -116,7 +117,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
      * @return [Stats] provided by all built buildings in city
      */
     @Readonly
-    fun getStats(localUniqueCache: LocalUniqueCache): StatTreeNode {
+    fun getStats(localUniqueCache: LocalUniqueCache): StatTreeNode = timeThis("CityConstructions.getStats") {
         @LocalState val stats = StatTreeNode()
         for (building in getBuiltBuildings())
             stats.addStats(building.getStats(city, localUniqueCache), building.name)
@@ -357,7 +358,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         inProgressConstructions[constructionName] = inProgressConstructions[constructionName]!! + productionToAdd
     }
 
-    fun constructIfEnough() {
+    fun constructIfEnough() = timeThis("constructIfEnough") {
         validateConstructionQueue()
 
         // Update InProgressConstructions for any available refunds
@@ -815,7 +816,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     private fun removeCurrentConstruction() = removeFromQueue(0, true)
 
-    fun chooseNextConstruction() {
+    fun chooseNextConstruction() = timeThis("chooseNextConstruction") {
         if (!isQueueEmptyOrIdle()) {
             // If the USER set a perpetual construction, then keep it!
             if (getConstruction( currentConstructionName()) !is PerpetualConstruction || currentConstructionIsUserSet) return

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.city
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.Building
@@ -345,7 +346,7 @@ class CityStats(val city: City) {
     //endregion
     //region State-Changing Methods
 
-    fun updateTileStats(localUniqueCache: LocalUniqueCache = LocalUniqueCache()) {
+    fun updateTileStats(localUniqueCache: LocalUniqueCache = LocalUniqueCache()) = timeThis("updateTileStats") {
         val stats = Stats()
         val workedTiles = city.tilesInRange.asSequence()
             .filter {
@@ -456,7 +457,7 @@ class CityStats(val city: City) {
     }
     
     @Readonly
-    private fun getStatPercentBonusList(currentConstruction: IConstruction): StatTreeNode {
+    private fun getStatPercentBonusList(currentConstruction: IConstruction): StatTreeNode = timeThis("CityStats.getStatPercentBonusList") {
         val newStatsBonusTree = StatTreeNode()
 
         newStatsBonusTree.addStats(getStatPercentBonusesFromGoldenAge(city.civ.goldenAges.isGoldenAge()),"Golden Age")
@@ -487,7 +488,7 @@ class CityStats(val city: City) {
                updateTileStats:Boolean = true,
                updateCivStats:Boolean = true,
                localUniqueCache:LocalUniqueCache = LocalUniqueCache(),
-               calculateGrowthModifiers:Boolean = true) {
+               calculateGrowthModifiers:Boolean = true): Unit = timeThis<Unit>("CityStats.update") {
 
         if (updateTileStats) updateTileStats(localUniqueCache)
 

--- a/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.city.managers
 
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.automation.Automation
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
@@ -154,7 +155,7 @@ class CityPopulationManager : IsPartOfGameInfoSerialization {
     }
 
     /** Only assigns free population */
-    internal fun autoAssignPopulation() {
+    internal fun autoAssignPopulation() = timeThis("CityPopulationManager.autoAssignPopulation") {
         city.cityStats.update()  // calculate current stats with current assignments
         val freePopulation = getFreePopulation()
         if (freePopulation <= 0) return

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.city.managers
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityFlags
 import com.unciv.logic.city.CityFocus
@@ -18,7 +19,7 @@ import kotlin.random.Random
 class CityTurnManager(val city: City) {
 
 
-    fun startTurn() {
+    fun startTurn() = timeThis("CityTurnManager.startTurn") {
         city.clearCaches()
         
         for (resource in city.getResourcesGeneratedByCity()) {
@@ -134,7 +135,7 @@ class CityTurnManager(val city: City) {
     }
 
 
-    fun endTurn() {
+    fun endTurn() = timeThis("CityTurnManager.endTurn") {
         for (unique in city.getTriggeredUniques(UniqueType.TriggerUponTurnEnd, includeCivUniques = false).toList()) {
             UniqueTriggerActivation.triggerUnique(unique, city)
         }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -45,6 +45,7 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 enum class Proximity : IsPartOfGameInfoSerialization {
     None, // ie no cities
@@ -430,7 +431,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     @Transient
     val cache = CivInfoTransientCache(this)
 
-    fun updateStatsForNextTurn() {
+    fun updateStatsForNextTurn(): Unit = timeThis<Unit>("Civilization.updateStatsForNextTurn") {
         val previousHappiness = stats.happiness
         stats.happiness = stats.getHappinessBreakdown().values.sum().roundToInt()
         if (stats.happiness != previousHappiness && gameInfo.ruleset.allHappinessLevelsThatAffectUniques.any {
@@ -862,7 +863,7 @@ class Civilization : IsPartOfGameInfoSerialization {
                 ?: throw MissingNationException("Nation $civName is not found!", gameInfo.ruleset.mods)
     }
 
-    fun setTransients() {
+    fun setTransients() = timeThis("Civilization.setTransients") {
         goldenAges.civInfo = this
         greatPeople.civInfo = this
         civConstructions.setTransients(civInfo = this)

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.civilization.diplomacy
 
 import com.unciv.Constants
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.DiplomacyAction
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
@@ -16,7 +17,7 @@ import kotlin.math.min
 
 object DiplomacyTurnManager {
 
-    fun DiplomacyManager.nextTurn() {
+    fun DiplomacyManager.nextTurn() = timeThis("DiplomacyManager.nextTurn") {
         nextTurnTrades()
         removeUntenableTrades()
         updateHasOpenBorders()

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.civilization.managers
 
 import com.unciv.Constants
 import com.unciv.logic.IsPartOfGameInfoSerialization
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.*
 import com.unciv.logic.map.tile.RoadStatus
@@ -151,7 +152,7 @@ class TechManager : IsPartOfGameInfoSerialization {
         }
     }
     
-    @Readonly fun isResearched(techName: String): Boolean = techsResearched.contains(techName)
+    @Readonly fun isResearched(techName: String): Boolean { return techsResearched.contains(techName) }
     @Readonly fun isResearched(construction: INonPerpetualConstruction): Boolean = construction.requiredTechs().all{ requiredTech -> isResearched(requiredTech) }
 
     /** resources which need no research count as researched */

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -20,11 +20,12 @@ import com.unciv.utils.Log
 import yairm210.purity.annotations.Readonly
 import kotlin.math.min
 import kotlin.random.Random
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 class TurnManager(val civInfo: Civilization) {
 
 
-    fun startTurn(progressBar: NextTurnProgress? = null) {
+    fun startTurn(progressBar: NextTurnProgress? = null) = timeThis("TurnManager.startTurn") {
         if (civInfo.isSpectator()) return
 
         civInfo.threatManager.clear()
@@ -236,7 +237,7 @@ class TurnManager(val civInfo: Civilization) {
             * civInfo.gameInfo.speed.modifier.coerceAtLeast(1f)).toInt()
 
 
-    fun endTurn(progressBar: NextTurnProgress? = null) {
+    fun endTurn(progressBar: NextTurnProgress? = null) = timeThis("TurnManager.endTurn") {
         if (UncivGame.Current.settings.citiesAutoBombardAtEndOfTurn)
             NextTurnAutomation.automateCityBombardment(civInfo) // Bombard with all cities that haven't, maybe you missed one
 
@@ -353,13 +354,14 @@ class TurnManager(val civInfo: Civilization) {
         // Defeated civs do nothing
         if (civInfo.isDefeated())
             return
-
-        // Do stuff
+        timeThis("automateTurn") {
+            // Do stuff
         NextTurnAutomation.automateCivMoves(civInfo)
 
         // Update barbarian camps
         if (civInfo.isBarbarian && !civInfo.gameInfo.gameParameters.noBarbarians)
             civInfo.gameInfo.barbarians.updateEncampments()
+        }
     }
 
 }

--- a/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.civilization.transients
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
@@ -40,7 +41,7 @@ class CapitalConnectionsFinder(private val civInfo: Civilization) {
     private val railroadIsResearched = ruleset.tileImprovements[RoadStatus.Railroad.name].let {
         it != null && (it.techRequired==null || civInfo.tech.isResearched(it.techRequired!!)) }
 
-    fun find(): Map<City, EnumSet<CapitalConnectionMedium>> {
+    fun find(): Map<City, EnumSet<CapitalConnectionMedium>> = timeThis("CapitalConnectionsFinder.find") {
         // We map which cities we've reached, to the mediums they've been reached by -
         // this is so we know that if we've seen which cities can be connected by port A, and one
         // of those is city B, then we don't need to check the cities that B can connect to by port,
@@ -82,7 +83,7 @@ class CapitalConnectionsFinder(private val civInfo: Civilization) {
         )
     }
 
-    private fun checkHarbor(cityToConnectFrom: City) {
+    private fun checkHarbor(cityToConnectFrom: City) = timeThis("CapitalConnectionsFinder.checkHarbor") {
         check(
             cityToConnectFrom,
             transportType = if (cityToConnectFrom.wasPreviouslyReached(CapitalConnectionMedium.Railroad,null))
@@ -101,7 +102,7 @@ class CapitalConnectionsFinder(private val civInfo: Civilization) {
                       transportType: CapitalConnectionMedium,
                       overridingTransportType: CapitalConnectionMedium? = null,
                       tileFilter: (Tile) -> Boolean,
-                      cityFilter: (City) -> Boolean = { true }) {
+                      cityFilter: (City) -> Boolean = { true })  = timeThis("CapitalConnectionsFinder.check") {
         // This is the time-saving mechanism we discussed earlier - If I arrived at this city via a certain BFS,
         // then obviously I already have all the cities that can be reached via that BFS so I don't need to run it again.
         if (cityToConnectFrom.wasPreviouslyReached(transportType, overridingTransportType))

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.civilization.transients
 
 import com.unciv.Constants
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
@@ -168,7 +169,7 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
     @Readonly fun getUnitSupplyProductionPenalty(): Float = -min(getUnitSupplyDeficit() * 10f, 70f)
 
     @Readonly
-    fun getStatMapForNextTurn(): StatMap {
+    fun getStatMapForNextTurn(): StatMap = timeThis("getStatMapForNextTurn") {
         val statMap = StatMap()
         for (city in civInfo.cities) {
             for (entry in city.cityStats.finalStatList)

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -21,6 +21,7 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stats
 import com.unciv.utils.DebugUtils
 import java.util.EnumSet
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 /** CivInfo class was getting too crowded */
 class CivInfoTransientCache(val civInfo: Civilization) {
@@ -91,7 +92,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         }
     }
 
-    fun updateSightAndResources() {
+    fun updateSightAndResources() = timeThis("updateSightAndResources") {
         updateViewableTiles()
         updateHasActiveEnemyMovementPenalty()
         updateCivResources()
@@ -168,7 +169,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
     /** Our tiles update pretty infrequently - most 'viewable tile' changes are due to unit movements,
      * which means we can store this separately and use it 'as is' so we don't need to find the neighboring tiles every time
      * a unit moves */
-    fun updateOurTiles() {
+    fun updateOurTiles() = timeThis("CivInfoTransientCache.updateOurTiles")  {
         ourTilesAndNeighboringTiles = civInfo.cities.asSequence()
             .flatMap { it.getTiles() } // our owned tiles, still distinct
             .flatMap { sequenceOf(it) + it.neighbors }
@@ -288,7 +289,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
                 civInfo.getMatchingUniques(UniqueType.EnemyUnitsSpendExtraMovement)
     }
 
-    fun updateCitiesConnectedToCapital(initialSetup: Boolean = false) {
+    fun updateCitiesConnectedToCapital(initialSetup: Boolean = false) = timeThis("CivInfoTransientCache.updateCitiesConnectedToCapital") {
         if (civInfo.cities.isEmpty()) return // No cities to connect
 
         val oldConnectedCities = if (initialSetup)
@@ -316,7 +317,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             city.connectedToCapitalStatus = city in newConnectedCities
     }
 
-    fun updateCivResources() {
+    fun updateCivResources() = timeThis("CivInfoTransientCache.updateCivResources") {
         val newDetailedCivResources = ResourceSupplyList()
         for (city in civInfo.cities) newDetailedCivResources.add(city.getResourcesGeneratedByCity())
 

--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.map
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.FixedPointMovement.Companion.FPM_ONE
@@ -130,7 +131,7 @@ class PathingMap(
      */
     @Readonly
     @Suppress("purity")
-    fun getShortestPath(destination: Tile, maxTurns: Int = MAX_VALID_TURNS): List<Tile>? {
+    fun getShortestPath(destination: Tile, maxTurns: Int = MAX_VALID_TURNS): List<Tile>? =timeThis("TileStatFunctions.getShortestPath") {
         val cache = fetchCache()
         if (destination.position == cache.key.startingPoint) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -29,6 +29,7 @@ import yairm210.purity.annotations.Readonly
 import java.text.DecimalFormat
 import kotlin.math.pow
 import kotlin.math.ulp
+import com.unciv.logic.automation.Timers.Companion.timeThis
 
 
 /**
@@ -764,7 +765,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     /**
      * Update this unit's cache of viewable tiles and its civ's as well.
      */
-    fun updateVisibleTiles(updateCivViewableTiles: Boolean = true, explorerPosition: HexCoord? = null) {
+    fun updateVisibleTiles(updateCivViewableTiles: Boolean = true, explorerPosition: HexCoord? = null) = timeThis("MapUnit.updateVisibleTiles") {
         val oldViewableTiles = viewableTiles
 
         viewableTiles = when {

--- a/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.map.mapunit
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.*
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
@@ -135,7 +136,7 @@ class UnitTurnManager(val unit: MapUnit) {
     }
 
 
-    fun startTurn() {
+    fun startTurn() = timeThis("UnitTurnManager.startTurn") {
         unit.movement.clearPathfindingCache()
         unit.currentMovement = unit.getMaxMovement().toFloat()
         unit.attacksThisTurn = 0

--- a/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.map.mapunit.movement
 
 import com.unciv.Constants
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.MapUnitCache
@@ -19,7 +20,7 @@ object MovementCost {
         to: Tile,
         considerZoneOfControl: Boolean = true,
         includeEscortUnit: Boolean = true,
-    ): Float {
+    ): Float = timeThis("MovementCost.getMovementCostBetweenAdjacentTilesEscort")  {
         val movementCost = if (includeEscortUnit && unit.isEscorting()) {
             maxOf(getMovementCostBetweenAdjacentTiles(unit, from, to, considerZoneOfControl),
                 getMovementCostBetweenAdjacentTiles(unit.getOtherEscortUnit()!!, from, to, considerZoneOfControl))

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -4,6 +4,7 @@ package com.unciv.logic.map.mapunit.movement
 
 import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.BFS
 import com.unciv.logic.map.HexCoord
@@ -70,7 +71,7 @@ class UnitMovement(val unit: MapUnit) {
         canPassThroughCache: ArrayList<Boolean?> = ArrayList(),
         movementCostCache: HashMap<Int, Float> = HashMap(),
         includeOtherEscortUnit: Boolean = true
-    ): PathsToTilesWithinTurn {
+    ): PathsToTilesWithinTurn = timeThis("getMovementToTilesAtPosition") {
         if (UncivGame.Current.settings.useAStarPathfinding) {
             if (!considerZoneOfControl) require(includeOtherEscortUnit)
             val pathingMap = if (!considerZoneOfControl) aStarPathingWithoutZoneControl
@@ -146,7 +147,7 @@ class UnitMovement(val unit: MapUnit) {
      * Returns an empty list if there's no way to get to the destination.
      */
     @Readonly @Suppress("purity")
-    fun getShortestPath(destination: Tile, avoidDamagingTerrain: Boolean = false): List<Tile> {
+    fun getShortestPath(destination: Tile, avoidDamagingTerrain: Boolean = false): List<Tile> = timeThis<List<Tile>>("getShortestPath")  {
         if (unit.cache.cannotMove) return listOf()
         if (UncivGame.Current.settings.useAStarPathfinding)
             return aStarPathing.getShortestPath(destination) ?: listOf()
@@ -262,6 +263,7 @@ class UnitMovement(val unit: MapUnit) {
 
             distance++
         }
+        return emptyList()
     }
 
     class UnreachableDestinationException(msg: String) : Exception(msg)
@@ -464,7 +466,7 @@ class UnitMovement(val unit: MapUnit) {
         else unit.destroy()
     }
 
-    fun moveToTile(destination: Tile, considerZoneOfControl: Boolean = true) {
+    fun moveToTile(destination: Tile, considerZoneOfControl: Boolean = true): Unit = timeThis<Unit>("moveToTile") {
         if (destination == unit.getTile() || unit.isDestroyed) return // already here (or dead)!
         // Reset closestEnemy chache
         val escortUnit = if (unit.isEscorting()) unit.getOtherEscortUnit()!! else null

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -5,6 +5,7 @@ import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.MultiFilter
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.PlayerType
@@ -534,12 +535,12 @@ class Tile : IsPartOfGameInfoSerialization {
 
     /** Implements [UniqueParameterType.TileFilter][com.unciv.models.ruleset.unique.UniqueParameterType.TileFilter] */
     @Readonly
-    fun matchesFilter(filter: String, civInfo: Civilization? = null): Boolean {
+    fun matchesFilter(filter: String, civInfo: Civilization? = null): Boolean = timeThis("Tile.matchesFilter")  {
         return MultiFilter.multiFilter(filter, { matchesSingleFilter(it, civInfo) })
     }
 
     @Readonly
-    private fun matchesSingleFilter(filter: String, civInfo: Civilization? = null): Boolean {
+    private fun matchesSingleFilter(filter: String, civInfo: Civilization? = null): Boolean = timeThis("Tile.matchesSingleFilter")  {
         if (matchesSingleTerrainFilter(filter, civInfo)) return true
         if ((improvement == null || improvementIsPillaged) && filter == "unimproved") return true
         if (improvement != null && !improvementIsPillaged && filter == "improved") return true

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.map.tile
 
 import com.unciv.Constants
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.tile.Terrain
@@ -36,7 +37,7 @@ class TileStatFunctions(val tile: Tile) {
     fun getTileStats(
         city: City?, observingCiv: Civilization?,
         localUniqueCache: LocalUniqueCache = LocalUniqueCache(false)
-    ): Stats {
+    ): Stats = timeThis("getTileStats") {
         val statsBreakdown = getTileStatsBreakdown(city, observingCiv, localUniqueCache)
 
         val improvement = tile.getUnpillagedImprovement()
@@ -197,7 +198,8 @@ class TileStatFunctions(val tile: Tile) {
     // Only gets the tile percentage bonus, not the improvement percentage bonus
     @Suppress("MemberVisibilityCanBePrivate")
     @Readonly
-    fun getTilePercentageStats(observingCiv: Civilization?, city: City?, uniqueCache: LocalUniqueCache): EnumMap<TilePercentageCategory, Stats> {
+    fun getTilePercentageStats(observingCiv: Civilization?, city: City?, uniqueCache: LocalUniqueCache): EnumMap<TilePercentageCategory, Stats>
+    = timeThis("TileStatFunctions.getTilePercentageStats") {
         val terrainStats = Stats()
         val gameContext = GameContext(civInfo = observingCiv, city = city, tile = tile)
 
@@ -314,7 +316,7 @@ class TileStatFunctions(val tile: Tile) {
         improvement: TileImprovement,
         observingCiv: Civilization,
         city: City?
-    ): Stats {
+    ): Stats = timeThis("TileStatFunctions.getExtraImprovementStats"){
         val stats = Stats()
 
         val resource = tile.tileResource

--- a/core/src/com/unciv/logic/simulation/Simulation.kt
+++ b/core/src/com/unciv/logic/simulation/Simulation.kt
@@ -4,6 +4,7 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameStarter
+import com.unciv.logic.automation.Timers
 import com.unciv.models.metadata.GameSetupInfo
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
@@ -92,6 +93,7 @@ class Simulation(
 
         newGameInfo.gameParameters.shufflePlayerOrder = true
 
+        Timers.singleton.startTiming()
         val jobs = (1..threadsNumber).map { threadId ->
             launch(Dispatchers.Default + CoroutineName("simulation-$threadId")) {
                 repeat(simulationsPerThread) {
@@ -135,6 +137,7 @@ class Simulation(
         }
 
         jobs.forEach { it.join() }
+        Timers.singleton.endTiming()
     }
 
     @Suppress("UNUSED_PARAMETER")   // used when activating debug output

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset
 
 import com.unciv.logic.GameInfo
 import com.unciv.logic.MultiFilter
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityConstructions
 import com.unciv.logic.civilization.Civilization
@@ -81,7 +82,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     fun getStats(city: City,
                  /* By default, do not cache - if we're getting stats for only one building this isn't efficient.
                  * Only use a cache if it was sent to us from outside, which means we can use the results for other buildings.  */
-                 localUniqueCache: LocalUniqueCache = LocalUniqueCache(false)): Stats {
+                 localUniqueCache: LocalUniqueCache = LocalUniqueCache(false)): Stats = timeThis("Building.getStats") {
         // Calls the clone function of the NamedStats this class is derived from, not a clone function of this class
         @LocalState val stats = cloneStats()
         

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset.unique
 
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.battle.CombatAction
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
@@ -28,7 +29,7 @@ object Conditionals {
         unique: Unique?,
         conditional: Unique,
         state: GameContext
-    ): Boolean {
+    ): Boolean = timeThis("Conditionals.conditionalApplies") {
 
         if (conditional.isOtherModifierType)
             return true // not a filtering condition, includes e.g. ModifierHiddenFromUsers

--- a/core/src/com/unciv/models/ruleset/unique/LocalUniqueCache.kt
+++ b/core/src/com/unciv/models/ruleset/unique/LocalUniqueCache.kt
@@ -1,5 +1,6 @@
 package com.unciv.models.ruleset.unique
 
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import yairm210.purity.annotations.Cache
@@ -16,7 +17,7 @@ class LocalUniqueCache(val cache: Boolean = true) {
         city: City,
         uniqueType: UniqueType,
         gameContext: GameContext = city.state
-    ): Sequence<Unique> {
+    ): Sequence<Unique> = timeThis("LocalUniqueCache.forCiyGetMatchingUniques") {
         // City uniques are a combination of *global civ* uniques plus *city relevant* uniques (see City.getMatchingUniques())
         // We can cache the civ uniques separately, so if we have several cities using the same cache,
         //   we can cache the list of *civ uniques* to reuse between cities.
@@ -37,7 +38,7 @@ class LocalUniqueCache(val cache: Boolean = true) {
         civ: Civilization,
         uniqueType: UniqueType,
         gameContext: GameContext = civ.state
-    ): Sequence<Unique> {
+    ): Sequence<Unique> = timeThis("LocalUniqueCache.forCivGetMatchingUniques") {
         val sequence = civ.getMatchingUniques(uniqueType, GameContext.IgnoreMultiplicationForCaching)
         // The uniques CACHED are ALL civ uniques, regardless of conditional matching.
         // The uniques RETURNED are uniques AFTER conditional matching.

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.unique
 
 import com.unciv.Constants
+import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.GlobalUniques
@@ -82,7 +83,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
     }
 
     @Readonly
-    fun conditionalsApply(state: GameContext): Boolean {
+    fun conditionalsApply(state: GameContext): Boolean = timeThis("Unique.conditionalsApply") {
         if (state.ignoreConditionals) return true
         // Always allow Timed conditional uniques. They are managed elsewhere
         if (isTimedTriggerable) return true

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/AutoPlay.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/AutoPlay.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.screens.worldscreen.unit
 
+import com.unciv.logic.automation.Timers
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.screens.worldscreen.WorldScreen
 import com.unciv.utils.Concurrency
@@ -21,6 +22,7 @@ class AutoPlay(private var autoPlaySettings: GameSettings.GameSettingsAutoPlay) 
     var autoPlayJob: Job? = null
 
     fun startMultiturnAutoPlay() {
+        Timers.singleton.startTiming()
         autoPlayTurnInProgress = false
         turnsToAutoPlay = autoPlaySettings.autoPlayMaxTurns
     }
@@ -40,6 +42,7 @@ class AutoPlay(private var autoPlaySettings: GameSettings.GameSettingsAutoPlay) 
     fun stopAutoPlay() {
         turnsToAutoPlay = 0
         autoPlayTurnInProgress = false
+        Timers.singleton.endTiming()
     }
 
     /**

--- a/core/src/com/unciv/utils/CollectionExtensions.kt
+++ b/core/src/com/unciv/utils/CollectionExtensions.kt
@@ -1,6 +1,8 @@
 package com.unciv.utils
 
 import com.badlogic.gdx.utils.Array
+import com.badlogic.gdx.utils.IntArray as GdxIntArray
+import com.badlogic.gdx.utils.LongArray as GdxLongArray
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
 import java.util.BitSet
@@ -149,3 +151,27 @@ inline fun BitSet.forEachClearBit(action: (Int) -> Unit) {
     }
 }
 
+inline fun GdxIntArray.forEach(op: (Int) -> Unit) {
+    for (i in 0 until size) {
+        op(items[i])
+    }
+}
+inline fun <T> GdxIntArray.fold(initial: T, op: (T, Int) -> T): T {
+    var r = initial
+    for (i in 0 until size) {
+        r = op(r, items[i])
+    }
+    return r
+}
+inline fun GdxLongArray.forEach(op: (Long) -> Unit) {
+    for (i in 0 until size) {
+        op(items[i])
+    }
+}
+inline fun <T> GdxLongArray.fold(initial: T, op: (T, Long) -> T): T {
+    var r = initial
+    for (i in 0 until size) {
+        r = op(r, items[i])
+    }
+    return r
+}

--- a/core/src/com/unciv/utils/PlatformSpecific.kt
+++ b/core/src/com/unciv/utils/PlatformSpecific.kt
@@ -13,4 +13,6 @@ interface PlatformSpecific {
 
     /** If the OS localizes all error messages, this should provide a lookup */
     fun getSystemErrorMessage(errorCode: Int): String? = null
+
+    fun getGcCount(): Int
 }

--- a/desktop/src/com/unciv/app/desktop/DesktopGame.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopGame.kt
@@ -4,6 +4,10 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
 import com.sun.jna.platform.win32.Kernel32Util
 import com.unciv.UncivGame
+import java.lang.management.GarbageCollectorMXBean
+import java.lang.management.ManagementFactory
+
+
 
 class DesktopGame(config: Lwjgl3ApplicationConfiguration, override var customDataDirectory: String?) : UncivGame() {
 


### PR DESCRIPTION
Timers enable when AutoPlay is enabled, and disable and log when AutoPlay is disabled.

This is useful for measuring performance, and calculating improvements of local changes.

Also it logs average GCs per turn at the end.