### PR TITLE
Update stats GUI after discovering natural wonder

### DIFF
--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -276,6 +276,9 @@ class CivInfoTransientCache(val civInfo: Civilization) {
                 GameContext(civInfo, tile = tile)
             ))
                 UniqueTriggerActivation.triggerUnique(unique, civInfo, tile=tile, triggerNotificationText = "due to discovering a Natural Wonder")
+
+            // G&K in particular; update the happiness counter in the top bar in the world screen
+            civInfo.updateStatsForNextTurn()
         }
     }
 


### PR DESCRIPTION
When discovering a natural wonder in G&K, you get 1 happiness. This was not immediately reflected in the top bar in the world screen GUI.