### PR TITLE
Clicking Bully or Conquer CS quest centers map on target's capital

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
@@ -1006,6 +1006,18 @@ class AssignedQuest : IsPartOfGameInfoSerialization {
                 GUI.resetToWorldScreen()
                 GUI.getMap().setCenterPosition(assignerCiv.getCapital()!!.location.toHexCoord(), selectUnit = false)
             }
+            QuestName.BullyCityState, QuestName.ConquerCityState -> {
+                // In case they were destroyed after issuing the quest
+                val targetCs = gameInfo.getAliveCityStates().firstOrNull { it.civID == data1 }
+                if (targetCs != null) {
+                    // Did they even settle their first city?
+                    val capital = targetCs.getCapital()
+                    if (capital != null) {
+                        GUI.resetToWorldScreen()
+                        GUI.getMap().setCenterPosition(capital.location.toHexCoord(), selectUnit = false)
+                    }
+                }
+            }
             else -> Unit
         }
     }


### PR DESCRIPTION
Clicking the bully quest...
<img width="1071" height="1058" alt="image" src="https://github.com/user-attachments/assets/0d679837-a73d-4428-a050-1e366775b62a" />
...centers the map on the capital of the target CS
<img width="1187" height="951" alt="image" src="https://github.com/user-attachments/assets/fa95be7f-5de9-48e7-a400-d6b48c158a0c" />
