### PR TITLE
Removing some unseeded randomness

### DIFF
--- a/.github/workflows/detekt_config/detekt-warnings.yml
+++ b/.github/workflows/detekt_config/detekt-warnings.yml
@@ -321,7 +321,7 @@ naming:
     enumEntryPattern: '^[a-zA-Z0-9_]*$'
   ForbiddenClassName:
     active: false
-    forbiddenName: []
+    forbiddenName: ['kotlin.random.(Random.)?Default']
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
@@ -581,12 +581,20 @@ style:
     imports: []
     forbiddenPatterns: ''
   ForbiddenMethodCall:
-    active: false
+    active: true
     methods:
       - reason: 'print does not allow you to configure the output stream. Use a logger instead.'
         value: 'kotlin.io.print'
       - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
         value: 'kotlin.io.println'
+      - reason: 'Avoid unseeded random. Instead, use GameContext.random'
+        value: 'kotlin.collections.Collection.random()'
+      - reason: 'Unciv prefers pseudorandom. Instead, use GameContext.random'
+        value: 'kotlin.collections.Collection.randomOrNull()'
+      - reason: 'Unciv prefers pseudorandom. Instead, use GameContext.random'
+        value: 'java.util.Random.<init>()'
+      - reason: 'Unciv prefers pseudorandom. Instead, use GameContext.random'
+        value: 'java.util.Random.Default.*'
   ForbiddenSuppress:
     active: false
     rules: []

--- a/core/src/com/unciv/logic/HolidayDates.kt
+++ b/core/src/com/unciv/logic/HolidayDates.kt
@@ -102,7 +102,7 @@ object HolidayDates {
                 (1..12)
                     .map { LocalDate.of(year, it, 13) }
                     .filter { it.dayOfWeek == DayOfWeek.FRIDAY }
-                    .randomOrNull()
+                    .randomOrNull(Random(year))
                     ?.let { DateRange.of(it) }
                     ?: DateRange.never
         },

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -194,6 +194,7 @@ object Automation {
 
     @Readonly
     fun chooseMilitaryUnit(city: City, availableUnits: Sequence<BaseUnit>): BaseUnit? {
+        val rng = city.state.stateBasedRandom("Automation.chooseMilitaryUnit")
         val currentChoice = city.cityConstructions.getCurrentConstruction()
         if (currentChoice is BaseUnit && !currentChoice.isCivilian()) return currentChoice
 
@@ -261,7 +262,7 @@ object Automation {
             }
             // Check the maximum force evaluation for the shortlist so we can prune useless ones (ie scouts)
             val bestForce = bestUnitsForType.maxOfOrNull { it.value.getForceEvaluation() } ?: return null
-            chosenUnit = bestUnitsForType.filterValues { it.uniqueTo != null || it.getForceEvaluation() > bestForce / 3 }.values.random()
+            chosenUnit = bestUnitsForType.filterValues { it.uniqueTo != null || it.getForceEvaluation() > bestForce / 3 }.values.random(rng)
         }
         return chosenUnit
     }

--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -15,7 +15,6 @@ import yairm210.purity.annotations.Readonly
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
-import kotlin.random.Random
 
 class BarbarianManager : IsPartOfGameInfoSerialization {
 
@@ -75,8 +74,9 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
     }
 
     fun placeBarbarianEncampment(forTesting: Boolean = false) {
+        val rng = gameInfo.getBarbarianCivilization().state.stateBasedRandom("BarbarianManager.placeBarbarianEncampent")
         // Before we do the expensive stuff, do a roll to see if we will place a camp at all
-        if (!forTesting && gameInfo.turns > 1 && Random.Default.nextBoolean())
+        if (!forTesting && gameInfo.turns > 1 && rng.nextBoolean())
             return
 
         // Barbarians will only spawn in places that no one can see
@@ -117,7 +117,7 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
 
         var tile: Tile?
         var addedCamps = 0
-        var biasCoast = Random.Default.nextInt(6) == 0
+        var biasCoast = rng.nextInt(6) == 0
 
         // Add the camps
         while (addedCamps < campsToAdd) {
@@ -126,11 +126,11 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
 
             // If we're biasing for coast, get a coast tile if possible
             if (biasCoast) {
-                tile = viableTiles.filter { it.isAdjacentToCoast() }.randomOrNull()
+                tile = viableTiles.filter { it.isAdjacentToCoast() }.randomOrNull(rng)
                 if (tile == null)
-                    tile = viableTiles.random()
+                    tile = viableTiles.random(rng)
             } else
-                tile = viableTiles.random()
+                tile = viableTiles.random(rng)
 
             createNewCamp(tile)
             notifyCivsOfBarbarianEncampment(tile)
@@ -141,7 +141,7 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
                 // Remove some newly non-viable tiles
                 viableTiles.removeAll(tile.getTilesInDistance(7).toSet())
                 // Reroll bias
-                biasCoast = Random.Default.nextInt(6) == 0
+                biasCoast = rng.nextInt(6) == 0
             }
         }
     }
@@ -241,7 +241,8 @@ class Encampment() : IsPartOfGameInfoSerialization {
         }
         if (validTiles.isEmpty()) return false
 
-        return spawnUnit(validTiles.random().isWater) // Attempt to spawn a barbarian on a valid tile
+        val rng = gameInfo.getBarbarianCivilization().state.stateBasedRandom("BarbarianManager.spawnBarbarian")
+        return spawnUnit(validTiles.random(rng).isWater) // Attempt to spawn a barbarian on a valid tile
     }
 
     /** Attempts to spawn a barbarian on [position], returns true if successful and false if unsuccessful. */
