### PR TITLE
Do not forcibly reset mod selections after closing warning in new game screen

### DIFF
--- a/core/src/com/unciv/ui/screens/newgamescreen/AcceptModErrorsPopup.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/AcceptModErrorsPopup.kt
@@ -10,14 +10,12 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 internal class AcceptModErrorsPopup(
     screen: BaseScreen,
     modCheckResult: String,
-    restoreDefault: () -> Unit,
     action: () -> Unit
 ) : ConfirmPopup(
     screen,
     question = "",  // do coloured label instead
     confirmText = "Accept",
     isConfirmPositive = false,
-    restoreDefault = restoreDefault,
     action = action
 ) {
     init {

--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -528,15 +528,6 @@ class GameOptionsTable(
         modCheckboxes.setBaseRuleset(gameParameters.baseRuleset)
     }
 
-    fun resetRuleset() {
-        val rulesetName = BaseRuleset.Civ_V_GnK.fullName
-        gameParameters.baseRuleset = rulesetName
-        modCheckboxes.setBaseRuleset(rulesetName)
-        modCheckboxes.disableAllCheckboxes()
-        baseRulesetSelectBox?.setSelected(rulesetName)
-        reloadRuleset()
-    }
-
     private fun reloadRuleset() {
         ruleset.clear()
         val newRuleset = RulesetCache.getComplexRuleset(gameParameters)

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -140,7 +140,7 @@ class NewGameScreen(
                 Concurrency.runOnGLThread {
                     AcceptModErrorsPopup(
                         this@NewGameScreen, modCheckResult,
-                        restoreDefault = { newGameOptionsTable.resetRuleset() },
+                        restoreDefault = { }, 
                         action = {
                             gameSetupInfo.gameParameters.acceptedModCheckErrors = modCheckResult
                             startGameAvoidANRs()

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -140,7 +140,6 @@ class NewGameScreen(
                 Concurrency.runOnGLThread {
                     AcceptModErrorsPopup(
                         this@NewGameScreen, modCheckResult,
-                        restoreDefault = { }, 
                         action = {
                             gameSetupInfo.gameParameters.acceptedModCheckErrors = modCheckResult
                             startGameAvoidANRs()


### PR DESCRIPTION
From [issue](https://github.com/yairm210/Unciv/issues/14730).

Previously: click button to start new game (while having mod compatibility issues) -> confirmation popup with warning -> cancel -> resets all ruleset and mod selections.
I can see how this is frustrating. If the player wants to reset the settings, they can click the reset to defaults button.

Shame to remove the resetRuleset method, but it's not used elsewhere.