### PR TITLE
Allow beliefs gotten from triggers to use triggerables

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -421,7 +421,7 @@ object UniqueTriggerActivation {
                         true
                     }
                     belief != null && civInfo.religionManager.religion?.hasBelief(name) == false -> return {
-                        civInfo.religionManager.religion?.addBelief(belief)
+                        civInfo.religionManager.chooseBeliefs(listOf(belief))
                         getNotificationText(notification, triggerNotificationText, "You gain the [$name] Belief")?.let {
                             civInfo.addNotification(it, NotificationCategory.Religion, NotificationIcon.Faith)
                         }


### PR DESCRIPTION
The previous code used ``Religion.addBelief``, which adds the belief _without side effects_. This very much does not match up with modder or player expectations, especially since other similar triggerables (including this one when used for policies) don't behavor like this

----------------

Is there a reason ``chooseBeliefs`` always clears the free beliefs, even when we aren't using them?

Also, there is a timing problem between this and prophets. You can found/enhance a religion, then get this trigger. In which case, ``chooseBeliefs`` will happily complete the founding/enhancing process not knowing the wrong function called it. I get the impression that this function needs a refactor