### PR TITLE
Android can receive links directly to games or new friends

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -47,7 +47,24 @@
                     android:scheme="https"
                     android:host="unciv.app"
                     android:path="/multiplayer"
-                />
+                    />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SENDTO" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="yairm210.github.io" />
+                <data android:pathPrefix="/Unciv/G/" />
+                <data android:pathPrefix="/Unciv/g/" />
+                <data android:pathPrefix="/unciv/G/" />
+                <data android:pathPrefix="/unciv/g/" />
+                <data android:pathPrefix="/Unciv/P/" />
+                <data android:pathPrefix="/Unciv/p/" />
+                <data android:pathPrefix="/unciv/P/" />
+                <data android:pathPrefix="/unciv/p/" />
             </intent-filter>
         </activity>
 

--- a/android/src/com/unciv/app/AndroidGame.kt
+++ b/android/src/com/unciv/app/AndroidGame.kt
@@ -12,10 +12,12 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.backends.android.AndroidGraphics
 import com.badlogic.gdx.math.Rectangle
 import com.unciv.UncivGame
+import com.unciv.logic.IdChecker
 import com.unciv.logic.event.EventBus
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.UncivStage
 import com.unciv.utils.Concurrency
+import com.unciv.utils.isUUID
 
 class AndroidGame(private val activity: Activity) : UncivGame() {
 
@@ -74,10 +76,15 @@ class AndroidGame(private val activity: Activity) : UncivGame() {
     /** This is needed in onCreate _and_ onNewIntent to open links and notifications
      *  correctly even if the app was not running */
     fun setDeepLinkedGame(intent: Intent) {
-        deepLinkedMultiplayerGame = if (intent.action != Intent.ACTION_VIEW) null else {
-            val uri: Uri? = intent.data
-            uri?.getQueryParameter("id")
+        if (intent.action != Intent.ACTION_VIEW) {
+            deepLinkedMultiplayerGame = null
         }
+        val uri: Uri? = intent.data
+        val idParam = uri?.getQueryParameter("id") //legacy game url
+        deepLinkedMultiplayerGame = 
+            if (idParam != null && idParam.isUUID()) idParam
+            else if (IdChecker.isGameDeepLink(uri.toString())) IdChecker.checkAndReturnUuiId(uri.toString())
+            else null
     }
 
     fun isInitializedProxy() = super.isInitialized

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -6,10 +6,15 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.work.WorkManager
 import com.badlogic.gdx.backends.android.AndroidApplication
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration
+import com.unciv.logic.IdChecker
 import com.unciv.logic.files.UncivFiles
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.screens.multiplayerscreens.AddFriendScreen
+import com.unciv.utils.Concurrency.runOnGLThread
+import com.unciv.utils.Dispatcher
 import com.unciv.utils.Display
 import com.unciv.utils.Log
+import com.unciv.utils.launchOnGLThread
 import java.io.File
 import java.lang.Exception
 import kotlinx.coroutines.CoroutineScope
@@ -54,8 +59,12 @@ open class AndroidLauncher : AndroidApplication() {
         game = AndroidGame(this)
         initialize(game, config)
 
+        // can be triggered via `adb shell am start -a android.intent.action.VIEW -d https://unciv.app/g/G-ef0f5e5a-f1db-4a54-9d94-92ca986afe8a-9 com.unciv.app`
+        // or whatever your game id is
         game!!.setDeepLinkedGame(intent)
         game!!.addScreenObscuredListener()
+        processPossibleFriendDeepLink(intent)
+        
     }
 
     /**
@@ -116,6 +125,19 @@ open class AndroidLauncher : AndroidApplication() {
         if (intent == null)
             return
         game?.setDeepLinkedGame(intent)
+        processPossibleFriendDeepLink(intent)
+    }
+    
+    private fun processPossibleFriendDeepLink(intent: Intent) {
+        // can be triggered via 
+        // `adb shell am start -a android.intent.action.VIEW -d https://unciv.app/p/P-63971008-a533-47f6-ad6a-57b616626138-9?name=Yairm210 com.unciv.app`
+        // or whatever your friend id and name are
+        if (intent.data != null && IdChecker.isFriendDeepLink(intent.data.toString())) {
+            val newFriend = IdChecker.checkAndReturnPlayerUuid(intent.data.toString())
+            if (newFriend != null) runOnGLThread {
+                game!!.pushScreen(AddFriendScreen(newFriend.name, newFriend.playerID))
+            }
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -162,7 +162,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
             Log.i(LOG_TAG, "notifyUserAboutTurn ${game.first}")
             val intent = Intent(applicationContext, AndroidLauncher::class.java).apply {
                 action = Intent.ACTION_VIEW
-                data = Uri.parse("https://unciv.app/multiplayer?id=${game.second}")
+                data = Uri.parse("https://unciv.app/${game.second}")
             }
             val flags = (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) FLAG_IMMUTABLE else 0) or
                     FLAG_UPDATE_CURRENT

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ allprojects {
     apply(plugin = "io.github.yairm210.purity-plugin")
     configure<yairm210.purity.PurityConfiguration> {
         wellKnownPureFunctions = setOf(
+            "io.ktor.http.Url", //constructor
         )
         wellKnownReadonlyFunctions = setOf(
             "com.badlogic.gdx.math.Vector2.len",
@@ -73,9 +74,15 @@ allprojects {
             "java.util.stream.StreamSupport.longStream",
             "java.util.stream.LongStream.parallel",
             "kotlin.sequences.shuffled",
+            
             "kotlin.LongArray.get",
             "kotlin.LongArray.iterator",
             "kotlin.collections.copyInto",
+            "kotlin.collections.List.get",
+            
+            "io.ktor.http.Url.segments",
+            "io.ktor.http.Url.parameters",
+            "io.ktor.http.Parameters.get",
         )
         wellKnownPureClasses = setOf(
         )

--- a/core/src/com/unciv/logic/IdChecker.kt
+++ b/core/src/com/unciv/logic/IdChecker.kt
@@ -1,5 +1,12 @@
 package com.unciv.logic
 
+import com.unciv.logic.multiplayer.FriendList.Friend
+import com.unciv.utils.Log
+import com.unciv.utils.isUUID
+import com.unciv.utils.softRequire
+import io.ktor.http.URLParserException
+import io.ktor.http.Url
+import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Pure
 import java.util.Locale
 import kotlin.math.abs
@@ -23,35 +30,85 @@ import kotlin.math.abs
  * G-2ddb3a34-0699-4126-b7a5-38603e665928-5
  */
 object IdChecker {
+    const val uncivUrlPrefix = "https://yairm210.github.io/Unciv/"
 
     @Pure
-    fun checkAndReturnPlayerUuid(playerId: String): String? {
-        return checkAndReturnUuiId(playerId, "P")
+    fun isGameDeepLink(url: String) = url.startsWith(uncivUrlPrefix + "G/", ignoreCase = true)
+    @Pure
+    fun isFriendDeepLink(url: String) = url.startsWith(uncivUrlPrefix + "P/", ignoreCase = true)
+    
+    @Pure
+    fun checkAndReturnPlayerUuid(playerId: String): Friend? {
+        return checkAndReturnId(playerId, "P")
     }
 
     @Pure
-    fun checkAndReturnGameUuid(gameId: String): String? {
-        return checkAndReturnUuiId(gameId, "G")
+    fun checkAndReturnUuiId(gameId: String): String? {
+        return checkAndReturnId(gameId, "G")?.playerID
+    }
+    
+    @Pure
+    private fun checkAndReturnId(id: String, prefix: String): Friend? {
+        val trimmedId = id.trim(spaceOrWrapperPredicate)
+        return if (trimmedId.startsWith(uncivUrlPrefix, ignoreCase = true))
+            checkAndReturnIdFromUrl(trimmedId, prefix)
+        else checkAndReturnUuiId(trimmedId, prefix)?.let { Friend("", it) }
+    }
+
+    // parses urls like "http://unciv.app/G/G-2ddb3a34-0699-4126-b7a5-38603e665928-2"
+    // or "http://unciv.app/P-2ddb3a34-0699-4126-b7a5-38603e665928-2?name=%C4%90%E1%BA%B7ng"
+    @Pure
+    private fun checkAndReturnIdFromUrl(id: String, prefix: String): Friend? {
+        @LocalState
+        val url = try {
+            Url(id)
+        } catch (e: URLParserException) {
+            Log.error("invalid format for url $id", e)
+            return null
+        }
+        @LocalState
+        val segments = url.segments
+        @LocalState
+        val parameters = url.parameters
+        softRequire(segments.size==3, "url %s should be in \"Unciv\\G\" path", id) ?: return null
+        softRequire(segments[0].equals("Unciv", ignoreCase=true), "%s url %s is not an \"Unciv\" link", id, segments[0]) ?: return null
+        softRequire(segments[1].equals(prefix, ignoreCase=true), "%s url %s has incorrect prefix %s", prefix, id, segments[0]) ?: return null
+        val gameId = checkAndReturnUuiId(segments[2], prefix, id) ?: return null
+        val name = parameters["name"] ?: ""
+        return Friend(name, gameId)
     }
 
     @Pure
-    private fun checkAndReturnUuiId(id: String, prefix: String): String? {
-        val trimmedPlayerId = id.trim()
+    private fun checkAndReturnUuiId(id: String, prefix: String, url:String = id): String? {
+        val trimmedPlayerId = id.trim(spaceOrWrapperPredicate)
         if (trimmedPlayerId.length == 40) { // length of a UUID (36) with pre- and postfix
-            if (!trimmedPlayerId.startsWith(prefix, true))
+            if (!trimmedPlayerId.startsWith(prefix, true)) {
+                Log.error("$prefix uuid $url has incorrect prefix")
                 return null
+            }
 
             val checkDigit = trimmedPlayerId.substring(trimmedPlayerId.lastIndex, trimmedPlayerId.lastIndex + 1)
             // remember, the format is: P-9e37e983-a676-4ecc-800e-ef8ec721a9b9-5
             val shortenedPlayerId = trimmedPlayerId.substring(2, 38)
             val calculatedCheckDigit = getCheckDigit(shortenedPlayerId)
-            if (calculatedCheckDigit == null || calculatedCheckDigit.toString() != checkDigit)
+            if (calculatedCheckDigit == null || calculatedCheckDigit.toString() != checkDigit) {
+                Log.error("$prefix uuid $url has incorrect checkDigit $checkDigit")
                 return null
+            }
 
+            if (!shortenedPlayerId.isUUID()) {
+                Log.error("invalid uuid $url")
+                return null
+            }
             return shortenedPlayerId
         } else if (trimmedPlayerId.length == 36) {
+            if (!trimmedPlayerId.isUUID()) {
+                Log.error("invalid uuid $url")
+                return null
+            }
             return trimmedPlayerId
         }
+        Log.error("$prefix uuid $url has incorrect length")
         return null
     }
 
@@ -112,5 +169,20 @@ object IdChecker {
         // check digit is amount needed to reach next number
         // divisible by ten
         return (10 - (sum % 10)) % 10
+    }
+    
+    private val spaceOrWrapperPredicate: (Char)->Boolean = {
+        // trim spaces, parenthesis, quotation marks, periods, commas, newlines, etc.
+        // We do NOT drop hyphens or connectors.
+        when (Character.getType(it).toByte()) {
+            Character.SPACE_SEPARATOR,
+            Character.START_PUNCTUATION,
+            Character.END_PUNCTUATION,
+            Character.INITIAL_QUOTE_PUNCTUATION,
+            Character.FINAL_QUOTE_PUNCTUATION,
+            Character.OTHER_PUNCTUATION,
+            Character.CONTROL -> true
+            else -> false
+        }
     }
 }

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/AddFriendScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/AddFriendScreen.kt
@@ -15,11 +15,14 @@ import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.utils.isUUID
 
-class AddFriendScreen : PickerScreen() {
+class AddFriendScreen(
+    initialName: String = "",
+    initialID: String = ""
+) : PickerScreen() {
     init {
-        val friendNameTextField = UncivTextField("Please input a name for your friend!")
+        val friendNameTextField = UncivTextField("Please input a name for your friend!", initialName)
         val pastePlayerIDButton = "Paste player ID from clipboard".toTextButton()
-        val playerIDTextField = UncivTextField("Please input a player ID for your friend!")
+        val playerIDTextField = UncivTextField("Please input a player ID for your friend!", initialID)
         val friendlist = FriendList()
 
         topTable.add("Friend name".toLabel()).row()
@@ -45,10 +48,13 @@ class AddFriendScreen : PickerScreen() {
         rightSideButton.setText("Add friend".tr())
         rightSideButton.enable()
         rightSideButton.onClick {
-            if (!(IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text)?.isUUID() ?: false)) {
+            val friend = IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text)
+            if (friend?.playerID?.isUUID() != true) {
                 ToastPopup("Player ID is incorrect", this)
                 return@onClick
             }
+            if (friendNameTextField.text.isEmpty() && friend.name.isNotEmpty())
+                friendNameTextField.text = friend.name
 
             when (friendlist.add(friendNameTextField.text, playerIDTextField.text)) {
                 FriendList.ErrorType.NAME -> ToastPopup("Friend name is already in your friends list!", this)

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/AddMultiplayerGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/AddMultiplayerGameScreen.kt
@@ -48,7 +48,7 @@ class AddMultiplayerGameScreen(multiplayerScreen: MultiplayerScreen) : PickerScr
         rightSideButton.enable()
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)
         rightSideButton.onActivation {
-            if (!(IdChecker.checkAndReturnGameUuid(gameIDTextField.text)?.isUUID() ?: false)) {
+            if (!(IdChecker.checkAndReturnUuiId(gameIDTextField.text)?.isUUID() ?: false)) {
                 ToastPopup("Invalid game ID!", this)
                 return@onActivation
             }

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/EditFriendScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/EditFriendScreen.kt
@@ -75,10 +75,14 @@ class EditFriendScreen(selectedFriend: FriendList.Friend) : PickerScreen() {
                 ToastPopup("Player ID already used!", this)
                 return@onClick
             }
-            if (!(IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text)?.isUUID() ?: false)) {
+            val friend = IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text)
+            if (friend?.playerID?.isUUID() != true) {
                 ToastPopup("Player ID is incorrect", this)
                 return@onClick
             }
+            if (friendNameTextField.text.isEmpty() && friend.name.isNotEmpty())
+                friendNameTextField.text = friend.name
+            
             friendlist.edit(selectedFriend, friendNameTextField.text, playerIDTextField.text)
             goBack()
         }

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -161,7 +161,7 @@ class NewGameScreen(
                     else "Couldn't connect to Dropbox!"
 
             for (player in gameSetupInfo.gameParameters.players.filter { it.playerType == PlayerType.Human }) {
-                if (!(IdChecker.checkAndReturnPlayerUuid(player.playerId)?.isUUID() ?: false)) {
+                if (!(IdChecker.checkAndReturnPlayerUuid(player.playerId)?.playerID?.isUUID() ?: false)) {
                     return "Invalid player ID!"
                 }
             }

--- a/core/src/com/unciv/ui/screens/newgamescreen/PlayerPickerTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/PlayerPickerTable.kt
@@ -246,7 +246,8 @@ class PlayerPickerTable(
         add(errorLabel).pad(5f).row()
 
         fun onPlayerIdTextUpdated() {
-            if (IdChecker.checkAndReturnPlayerUuid(playerIdTextField.text)?.isUUID() ?: false) {
+            val friend = IdChecker.checkAndReturnPlayerUuid(playerIdTextField.text)
+            if (friend?.playerID?.isUUID() ?: false) {
                 player.playerId = playerIdTextField.text.trim()
                 errorLabel.apply {
                     setText("✔") // U+2714 heavy checkmark

--- a/core/src/com/unciv/utils/Log.kt
+++ b/core/src/com/unciv/utils/Log.kt
@@ -5,6 +5,10 @@ import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
 import java.time.Instant
 import java.util.regex.Pattern
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.Returns
+import kotlin.contracts.ReturnsNotNull
+import kotlin.contracts.contract
 
 
 /**
@@ -112,6 +116,7 @@ object Log {
      *
      * The [params] can contain value-producing lambdas, which will be called and their value used as parameter for the message instead.
      */
+    @Pure @Suppress("purity") // good suppression - log considered pure everywhere
     fun error(msg: String, vararg params: Any?) {
         error(getTag(), msg, *params)
     }
@@ -138,6 +143,7 @@ object Log {
      *
      * A tag will be added equal to the name of the calling class.
      */
+    @Pure @Suppress("purity") // good suppression - log considered pure everywhere
     fun error(msg: String, throwable: Throwable) {
         error(getTag(), msg, throwable)
     }
@@ -208,6 +214,26 @@ fun debug(msg: String, throwable: Throwable) {
 /** Shortcut for [Log.debug] */
 fun debug(tag: Tag, msg: String, throwable: Throwable) {
     Log.debug(tag, msg, throwable)
+}
+
+/**
+ * If condition is met, returns non-null. Otherwise, logs an error and returns null
+ * 
+ * Usage:
+ *     softRequire(input > 0, "input %s must be positive", input) ?: return
+ **/
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(ExperimentalContracts::class)
+@Pure
+inline fun softRequire(condition: Boolean, msg: String, vararg params: Any?): Any? {
+    contract { // theoretically this helps the compiler cast nullables correctly in callers
+        returns(null) implies !condition // but in practice the compiler isn't figuring it out
+        returns(true) implies condition
+    }
+    if (condition)
+        return msg
+    Log.error(msg, *params)
+    return null
 }
 
 private fun doLog(logger: (Tag, String, String) -> Unit, tag: Tag, msg: String, vararg params: Any?) {

--- a/tests/src/com/unciv/logic/IdHelperTests.kt
+++ b/tests/src/com/unciv/logic/IdHelperTests.kt
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith
 @RunWith(GdxTestRunner::class)
 class IdHelperTests {
     @Test
-    fun testCheckDigits() {
+    fun getCheckDigit_uuid_tests() {
         val correctString = "2ddb3a34-0699-4126-b7a5-38603e665928"
         val inCorrectString1 = "2ddb3a34-0699-4126-b7a5-38603e665929"
         val inCorrectString2 = "2ddb3a34-0969-4126-b7a5-38603e665928"
@@ -39,41 +39,99 @@ class IdHelperTests {
     }
 
     @Test
-    fun testIdsSuccess() {
+    fun checkAndReturnUuiId_uuid_valid_success() {
         val correctString = "2ddb3a34-0699-4126-b7a5-38603e665928"
 
-        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid(correctString))
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid(correctString)?.playerID)
         Assert.assertEquals(
             "c872b8e0-f274-47d4-b761-ce684c5d224c",
-            IdChecker.checkAndReturnGameUuid("c872b8e0-f274-47d4-b761-ce684c5d224c")
+            IdChecker.checkAndReturnUuiId("c872b8e0-f274-47d4-b761-ce684c5d224c")
         )
 
-        Assert.assertEquals(correctString, IdChecker.checkAndReturnGameUuid("G-$correctString-2"))
-        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid("P-$correctString-2"))
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnUuiId("G-$correctString-2"))
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid("P-$correctString-2")?.playerID)
     }
 
-    @Test // too short
-    fun testIdFailure1() {
-        Assert.assertNull(IdChecker.checkAndReturnGameUuid("2ddb3a34-0699-4126-b7a5-38603e66592"))
+    @Test
+    fun checkAndReturnUuiId_gameId_tooShort_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("2ddb3a34-0699-4126-b7a5-38603e66592"))
     }
 
-    @Test // wrong prefix
-    fun testIdFailure2() {
-        Assert.assertNull(IdChecker.checkAndReturnGameUuid("P-2ddb3a34-0699-4126-b7a5-38603e665928-2"))
+    @Test
+    fun checkAndReturnUuiId_gameId_wrongPrefix_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("P-2ddb3a34-0699-4126-b7a5-38603e665928-2"))
     }
 
-    @Test // wrong prefix
-    fun testIdFailure3() {
-        Assert.assertNull(IdChecker.checkAndReturnPlayerUuid("G-2ddb3a34-0699-4126-b7a5-38603e665928-2"))
+    @Test 
+    fun checkAndReturnUuiId_playerId_wrongPrefix_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnPlayerUuid("G-2ddb3a34-0699-4126-b7a5-38603e665928-2")?.playerID)
     }
 
-    @Test // changed checkDigit
-    fun testIdFailure4() {
-        Assert.assertNull(IdChecker.checkAndReturnGameUuid("G-2ddb3a34-0699-4126-b7a5-38603e665928-3"))
+    @Test
+    fun checkAndReturnUuiId_gameId_changedCheckDigit_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("G-2ddb3a34-0699-4126-b7a5-38603e665928-3"))
+    }
+
+    @Test
+    fun checkAndReturnUuiId_gameId_changedUuid_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("G-2ddb3a34-0699-4126-b7a5-48603e665928-2"))
+    }
+
+    @Test
+    fun checkAndReturnUuiId_gameId_withPunctuation_succeeds() {
+        val result = IdChecker.checkAndReturnUuiId(" (“G-2ddb3a34-0699-4126-b7a5-38603e665928-2”.)\n")
+        Assert.assertEquals("2ddb3a34-0699-4126-b7a5-38603e665928", result)
+    }
+
+    @Test
+    fun checkAndReturnUuiId_url_valid_success() {
+        val correctString = "2ddb3a34-0699-4126-b7a5-38603e665928"
+
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid(correctString)?.playerID)
+        Assert.assertEquals(
+            "c872b8e0-f274-47d4-b761-ce684c5d224c",
+            IdChecker.checkAndReturnUuiId("c872b8e0-f274-47d4-b761-ce684c5d224c")
+        )
+
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnUuiId("https://yairm210.github.io/Unciv/G/G-$correctString-2"))
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid("https://yairm210.github.io/Unciv/P/P-$correctString-2")?.playerID)
+    }
+
+    @Test
+    fun checkAndReturnUuiId_url_tooShort_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("https://yairm210.github.io/Unciv/G/2ddb3a34-0699-4126-b7a5-38603e66592"))
+    }
+
+    @Test 
+    fun checkAndReturnUuiId_gameUrl_wrongPrefix_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("https://yairm210.github.io/Unciv/P/P-2ddb3a34-0699-4126-b7a5-38603e665928-2"))
+    }
+
+    @Test
+    fun checkAndReturnUuiId_playerUrl_wrongPrefix_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnPlayerUuid("https://yairm210.github.io/Unciv/G/G-2ddb3a34-0699-4126-b7a5-38603e665928-2")?.playerID)
+    }
+
+    @Test 
+    fun checkAndReturnUuiId_url_changedCheckDigit_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("https://yairm210.github.io/Unciv/G/G-2ddb3a34-0699-4126-b7a5-38603e665928-3"))
     }
 
     @Test // changed uuid without changing checkdigit
-    fun testIdFailure5() {
-        Assert.assertNull(IdChecker.checkAndReturnGameUuid("G-2ddb3a34-0699-4126-b7a5-48603e665928-2"))
+    fun checkAndReturnUuiId_url_changedUuid_isNull() {
+        Assert.assertNull(IdChecker.checkAndReturnUuiId("https://yairm210.github.io/Unciv/G/G-2ddb3a34-0699-4126-b7a5-48603e665928-2"))
+    }
+
+    @Test
+    fun checkAndReturnUuiId_url_withPunctuation_succeeds() {
+        val result = IdChecker.checkAndReturnUuiId(" (“https://yairm210.github.io/Unciv/G/G-2ddb3a34-0699-4126-b7a5-38603e665928-2”.)\n")
+        Assert.assertEquals("2ddb3a34-0699-4126-b7a5-38603e665928", result)
+    }
+
+    @Test
+    fun checkAndReturnUuiId_url_withName_succeeds() {
+        val result = IdChecker.checkAndReturnPlayerUuid(" (“https://yairm210.github.io/Unciv/P/P-2ddb3a34-0699-4126-b7a5-38603e665928-2?name=%C4%90%E1%BA%B7ng”.)\n")
+        Assert.assertEquals("2ddb3a34-0699-4126-b7a5-38603e665928", result?.playerID)
+        Assert.assertEquals("Đặng", result?.name)
     }
 }


### PR DESCRIPTION
Unciv can receive links directly to games or new friends

Game urls are like “https://yairm210.github.io/Unciv/G/G-2ddb3a34-0699-4126-b7a5-38603e665928-2”, and player urls look the same except with `P`s instead of `G`s. Player urls may also optionally have a name parameter ("?name=%C4%90%E1%BA%B7ng") to autofill that field.

These urls are not yet publicly exposed anywhere.  We should let users update to a binary with this first, so then when we expose the game/player links, they work for almost everyone immediately.

This also fixes https://github.com/yairm210/Unciv/issues/14590 while I was in the area.

This is built on top of https://github.com/yairm210/Unciv/pull/14770

Signed-off-by: MPD <mooing_psycho_duck@hotmail.com>