@@ -284,8 +285,9 @@ class Encampment() : IsPartOfGameInfoSerialization {
 
     /** When a barbarian is spawned, seed the counter for next spawn */
     private fun resetCountdown() {
+        val rng = gameInfo.getBarbarianCivilization().state.stateBasedRandom("BarbarianManager.resetCooldown")
         // Base 8-12 turns
-        countdown = 8 + Random.Default.nextInt(5)
+        countdown = 8 + rng.nextInt(5)
         // Quicker on Raging Barbarians
         if (gameInfo.gameParameters.ragingBarbarians)
             countdown /= 2

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -37,6 +37,7 @@ object DiplomacyAutomation {
             }
             .sortedByDescending { it.getDiplomacyManager(civInfo)!!.relationshipLevel() }.toList()
         for (otherCiv in civsThatWeCanDeclareFriendshipWith) {
+            val rng = civInfo.getDiplomacyManager(otherCiv)!!.state.stateBasedRandom("DiplomacyAutomation.offerDeclarationOfFriendship")
             // Default setting is 2, this will be changed according to different civ.
             if ((1..10).random(getRandom(civInfo, otherCiv, "declaration of friendship"))
                 <= 2 * civInfo.getPersonality().scaledFocus(PersonalityValue.Diplomacy) 
@@ -135,6 +136,7 @@ object DiplomacyAutomation {
         }.sortedByDescending { it.getDiplomacyManager(civInfo)!!.relationshipLevel() }
 
         for (otherCiv in civsThatWeCanEstablishEmbassyWith) {
+            val rng = civInfo.getDiplomacyManager(otherCiv)!!.state.stateBasedRandom("DiplomacyAutomation.offerToEstablishEmbassy")
             // Default setting is 3
             if ((1..10).random(getRandom(civInfo, otherCiv, "embassy")) < 7) continue
             if (wantsToAcceptEmbassy(civInfo, otherCiv)) {
@@ -182,6 +184,7 @@ object DiplomacyAutomation {
         }.sortedByDescending { it.getDiplomacyManager(civInfo)!!.relationshipLevel() }
 
         for (otherCiv in civsThatWeCanOpenBordersWith) {
+            val rng = civInfo.getDiplomacyManager(otherCiv)!!.state.stateBasedRandom("DiplomacyAutomation.offerOpenBorders")
             // Default setting is 3
             if ((1..10).random(getRandom(civInfo, otherCiv, "open borders")) < 7) continue
             if (wantsToOpenBorders(civInfo, otherCiv)) {
@@ -252,6 +255,7 @@ object DiplomacyAutomation {
         }.sortedByDescending { it.stats.statsForNextTurn.science }
 
         for (otherCiv in civsThatWeCanSignResearchAgreementWith) {
+            val rng = civInfo.getDiplomacyManager(otherCiv)!!.state.stateBasedRandom("DiplomacyAutomation.offerResearchAgreement")
             // Default setting is 5, this will be changed according to different civ.
             if ((1..10).random(getRandom(civInfo, otherCiv, "research agreement"))
                 <= 5 * civInfo.getPersonality().scaledFocus(PersonalityValue.Science)) continue
@@ -277,6 +281,7 @@ object DiplomacyAutomation {
         }
 
         for (otherCiv in civsThatWeCanSignDefensivePactWith) {
+            val rng = civInfo.getDiplomacyManager(otherCiv)!!.state.stateBasedRandom("DiplomacyAutomation.offerDefensivePact")
             // Default setting is 3, this will be changed according to different civ.
             if ((1..10).random(getRandom(civInfo, otherCiv, "defensive pact"))
                 <= 7 * civInfo.getPersonality().inverseScaledFocus(PersonalityValue.Loyal)) continue

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -31,8 +31,6 @@ import com.unciv.ui.screens.victoryscreen.RankingType
 import com.unciv.utils.randomWeighted
 import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Readonly
-import kotlin.math.roundToInt
-import kotlin.random.Random
 
 object NextTurnAutomation {
 
@@ -282,6 +280,7 @@ object NextTurnAutomation {
     }
 
     private fun adoptPolicy(civInfo: Civilization) {
+        val rng = civInfo.state.stateBasedRandom("NextTurnAutomation.adoptPolicy")
         /*
         # Branch-based policy-to-adopt decision
         Basically the AI prioritizes finishing incomplete branches before moving on, \
@@ -333,7 +332,7 @@ object NextTurnAutomation {
             // Choose the branch with the LEAST REMAINING policies, not the MOST ADOPTED ones
             val targetBranch = candidateCompletionMap.asIterable()
                 .groupBy { it.key.policies.size - it.value }
-                .minByOrNull { it.key }!!.value.random().key
+                .minByOrNull { it.key }!!.value.random(rng).key
 
             val policyToAdopt: Policy =
                 if (civInfo.policies.isAdoptable(targetBranch)) targetBranch
@@ -346,6 +345,7 @@ object NextTurnAutomation {
 
     fun chooseGreatPerson(civInfo: Civilization) {
         if (civInfo.greatPeople.freeGreatPeople == 0) return
+        val rng = civInfo.state.stateBasedRandom("NextTurnAutomation.chooseGreatPerson")
         val mayanGreatPerson = civInfo.greatPeople.mayaLimitedFreeGP > 0
         val greatPeople =
             if (mayanGreatPerson)
@@ -353,7 +353,7 @@ object NextTurnAutomation {
             else civInfo.greatPeople.getGreatPeople()
 
         if (greatPeople.isEmpty()) return
-        var greatPerson = greatPeople.random()
+        var greatPerson = greatPeople.random(rng)
         val scienceGP = greatPeople.firstOrNull { it.uniques.contains("Great Person - [Science]") }
         if (scienceGP != null)  greatPerson = scienceGP
         // Humans would pick a prophet or engineer, but it'd require more sophistication on part of the AI - a scientist is the safest option for now
@@ -387,12 +387,13 @@ object NextTurnAutomation {
             for (city in civInfo.cities) {
                 if (city.hasSoldBuildingThisTurn)
                     continue
+                val rng = city.state.stateBasedRandom("NextTurnAutomation.freeUpSpaceResources")
                 val buildingToSell = civInfo.gameInfo.ruleset.buildings.values.filter {
                         city.cityConstructions.isBuilt(it.name)
                         && it.requiredResources(city.state).contains(resource)
                         && it.isSellable()
                         && !civInfo.civConstructions.hasFreeBuilding(city, it) }
-                    .randomOrNull()
+                    .randomOrNull(rng)
                 if (buildingToSell != null) {
                     city.sellBuilding(buildingToSell)
                     break
@@ -614,6 +615,7 @@ object NextTurnAutomation {
     // However, that can be added in another update, this PR is large enough as it is.
     private fun tryVoteForDiplomaticVictory(civ: Civilization) {
         if (!civ.mayVoteForDiplomaticVictory()) return
+        val rng = civ.state.stateBasedRandom("NextTurnAutomation.tryVoteForDiplomaticVictory")
 
         val chosenCiv: Civilization? = if (civ.isMajorCiv()) {
             val knownMajorCivs = civ.getKnownCivs().filter { it.isMajorCiv() }
@@ -623,11 +625,11 @@ object NextTurnAutomation {
                 }
 
             if (highestOpinion == null) null  // Abstain if we know nobody
-            else if (highestOpinion < -80 || highestOpinion < -40 && highestOpinion + Random.Default.nextInt(40) < -40)
+            else if (highestOpinion < -80 || highestOpinion < -40 && highestOpinion + rng.nextInt(40) < -40)
                 null // Abstain if we hate everybody (proportional chance in the RelationshipLevel.Enemy range - lesser evil)
             else knownMajorCivs
                 .filter { civ.getDiplomacyManager(it)!!.opinionOfOtherCiv() == highestOpinion }
-                .toList().random()
+                .toList().random(rng)
 
         } else {
             civ.allyCiv

--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -435,14 +435,15 @@ object ReligionAutomation {
 
     private fun foundReligion(civInfo: Civilization) {
         if (civInfo.religionManager.religionState != ReligionState.FoundingReligion) return
+        val rng = civInfo.state.stateBasedRandom("ReligionAutomation.foundReligion")
         val usedReligions = civInfo.gameInfo.religions.values.mapTo(mutableSetOf()) { it.name }
         val availableReligions = civInfo.gameInfo.ruleset.religions.filterNot { it in usedReligions }
         val favoredReligion = civInfo.nation.favoredReligion?.takeIf { it in availableReligions }
         val allFavoredReligions = civInfo.gameInfo.civilizations.mapNotNullTo(mutableSetOf()) { it.nation.favoredReligion}
         val nonFavoredReligions = availableReligions.filterNot { it in allFavoredReligions }
         val chosenReligion = favoredReligion
-            ?: nonFavoredReligions.randomOrNull() // allow other civs to found their own favoured religion when possible
-            ?: availableReligions.randomOrNull()
+            ?: nonFavoredReligions.randomOrNull(rng) // allow other civs to found their own favoured religion when possible
+            ?: availableReligions.randomOrNull(rng)
             ?: return // Wait what? How did we pass the checking when using a great prophet but not this?
 
         civInfo.religionManager.foundReligion(chosenReligion, chosenReligion)

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -175,10 +175,11 @@ object UnitAutomation {
             return false
         }
 
+        val rng = unit.cache.state.stateBasedRandom("UnitAutomation.tryFogBust")
         val reachableTilesThisTurn =
                 unit.movement.getDistanceToTiles().keys.filter { isGoodTileForFogBusting(unit, it) }
         if (reachableTilesThisTurn.any()) {
-            unit.movement.headTowards(reachableTilesThisTurn.random()) // Just pick one
+            unit.movement.headTowards(reachableTilesThisTurn.random(rng)) // Just pick one
             return true
         }
 
@@ -215,7 +216,8 @@ object UnitAutomation {
                         && unit.getDamageFromTerrain(it) <= 0 // Don't end turn on damaging terrain for no good reason
                         && (!stayInTerritory || it.getOwner() == unit.civ || unit.currentTile.getOwner() != unit.civ)
                 }
-        if (reachableTiles.any()) unit.movement.moveToTile(reachableTiles.toList().random())
+        val rng = unit.cache.state.stateBasedRandom("UnitAutomation.wander")
+        if (reachableTiles.any()) unit.movement.moveToTile(reachableTiles.toList().random(rng))
     }
 
     internal fun tryUpgradeUnit(unit: MapUnit): Boolean {

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -171,6 +171,7 @@ class CityFounder {
         aliveCivs: Set<Civilization>,
         usedCityNames: Set<String>
     ): String? {
+        val rng = foundingCiv.state.stateBasedRandom("CityFounder.borrowCityName")
         val aliveMajorNations: Sequence<Nation> =
                 aliveCivs.asSequence().filter { civ -> civ.isMajorCiv() }.map { civ -> civ.nation }
 
@@ -185,7 +186,7 @@ class CityFounder {
                 otherMajorNations.mapNotNull { nation ->
                     nation.cities.lastOrNull { city -> city !in usedCityNames }
                 }.toSet()
-        if (newCityNames.isNotEmpty()) return newCityNames.random()
+        if (newCityNames.isNotEmpty()) return newCityNames.random(rng)
 
         // As per fandom wiki, once the names from the other nations in the game are exhausted,
         // names are taken from the rest of the major nations in the rule set
@@ -197,7 +198,7 @@ class CityFounder {
                 absentMajorNations.flatMap { nation ->
                     nation.cities.asSequence().filter { city -> city !in usedCityNames }
                 }.toSet()
-        if (newCityNames.isNotEmpty()) return newCityNames.random()
+        if (newCityNames.isNotEmpty()) return newCityNames.random(rng)
 
         // If for some reason we have used every single city name in the game,
         // (are we using some sort of rule set mod without city names?)

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -14,7 +14,6 @@ import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
 import kotlin.math.roundToInt
-import kotlin.random.Random
 
 class CityTurnManager(val city: City) {
 
@@ -58,8 +57,9 @@ class CityTurnManager(val city: City) {
     }
     
     private fun setWltkResourceDemandCooldown(isNewCity: Boolean) {
+        val rng = city.state.stateBasedRandom("CityTurnManager.setWltkResourceDemandCooldown")
         // Demand a new resource in ~20 turns on Standard speed
-        var duration = 15 + Random.Default.nextInt(10)
+        var duration = 15 + rng.nextInt(10)
         if (isNewCity && city.isCapital())
             duration += 10
         city.setFlag(CityFlags.ResourceDemand, duration, true)
@@ -109,6 +109,7 @@ class CityTurnManager(val city: City) {
 
 
     private fun demandNewResource() {
+        val rng = city.state.stateBasedRandom("CityTurnManager.demandNewResource")
         val candidates = city.getRuleset().tileResources.values.filter {
             it.resourceType == ResourceType.Luxury && // Must be luxury
                     !it.hasUnique(UniqueType.CityStateOnlyResource) && // Not a city-state only resource eg jewelry
@@ -119,11 +120,11 @@ class CityTurnManager(val city: City) {
         val missingResources = candidates.filter { !city.civ.hasResource(it) }
         
         if (missingResources.isEmpty()) { // hooray happpy day forever!
-            city.demandedResource = candidates.randomOrNull()?.name ?: ""
+            city.demandedResource = candidates.randomOrNull(rng)?.name ?: ""
             return // actually triggering "wtlk" is done in tryWeLoveTheKing(), *next turn*
         }
 
-        val chosenResource = missingResources.randomOrNull()
+        val chosenResource = missingResources.randomOrNull(rng)
         
         city.demandedResource = chosenResource?.name ?: "" // mods may have no resources as candidates even
         setWltkResourceDemandCooldown(false)

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -29,6 +29,7 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     /** Attempts to initialize the city state, returning true if successful. */
     fun initCityState(ruleset: Ruleset, startingEra: String, usedMajorCivs: Sequence<Nation>): Boolean {
+        val rng = civInfo.state.stateBasedRandom("CityStateFunctions.initCityState")
         val allMercantileResources = ruleset.tileResources.values.filter { it.hasUnique(UniqueType.CityStateOnlyResource) }.map { it.name }
         val uniqueTypes = HashSet<UniqueType>()    // We look through these to determine what kinds of city states we have
 
@@ -37,12 +38,12 @@ class CityStateFunctions(val civInfo: Civilization) {
         uniqueTypes.addAll(cityStateType.allyBonusUniqueMap.getAllUniques().mapNotNull { it.type })
 
         // CS Personality
-        civInfo.cityStatePersonality = CityStatePersonality.entries.random()
+        civInfo.cityStatePersonality = CityStatePersonality.entries.random(rng)
 
         // Mercantile bonus resources
 
         if (uniqueTypes.contains(UniqueType.CityStateUniqueLuxury)) {
-            civInfo.cityStateResource = allMercantileResources.randomOrNull()
+            civInfo.cityStateResource = allMercantileResources.randomOrNull(rng)
         }
         
         fun possibleUnits(): ArrayList<BaseUnit> {
@@ -119,7 +120,8 @@ class CityStateFunctions(val civInfo: Civilization) {
     }
 
     @Readonly
-    fun turnsForGreatPersonFromCityState(): Int = ((37 + Random.Default.nextInt(7)) * civInfo.gameInfo.speed.modifier).toInt()
+    fun turnsForGreatPersonFromCityState(): Int = 
+        ((37 + civInfo.state.stateBasedRandom("CityStateFunctions.turnsForGreatPersonFromCityState").nextInt(7)) * civInfo.gameInfo.speed.modifier).toInt()
 
     /** Gain a random great person from the city state */
     fun giveGreatPersonToPatron(receivingCiv: Civilization) {
@@ -129,7 +131,8 @@ class CityStateFunctions(val civInfo: Civilization) {
                 && !it.hasUnique(UniqueType.MayFoundReligion) }
         if (giftableUnits.isEmpty()) // For badly defined mods that don't have great people but do have the policy that makes city states grant them
             return
-        val giftedUnit = giftableUnits.random()
+        val rng = civInfo.getDiplomacyManager(receivingCiv)!!.state.stateBasedRandom("CityStateFunctions.giveGreatPersonToPatron")
+        val giftedUnit = giftableUnits.random(rng)
         val city = NextTurnAutomation.getForeignCityNearCapital(civInfo.getCapital(), receivingCiv)?.city ?: return
         val placedUnit = receivingCiv.units.placeUnitNearTile(city.location.toHexCoord(), giftedUnit)
             ?: return
@@ -140,6 +143,7 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     fun giveMilitaryUnitToPatron(receivingCiv: Civilization) {
         val city = NextTurnAutomation.getForeignCityNearCapital(civInfo.getCapital(), receivingCiv)?.city ?: return
+        val rng = civInfo.getDiplomacyManager(receivingCiv)!!.state.stateBasedRandom("CityStateFunctions.giveGreatPersonToPatron")
 
         @Readonly
         fun giftableUniqueUnit(): BaseUnit? {
@@ -159,7 +163,7 @@ class CityStateFunctions(val civInfo: Civilization) {
                 .filter { it.getResourceRequirementsPerTurn(receivingCiv.state).none {
                     it.value > 0 && receivingCiv.getResourceAmount(it.key) < it.value
                 } }
-                .toList().randomOrNull()
+                .toList().randomOrNull(rng)
         
         val militaryUnit = giftableUniqueUnit() // If the receiving civ has discovered the required tech and not the obsolete tech for our unique, always give them the unique
             ?: randomGiftableUnit() // Otherwise pick at random
@@ -513,13 +517,14 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     fun tributeWorker(demandingCiv: Civilization) {
         if (!civInfo.isCityState) throw Exception("You can only demand workers from City-States!")
+        val rng = civInfo.getDiplomacyManager(demandingCiv)!!.state.stateBasedRandom("CityStateFunctions.tributeWorker")
 
         val buildableWorkerLikeUnits = civInfo.gameInfo.ruleset.units.filter {
             it.value.hasUnique(UniqueType.BuildImprovements) &&
                 it.value.isCivilian() && it.value.isBuildable(civInfo)
         }
         if (buildableWorkerLikeUnits.isEmpty()) return  // Bad luck?
-        demandingCiv.units.placeUnitNearTile(civInfo.getCapital()!!.location.toHexCoord(), buildableWorkerLikeUnits.values.random())
+        demandingCiv.units.placeUnitNearTile(civInfo.getCapital()!!.location.toHexCoord(), buildableWorkerLikeUnits.values.random(rng))
 
         civInfo.getDiplomacyManager(demandingCiv)!!.addInfluence(-50f)
         cityStateBullied(demandingCiv)

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -183,6 +183,15 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
             _otherCiv = civInfo.gameInfo.getCivilization(otherCivName)
         return _otherCiv
     }
+    
+    @Cache
+    @Transient
+    private lateinit var _context: GameContext
+    @get:Readonly val state: GameContext get() {
+        if (!::_context.isInitialized)
+            _context = GameContext(civInfo, otherCiv)
+        return _context
+    }
 
     // since this needs to be checked a lot during travel, putting it in a transient is a good performance booster
     @Transient

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -269,6 +269,7 @@ object DiplomacyTurnManager {
     }
 
     private fun DiplomacyManager.nextTurnDiplomaticModifiers() {
+        val rng = state.stateBasedRandom("DiplomacyManager.nextTurnDiplomaticModifiers")
         if (diplomaticStatus == DiplomaticStatus.Peace)
             accumulateToAtMost(DiplomaticModifiers.YearsOfPeace, 0.5f, 30f)
         else
@@ -344,7 +345,7 @@ object DiplomacyTurnManager {
             return
         }
 
-        val variance = listOf(-1, 0, 1).random()
+        val variance = listOf(-1, 0, 1).random(rng)
 
         val provideMilitaryUnitUniques = CityStateFunctions
             .getCityStateBonuses(otherCiv.cityStateType, relationshipIgnoreAfraid(), UniqueType.CityStateMilitaryUnits)

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -45,9 +45,10 @@ class EspionageManager : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun getSpyName(): String {
+        val rng = civInfo.state.stateBasedRandom("EspianageManager.getSpyName")
         val usedSpyNames = spyList.map { it.name }.toHashSet()
         val validSpyNames = civInfo.nation.spyNames.filter { it !in usedSpyNames }
-        return validSpyNames.randomOrNull()
+        return validSpyNames.randomOrNull(rng)
             ?: "Spy ${spyList.size + 1}" // +1 as non-programmers count from 1
     }
 

--- a/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
@@ -208,7 +208,9 @@ class QuestManager : IsPartOfGameInfoSerialization {
     @Readonly private fun getQuests(predicate: (Quest) -> Boolean) = ruleset.quests.values.filter(predicate)
 
     // by turn so the same civ doesn't give the same quests always, and by civID so on the same turn different civs give different quests
-    @Readonly private fun getRandom() = Random(civ.gameInfo.turns + civ.civID.hashCode())
+    @Readonly private fun getRandom() = civ.state.stateBasedRandom("QuestManager")
+    @Readonly private fun getRandom(challenger: Civilization?) = if (challenger == null) getRandom() 
+        else civ.getDiplomacyManager(challenger)?.state?.stateBasedRandom("QuestManager") ?: getRandom()
     
     private fun tryStartNewGlobalQuest() {
         if (globalQuestCountdown != 0)
@@ -244,7 +246,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
             val assignableQuests = getQuests { it.isIndividual() && isQuestValid(it, challenger) }
 
             if (assignableQuests.isNotEmpty()) {
-                val quest = assignableQuests.randomWeighted(getRandom()) { getQuestWeight(it.name) }
+                val quest = assignableQuests.randomWeighted(getRandom(challenger)) { getQuestWeight(it.name) }
                 val assignees = arrayListOf(challenger)
 
                 assignNewQuest(quest, assignees)
@@ -333,7 +335,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
 
             when (quest.questNameInstance) {
                 QuestName.ClearBarbarianCamp -> {
-                    val camp = getBarbarianEncampmentForQuest()!!
+                    val camp = getBarbarianEncampmentForQuest(assignee)!!
                     data1 = camp.position.x.toString()
                     data2 = camp.position.y.toString()
                     notificationActions = listOf(LocationAction(camp.position), notificationActions.first())
@@ -399,7 +401,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
             return false
 
         return when (quest.questNameInstance) {
-            QuestName.ClearBarbarianCamp -> getBarbarianEncampmentForQuest() != null
+            QuestName.ClearBarbarianCamp -> getBarbarianEncampmentForQuest(challenger) != null
             QuestName.Route -> isRouteQuestValid(challenger)
             QuestName.ConnectResource -> getResourceForQuest(challenger) != null
             QuestName.ConstructWonder -> getWonderToBuildForQuest(challenger) != null
@@ -773,11 +775,11 @@ class QuestManager : IsPartOfGameInfoSerialization {
      * to be destroyed
      */
     @Readonly
-    private fun getBarbarianEncampmentForQuest(): Tile? {
+    private fun getBarbarianEncampmentForQuest(challenger: Civilization? = null): Tile? {
         val encampments = civ.getCapital()!!.getCenterTile().getTilesInDistance(8)
                 .filter { it.improvement == Constants.barbarianEncampment }.toList()
 
-        return encampments.randomOrNull(getRandom())
+        return encampments.randomOrNull(getRandom(challenger))
     }
 
     /**
@@ -800,7 +802,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                     !ownedByMajorResources.contains(it)
         }.toList()
 
-        return notOwnedResources.randomOrNull(getRandom())
+        return notOwnedResources.randomOrNull(getRandom(challenger))
     }
 
     @Readonly
@@ -820,7 +822,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                     && civ.gameInfo.getCities().none { it.cityConstructions.isBuilt(building.name) || isMoreThanAQuarterDone(it, building.name) }
                 }
 
-        return wonders.randomOrNull(getRandom())
+        return wonders.randomOrNull(getRandom(challenger))
     }
 
     /**
@@ -833,7 +835,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
         civ.gameInfo.tileMap.naturalWonders
             .subtract(challenger.naturalWonders)
             .subtract(civ.naturalWonders)
-            .randomOrNull(getRandom())
+            .randomOrNull(getRandom(challenger))
 
     /**
      * Returns a Great Person [BaseUnit] that is not owned by both the [challenger] and the [civ]
@@ -855,7 +857,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                 .filterNot { it in existingGreatPeople || it.isUnavailableBySettings(civ.gameInfo) }
                 .toList()
 
-        return greatPeople.randomOrNull(getRandom())
+        return greatPeople.randomOrNull(getRandom(challenger))
     }
 
     /**
@@ -868,7 +870,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
             .filter { it.isAlive() && it.isMajorCiv() && !challenger.hasMetCivTerritory(it) }
             .toList()
 
-        return civilizationsToFind.randomOrNull(getRandom())
+        return civilizationsToFind.randomOrNull(getRandom(challenger))
     }
 
     /**
@@ -885,7 +887,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
         val validTargets = civ.getKnownCivs().filter { it.isCityState && challenger.knows(it)
                 && civ.proximity[it.civID] == closestProximity }
 
-        return validTargets.toList().randomOrNull(getRandom())
+        return validTargets.toList().randomOrNull(getRandom(challenger))
     }
 
     /** Returns a [Civilization] of the civ that most recently bullied [civ].

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -110,9 +110,10 @@ class TurnManager(val civInfo: Civilization) {
             if (!civInfo.flagsCountdown.containsKey(flag)) continue
 
             if (flag == CivFlags.CityStateGreatPersonGift.name) {
+                val rng = civInfo.state.stateBasedRandom("TurnManager.startTurnFlags")
                 val cityStateAllies: List<Civilization> =
                         civInfo.getKnownCivs().filter { it.isCityState && it.allyCiv == civInfo }.toList()
-                val givingCityState = cityStateAllies.filter { it.cities.isNotEmpty() }.randomOrNull()
+                val givingCityState = cityStateAllies.filter { it.cities.isNotEmpty() }.randomOrNull(rng)
 
                 if (cityStateAllies.isNotEmpty()) civInfo.flagsCountdown[flag] = civInfo.flagsCountdown[flag]!! - 1
 
@@ -189,7 +190,7 @@ class TurnManager(val civInfo: Civilization) {
             return
         }
 
-        val random = Random.Default
+        val random = civInfo.state.stateBasedRandom("TurnManager.doRevoltSpawn")
         val rebelCount = 1 + random.nextInt(100 + 20 * (civInfo.cities.size - 1)) / 100
         val spawnCity = civInfo.cities.maxByOrNull { random.nextInt(it.population.population + 10) } ?: return
         val spawnTile = spawnCity.getTiles().maxByOrNull { rateTileForRevoltSpawn(it) } ?: return
@@ -233,7 +234,7 @@ class TurnManager(val civInfo: Civilization) {
     
     @Readonly
     private fun getTurnsBeforeRevolt() =
-        ((civInfo.gameInfo.ruleset.modOptions.constants.baseTurnsUntilRevolt + Random.Default.nextInt(3)) 
+        ((civInfo.gameInfo.ruleset.modOptions.constants.baseTurnsUntilRevolt + civInfo.state.stateBasedRandom("TurnManager.getTurnsBeforeRevolt").nextInt(3)) 
             * civInfo.gameInfo.speed.modifier.coerceAtLeast(1f)).toInt()
 
 

--- a/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
@@ -53,6 +53,7 @@ class UnitManager(val civInfo: Civilization) {
      */
     fun addUnit(baseUnit: BaseUnit, city: City? = null): MapUnit? {
         if (civInfo.cities.isEmpty()) return null
+        val rng = (city?.state ?: civInfo.state).stateBasedRandom("UnitManager.addUnit")
 
         val unit = civInfo.getEquivalentUnit(baseUnit)
         val citiesNotInResistance = civInfo.cities.filterNot { it.isInResistance() }
@@ -62,10 +63,10 @@ class UnitManager(val civInfo: Civilization) {
         val cityToAddTo = when {
             unit.isWaterUnit && canSpawnUnitOnWater -> city
             unit.isWaterUnit ->
-                citiesNotInResistance.filter { it.isNaval() }.randomOrNull() ?:
-                civInfo.cities.filter { it.isNaval() }.randomOrNull()
+                citiesNotInResistance.filter { it.isNaval() }.randomOrNull(rng) ?:
+                civInfo.cities.filter { it.isNaval() }.randomOrNull(rng)
             city != null -> city
-            else -> citiesNotInResistance.randomOrNull() ?: civInfo.cities.random()
+            else -> citiesNotInResistance.randomOrNull(rng) ?: civInfo.cities.random(rng)
         } ?: return null // If we got a free water unit with no coastal city to place it in
         val placedUnit = placeUnitNearTile(cityToAddTo.location.toHexCoord(), unit.name)
         // silently bail if no tile to place the unit is found

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/StartNormalizer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/StartNormalizer.kt
@@ -269,7 +269,7 @@ object StartNormalizer {
             candidatePlots.remove(plot) // remove the plot as it has now been tried, whether successfully or not
             if (plot.getBaseTerrain().hasUnique(
                     UniqueType.BlocksResources,
-                    GameContext(attackedTile = plot)
+                    GameContext(attackedTile = plot, gameInfo = null)
                 )
             )
                 continue // Don't put bonuses on snow hills

--- a/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/MapRegionResources.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/MapRegionResources.kt
@@ -34,7 +34,7 @@ object MapRegionResources {
             ResourceType.Bonus -> ImpactType.Bonus
             ResourceType.Luxury -> ImpactType.Luxury
         }
-        val conditionalTerrain = GameContext(attackedTile = tileList.firstOrNull())
+        val conditionalTerrain = GameContext(attackedTile = tileList.firstOrNull(), gameInfo = null)
         val weightings = resourceOptions.associateWith {
             val unique = it.getMatchingUniques(UniqueType.ResourceWeighting, conditionalTerrain).firstOrNull()
             val weight = if (unique != null) unique.params[0].toFloat() else 1f

--- a/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/StrategicBonusResourcePlacementLogic.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/StrategicBonusResourcePlacementLogic.kt
@@ -56,7 +56,7 @@ object StrategicBonusResourcePlacementLogic {
         
         // Now go through the entire map to build lists
         for (tile in tileMap.values.asSequence().shuffled()) {
-            val terrainCondition = GameContext(attackedTile = tile, region = regions.firstOrNull { tile in it.tiles })
+            val terrainCondition = GameContext(attackedTile = tile, region = regions.firstOrNull { tile in it.tiles }, gameInfo = null)
             if (tile.getBaseTerrain().hasUnique(UniqueType.BlocksResources, terrainCondition)) continue // Don't count snow hills
             if (tile.isLand) landList.add(tile)
             for ((rule, list) in ruleLists) {
@@ -230,7 +230,7 @@ object StrategicBonusResourcePlacementLogic {
         for (tile in landList) {
             if (tile.resource != null || tileData[tile.position]!!.impacts.containsKey(ImpactType.Strategic))
                 continue
-            val conditionalTerrain = GameContext(attackedTile = tile)
+            val conditionalTerrain = GameContext(tile = tile)
             if (tile.getBaseTerrain().hasUnique(UniqueType.BlocksResources, conditionalTerrain))
                 continue
             val weightings = strategicResources.map {

--- a/core/src/com/unciv/models/ruleset/unique/GameContext.kt
+++ b/core/src/com/unciv/models/ruleset/unique/GameContext.kt
@@ -13,6 +13,7 @@ import com.unciv.logic.map.tile.Tile
 import com.unciv.models.stats.Stat
 import com.unciv.utils.hashOf
 import yairm210.purity.annotations.Readonly
+import kotlin.random.Random
 
 data class GameContext(
     val civInfo: Civilization? = null,
@@ -25,13 +26,20 @@ data class GameContext(
     val attackedTile: Tile? = null,
     val combatAction: CombatAction? = null,
 
+    val otherCiv: Civilization? = null,
+
     val region: Region? = null,
-    val gameInfo: GameInfo? = civInfo?.gameInfo,
+    // tile and region do not deduce gameInfo because that field is not set during MapGeneration,
+    // and querying if its initialized is non-trivial
+    val gameInfo: GameInfo? = (civInfo?.gameInfo) ?: (city?.civ?.gameInfo) ?: (unit?.civ?.gameInfo) ?:
+        (ourCombatant?.getCivInfo()?.gameInfo) ?: (theirCombatant?.getCivInfo()?.gameInfo) ?: (attackedTile?.tileMap?.gameInfo) ?:
+        (otherCiv?.gameInfo),
 
     val ignoreConditionals: Boolean = false,
 ) {
-    constructor(city: City) : this(city.civ, city, tile = city.getCenterTileOrNull())
-    constructor(unit: MapUnit) : this(unit.civ, unit = unit, tile = if (unit.hasTile()) unit.getTile() else null)
+    constructor(city: City) : this(city.civ, city, tile = city.getCenterTileOrNull(), gameInfo = city.civ.gameInfo)
+    constructor(unit: MapUnit) : this(unit.civ, unit = unit, tile = if (unit.hasTile()) unit.getTile() else null, gameInfo = unit.civ.gameInfo)
+    constructor(civ: Civilization, civ2: Civilization?=null) : this(civ, otherCiv = civ2, gameInfo = civ.gameInfo)
     constructor(ourCombatant: ICombatant, theirCombatant: ICombatant? = null,
                 attackedTile: Tile? = null, combatAction: CombatAction? = null) : this(
         ourCombatant.getCivInfo(),
@@ -41,7 +49,9 @@ data class GameContext(
         ourCombatant,
         theirCombatant,
         attackedTile,
-        combatAction
+        combatAction,
+        theirCombatant?.getCivInfo(),
+        gameInfo = ourCombatant.getCivInfo().gameInfo
     )
 
 
@@ -75,7 +85,11 @@ data class GameContext(
         relevantCity?.civ ?:
         relevantUnit?.civ
     }
-
+    
+    @Readonly
+    fun stateBasedRandom(caller: String, seed: Int=31) =
+        Random(hashOf(caller.hashCode(), seed, this.hashCode()))
+        
     @Readonly
     fun getResourceAmount(resourceName: String): Int {
         return when {
@@ -108,7 +122,9 @@ data class GameContext(
         fun Civilization?.hash() = this?.civID?.hashCode() ?: 0
         fun City?.hash() = this?.id?.hashCode() ?: 0
         fun Tile?.hash() = this?.position?.hashCode() ?: 0
-        fun MapUnit?.hash() = if (this == null) 0 else name.hashCode() + (if (hasTile()) 17 * currentTile.hash() else 0)
+        fun MapUnit?.hash() = if (this == null) 0 else name.hashCode() +
+            (if (hasTile()) 17 * currentTile.hash() else 0) +
+            (17 * currentMovement).hashCode()
         fun ICombatant?.hash() = if (this == null) 0
             else if (this is MapUnitCombatant) unit.hash()  // line only serves as `lateinit currentTile not initialized` guard
             else getName().hashCode() + 17 * getTile().hash()
@@ -116,6 +132,8 @@ data class GameContext(
         fun Region?.hash() = this?.rect?.hashCode() ?: 0
 
         val hash = hashOf(
+            gameInfo?.turns?.hashCode() ?: 0,
+            (gameInfo?.gameId?.hashCode() ?: gameInfo?.tileMap?.mapParameters?.seed?.hashCode() ?: 0),
             relevantCiv.hash(),
             relevantCity.hash(),
             relevantUnit.hash(),
@@ -124,6 +142,7 @@ data class GameContext(
             theirCombatant.hash(),
             attackedTile.hash(),
             combatAction.hash(),
+            otherCiv.hash(),
             region.hash(),
             ignoreConditionals.hashCode()
         )

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -351,10 +351,11 @@ object UniqueTriggerActivation {
                     civUnit = civInfo.getEquivalentUnit(replacementUnit.name)
                 }
 
-                val placingTile =
-                    tile ?: civInfo.cities.random().getCenterTile()
 
                 fun placeUnit(): Boolean {
+                    val rng = (unit?.cache?.state ?: civInfo.state).stateBasedRandom("UniqueTriggerActivation.getTriggerFunction") 
+                    val placingTile =
+                        tile ?: civInfo.cities.random(rng).getCenterTile()
                     val placedUnit = civInfo.units.placeUnitNearTile(placingTile.position, civUnit.name)
                     if (notification != null && placedUnit != null) {
                         val notificationText =

--- a/tests/src/com/unciv/logic/GameSerializationTests.kt
+++ b/tests/src/com/unciv/logic/GameSerializationTests.kt
@@ -89,11 +89,7 @@ class GameSerializationTests {
 
     @Test
     fun canSerializeGame() {
-        val json = try {
-            json().toJson(game)
-        } catch (_: Exception) {
-            ""
-        }
+        val json = json().toJson(game)
         Assert.assertTrue("This test will only pass when a game can be serialized", json.isNotEmpty())
     }
 
@@ -105,12 +101,7 @@ class GameSerializationTests {
             setDeprecated(classSynchronizedLazyImpl, "lock", true)  // this is the culprit as kotlin initializes it to `this@SynchronizedLazyImpl`
         }
 
-        val json = try {
-            jsonSerializer.toJson(game)
-        } catch (ex: Throwable) {
-            Log.error("Failed to serialize game", ex)
-            return
-        }
+        val json =  jsonSerializer.toJson(game)
 
         val pattern = """\{(\w+)\\${'$'}delegate:\{class:kotlin.SynchronizedLazyImpl,"""
         val matches = Regex(pattern).findAll(json)


### PR DESCRIPTION
- GameContext can refer to a second Civ, for Diplomacy and such
- GameContext now includes the turn number, and unit movement in the hash.
- GameContext now has a Random instance based on its hash

This allows each *state* to have a separate Random instance, so if we primarily used cached state instances, then given the same user inputs, then the game will make the same decisions, including (sometimes) if user inputs were in a different order.

I've replaced *some* uses of .random() with these state randoms, when there was already a cached GameContext instance.

There are still a lot of .random(), .randomOrNull(), Random(), and Random.Default remaining.