### PR TITLE
Add back option to disable rendering of unitset in display settings

### DIFF
--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -156,7 +156,8 @@ internal class DisplayTab(
 
     private fun addUnitSetSelectBox() {
         val nullValue = "None".tr()
-        addSelectBox("Unitset", settings::unitSet, ImageGetter.getAvailableUnitsets().asIterable()) { value, _ ->
+        val choices = sequenceOf(nullValue) + ImageGetter.getAvailableUnitsets()
+        addSelectBox("Unitset", settings::unitSet, choices.asIterable()) { value, _ ->
             if (value == nullValue) settings.unitSet = null
             // ImageGetter ruleset should be correct no matter what screen we're on
             TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)


### PR DESCRIPTION
Adds an option "None" in the dropdown for Unitset in display settings. Selecting it will cause no units to render, which is preferred by some :hand: 

From [issue](https://github.com/yairm210/Unciv/issues/14750).