### PR TITLE
BuildAndTest runs in `yairm210/unciv:main`.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -4,7 +4,7 @@ name: Build and test
 on:
   # Triggers the workflow on any push or pull request
   push:
-  pull_request:
+  pull_request_target:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Before this, the workflow runs on my Ambeco/unciv repository, and contributors never have access to the token information since their forked repository doesn't have the secret key, causing presubmit failures sometimes. https://github.com/yairm210/Unciv/pull/14693

The pull_request_target event runs in the main branch of the original repository. So, even if I'm working on the Ambeco/unciv repository, the workflow runs in the main branch of the yairm210/unciv repository. This way, contributors can benefit from the workflow because the secret key exists in the yairm/210 repository.

See https://github.com/eslint/workflows/pull/11 for another repo that hit this issue.

 To be fair, I don't know why sometimes PRs worked and sometimes they didn't.  Or if this will work or have unknown side effects :(