### PR TITLE
[Tests] Fix created base units starting with malformed ruleset unique lists

### DIFF
--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -260,9 +260,8 @@ class TestGame(vararg addGlobalUniques: String, forUITesting: Boolean = false) {
         createRulesetObject(ruleset.units, *uniques) {
             val baseUnit = BaseUnit()
             baseUnit.unitType = unitType
-            baseUnit.setRuleset(gameInfo.ruleset)
             baseUnit
-        }
+        }.apply { setRuleset(gameInfo.ruleset) }
     fun createBelief(type: BeliefType = BeliefType.Any, vararg uniques: String) =
         createRulesetObject(ruleset.beliefs, *uniques) { Belief(type) }
     fun createBuilding(vararg uniques: String) =


### PR DESCRIPTION
A ruleset object created via ``createRulesetObject`` is only given its uniuqes ***after*** the factory function is preformed. I'm not sure there's a worthwhile way to solve this. As such, any additional work for a ruleset object that relies on its uniques should always be done after the ruleset object has been created, not within the factory function


Here a base unit created via ``createBaseUnit`` would not have its triggerables trigger when created as that relies on the base unit having an unique list which relies on ``setRuleset`` being called. But since that relies on the ruleset object having uniques, it would not find anything within the factory function