### PR TITLE
Don't display empty message in DoW popup

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -496,7 +496,9 @@ class AlertPopup(
         if (civInfo.isDefeated()) return false
         addLeaderName(civInfo)
         addTopicHeader("DECLARATION OF WAR", LIGHTER_RED_COLOR)
-        addGoodSizedLabel(civInfo.nation.declaringWar).row()
+        val leaderMessage = civInfo.nation.declaringWar
+        if (leaderMessage.isNotEmpty())
+            addGoodSizedLabel(leaderMessage).row()
         addCloseButton("You'll pay for this!")
         addCloseButton("Very well.")
         equalizeLastTwoButtonWidths()


### PR DESCRIPTION
Should remove that unnatural space in cases where the leader message is an empty string.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/47cf8271-de71-49e7-9c9e-d635c60431b2" />