### PR TITLE
Confirmation popup before breaking promise not to spy

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -197,6 +197,7 @@ We have cancelled our Defensive Pact with [civName]! =
 [civName] and [targetCivName] have signed a Declaration of Friendship! = 
 [civName] has denounced [targetCivName]! = 
 Do you want to break your promise to [leaderName]? = 
+This may result in breaking your promise to [civName] = 
 Break promise = 
 
 [civName] is upset that you demanded tribute from [cityState], whom they have pledged to protect! = 

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -9,6 +9,7 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.models.Spy
 import com.unciv.models.SpyAction
 import com.unciv.models.translations.tr
@@ -225,9 +226,26 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
             arrow.setOrigin(Align.center)
             arrow.color = Color.WHITE
             onClick {
-                selectedSpy!!.moveTo(city)
-                resetSelection()
-                update()
+                fun move() {
+                    selectedSpy!!.moveTo(city)
+                    resetSelection()
+                    update()
+                }
+                if (city != null
+                    && civInfo.isHuman()
+                    && city.civ.civName != civInfo.civName
+                    && city.civ.isMajorCiv()
+                    && city.civ.getDiplomacyManager(civInfo)!!.hasFlag(DiplomacyFlags.AgreedToNotSendSpies)) {
+                    ConfirmPopup(
+                        UncivGame.Current.screen!!,
+                        // The promise isn't broken when you move the spy - only when they catch you stealing a tech
+                        "This may result in breaking your promise to [${city.civ.civName}]",
+                        "Move",
+                        action = ::move
+                    ).open(force = true)
+                } else {
+                    move()
+                }
             }
             spyActionButtons[this] = city
             isVisible = false

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -232,7 +232,6 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
                     update()
                 }
                 if (city != null
-                    && civInfo.isHuman()
                     && city.civ.civName != civInfo.civName
                     && city.civ.isMajorCiv()
                     && city.civ.getDiplomacyManager(civInfo)!!.hasFlag(DiplomacyFlags.AgreedToNotSendSpies)) {


### PR DESCRIPTION
Promise not to spy on Sweden, then attempt to move a spy to Stockholm:
<img width="1183" height="574" alt="image" src="https://github.com/user-attachments/assets/1ceaab75-de06-4104-b096-6d80561a3d61" />

Added 1 translation.
Reused the "Move" translation.