### PR TITLE
ConstructImprovementInstantly now clears tile improvement queue

### DIFF
--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -214,7 +214,7 @@ class TileImprovementFunctions(val tile: Tile) {
                 }
 
                 // relevant when the improvement was created instantly - such as Great Improvement
-                tile.improvementQueue.removeIf { it.improvement !in listOf("Road", "Railroad")}
+                tile.improvementQueue.removeIf { it.improvement !in listOf(RoadStatus.Road.name, RoadStatus.Railroad.name)}
             }
         }
 

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -214,7 +214,7 @@ class TileImprovementFunctions(val tile: Tile) {
                 }
 
                 // relevant when the improvement was created instantly - such as Great Improvement
-                tile.improvementQueue.removeIf { it.improvement !in listOf(RoadStatus.Road.name, RoadStatus.Railroad.name)}
+                tile.improvementQueue.removeIf { tile.ruleset.tileImprovements[it.improvement]?.isRoad() == true }
             }
         }
 

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -212,6 +212,9 @@ class TileImprovementFunctions(val tile: Tile) {
                     // Let's not cancel our "Districts" in progress unless when finishing it (don't mess it up with accidental worker movements etc.)
                     removeCreatesOneImprovementMarker()
                 }
+
+                // relevant when the improvement was created instantly - such as Great Improvement
+                tile.improvementQueue.removeIf { it.improvement !in listOf("Road", "Railroad")}
             }
         }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -350,6 +350,8 @@ object UnitActionsFromUniques {
                     associatedUnique = unique,
                     action = {
                         val unitTile = unit.getTile()
+                        
+                        tile.improvementQueue.removeIf { it.improvement !in listOf("Road", "Railroad")}
                         unitTile.setImprovement(improvement, unit.civ, unit)
 
                         unit.civ.cache.updateViewableTiles() // to update 'last seen improvement'

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -350,8 +350,6 @@ object UnitActionsFromUniques {
                     associatedUnique = unique,
                     action = {
                         val unitTile = unit.getTile()
-                        
-                        tile.improvementQueue.removeIf { it.improvement !in listOf("Road", "Railroad")}
                         unitTile.setImprovement(improvement, unit.civ, unit)
 
                         unit.civ.cache.updateViewableTiles() // to update 'last seen improvement'


### PR DESCRIPTION
Currently, placing a great improvement does not clear the tile improvement queue.
<img width="437" height="210" alt="image" src="https://github.com/user-attachments/assets/192e49a8-2a0a-4714-a72a-e536d773796b" />

This means that a worker may later accidentally replace the great improvement with the previous improvement that was being built (e.g. a Farm), either if the worker was moved ontop of the tile manually, or possibly through automation.

This PR clears the improvement queue...
<img width="437" height="210" alt="image" src="https://github.com/user-attachments/assets/9ebc3cdb-5166-4b36-b7bb-95fd6d0e58d1" />

...with the exception of roads and railroads
<img width="437" height="210" alt="image" src="https://github.com/user-attachments/assets/3522d8bf-83fa-4cba-a9e2-cf8a80742685" />
