### PR TITLE
Add restart game functionality and update translations

### DIFF
--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -2420,6 +2420,8 @@ Civilopedia =
  # Requires translation!
 Start new game = 
  # Requires translation!
+Restart game = 
+ # Requires translation!
 Save game = 
  # Requires translation!
 Load game = 

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -1346,6 +1346,7 @@ Civilopedia = 文明百科
 ??? = ?未知文明?
 
 Start new game = 开始新游戏
+Restart game = 重新开始
 Save game = 保存游戏
 Load game = 读取游戏
 Main menu = 主菜单

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -1333,6 +1333,7 @@ Civilopedia = 文明百科
 ??? = ???
 
 Start new game = 開始新遊戲
+Restart game = 重新開始
 Save game = 保存遊戲
 Load game = 讀取遊戲
 Main menu = 主選單

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1324,6 +1324,7 @@ Civilopedia =
 ??? = 
 
 Start new game = 
+Restart game = 
 Save game = 
 Load game = 
 Main menu = 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.logic.GameStarter
 import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.civilization.Civilization
@@ -246,6 +247,23 @@ class WorldScreen(
         newGameSetupInfo.mapParameters.reseed()
         val newGameScreen = NewGameScreen(newGameSetupInfo)
         game.pushScreen(newGameScreen)
+    }
+
+    fun restartGameWithCurrentSettings() {
+        autoPlay.stopAutoPlay()
+        Concurrency.run("Restart game with current settings") {
+            val newGame = try {
+                val setupInfo = GameSetupInfo(gameInfo)
+                setupInfo.mapParameters.reseed()
+                GameStarter.startNewGame(setupInfo)
+            } catch (_: Exception) {
+                launchOnGLThread {
+                    ToastPopup(message = "Could not restart game!", screen = this@WorldScreen)
+                }
+                return@run
+            }
+            startNewScreenJob(newGame, AutoPlay(game.settings.autoPlay))
+        }
     }
 
     fun openSaveGameScreen() {

--- a/core/src/com/unciv/ui/screens/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -31,9 +31,10 @@ class WorldScreenMenuPopup(
         defaults().fillX()
 
         val showSave = !worldScreen.gameInfo.gameParameters.isOnlineMultiplayer
+        val showRestart = !worldScreen.gameInfo.gameParameters.isOnlineMultiplayer
         val showMusic = worldScreen.game.musicController.isMusicAvailable()
         val showConsole = showSave && expertMode
-        val buttonCount = 8 + (if (showSave) 1 else 0) + (if (showMusic) 1 else 0) + (if (showConsole) 1 else 0)
+        val buttonCount = 8 + (if (showSave) 1 else 0) + (if (showRestart) 1 else 0) + (if (showMusic) 1 else 0) + (if (showConsole) 1 else 0)
 
         val emptyPrefHeight = this.prefHeight
         val firstCell = addButton("Main menu") {
@@ -61,6 +62,11 @@ class WorldScreenMenuPopup(
             close()
             worldScreen.openNewGameScreen()
         }.nextColumn()
+        if (showRestart)
+            addButton("Restart game") {
+                close()
+                worldScreen.restartGameWithCurrentSettings()
+            }.nextColumn()
         addButton("Victory status", KeyboardBinding.VictoryScreen) {
             close()
             worldScreen.game.pushScreen(VictoryScreen(worldScreen))


### PR DESCRIPTION
- Implemented a new method to restart the game with current settings in WorldScreen.
- Added "Restart game" button to the main menu, visible in single-player mode.
- Updated English, Simplified Chinese, Traditional Chinese, and template translation files to include the new "Restart game" string.
