### PR TITLE
Autosave on turn 0

### DIFF
--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -350,6 +350,8 @@ class NewGameScreen(
         }
 
         val worldScreen = game.loadGame(newGame)
+        
+        worldScreen.autoSave()
 
         if (newGame.gameParameters.isOnlineMultiplayer) {
             launchOnGLThread {


### PR DESCRIPTION
Creates an autosave right after starting a new game (e.g. `Autosave-Denmark-0`), instead of only after the completion of the first turn and onwards.