### PR TITLE
PolicyCultureCost ModConstant

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -168,8 +168,8 @@ class PolicyManager : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun getPolicyCultureCost(numberOfAdoptedPolicies: Int): Int {
-        val (base, multiplier, exponent) = civInfo.modConstants.policyCultureCost
-        var policyCultureCost = base + (numberOfAdoptedPolicies * multiplier).pow(exponent)
+        val (initial, multiplier, exponent) = civInfo.modConstants.policyCultureCost
+        var policyCultureCost = initial + (numberOfAdoptedPolicies * multiplier).pow(exponent)
         val worldSizeModifier = civInfo.gameInfo.tileMap.mapParameters.mapSize.getPredefinedOrNextSmaller().policyCostPerCityModifier
         var cityModifier = worldSizeModifier * (civInfo.cities.count { !it.isPuppet } - 1)
 

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -168,7 +168,8 @@ class PolicyManager : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun getPolicyCultureCost(numberOfAdoptedPolicies: Int): Int {
-        var policyCultureCost = 25 + (numberOfAdoptedPolicies * 6).toDouble().pow(civInfo.modConstants.policyCostExponent)
+        val (base, multiplier, exponent) = civInfo.modConstants.policyCultureCost
+        var policyCultureCost = base + (numberOfAdoptedPolicies * multiplier).pow(exponent)
         val worldSizeModifier = civInfo.gameInfo.tileMap.mapParameters.mapSize.getPredefinedOrNextSmaller().policyCostPerCityModifier
         var cityModifier = worldSizeModifier * (civInfo.cities.count { !it.isPuppet } - 1)
 

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -168,7 +168,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun getPolicyCultureCost(numberOfAdoptedPolicies: Int): Int {
-        var policyCultureCost = 25 + (numberOfAdoptedPolicies * 6).toDouble().pow(1.7)
+        var policyCultureCost = 25 + (numberOfAdoptedPolicies * 6).toDouble().pow(civInfo.modConstants.policyCostExponent)
         val worldSizeModifier = civInfo.gameInfo.tileMap.mapParameters.mapSize.getPredefinedOrNextSmaller().policyCostPerCityModifier
         var cityModifier = worldSizeModifier * (civInfo.cities.count { !it.isPuppet } - 1)
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -101,6 +101,10 @@ class ModConstants {
     // Factors in formula for pantheon cost
     var pantheonBase = 10
     var pantheonGrowth = 5
+    
+    // Affects the growth rate of policy costs.
+    // Small changes to this can have a significant impact in the late game.
+    var policyCostExponent = 1.7
 
     // AI behaviour
     var workboatAutomationSearchMaxTiles = 37

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -102,9 +102,16 @@ class ModConstants {
     var pantheonBase = 10
     var pantheonGrowth = 5
     
-    // Affects the growth rate of policy costs.
-    // Small changes to this can have a significant impact in the late game.
-    var policyCostExponent = 1.7
+    /** See usage in [com.unciv.logic.civilization.managers.PolicyManager.getPolicyCultureCost] */
+    data class PolicyCultureCost(
+        val initial: Float = 25f,
+        // multiplied with number of policies adopted
+        val multiplier: Float = 6f,
+        // small changes have big impact late game
+        val exponent: Float = 1.7f
+    )
+    
+    var policyCultureCost = PolicyCultureCost()
 
     // AI behaviour
     var workboatAutomationSearchMaxTiles = 37

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -274,12 +274,7 @@ open class RulesetValidator protected constructor(
     protected open fun addModOptionsErrors(lines: RulesetErrorList) {
         // Basic Unique validation (type, target, parameters) should always run.
         // Using reportRulesetSpecificErrors=true as ModOptions never should use Uniques depending on objects from a base ruleset anyway.
-        uniqueValidator.checkUniques(
-            ruleset.modOptions,
-            lines,
-            reportRulesetSpecificErrors = true,
-            tryFixUnknownUniques
-        )
+        uniqueValidator.checkUniques(ruleset.modOptions, lines, reportRulesetSpecificErrors = true, tryFixUnknownUniques)
         
         fun lineText(constantName: String, detail: String = ""): String {
             return "Invalid ModConstant '%s'. %s".format(constantName, detail)

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -274,20 +274,37 @@ open class RulesetValidator protected constructor(
     protected open fun addModOptionsErrors(lines: RulesetErrorList) {
         // Basic Unique validation (type, target, parameters) should always run.
         // Using reportRulesetSpecificErrors=true as ModOptions never should use Uniques depending on objects from a base ruleset anyway.
-        uniqueValidator.checkUniques(ruleset.modOptions, lines, reportRulesetSpecificErrors = true, tryFixUnknownUniques)
+        uniqueValidator.checkUniques(
+            ruleset.modOptions,
+            lines,
+            reportRulesetSpecificErrors = true,
+            tryFixUnknownUniques
+        )
+        
+        fun lineText(constantName: String, detail: String = ""): String {
+            return "Invalid ModConstant '%s'. %s".format(constantName, detail)
+        }
 
         //TODO: More thorough checks. Here I picked just those where bad values might endanger stability.
         val constants = ruleset.modOptions.constants
         if (constants.cityExpandRange !in 1..100)
-            lines.add("Invalid ModConstant 'cityExpandRange'.", sourceObject = null)
+            lines.add(lineText("cityExpandRange", "In range 1 to 100"), sourceObject = null)
         if (constants.cityWorkRange !in 1..100)
-            lines.add("Invalid ModConstant 'cityWorkRange'.", sourceObject = null)
+            lines.add(lineText("cityWorkRange", "In range 1 to 100"), sourceObject = null)
         if (constants.minimalCityDistance < 1)
-            lines.add("Invalid ModConstant 'minimalCityDistance'.", sourceObject = null)
+            lines.add(lineText("minimalCityDistance", "Minimum 1"), sourceObject = null)
         if (constants.minimalCityDistanceOnDifferentContinents < 1)
-            lines.add("Invalid ModConstant 'minimalCityDistanceOnDifferentContinents'.", sourceObject = null)
+            lines.add(lineText("minimalCityDistanceOnDifferentContinents", "Minimum 1"), sourceObject = null)
         if (constants.baseCityBombardRange < 1)
-            lines.add("Invalid ModConstant 'baseCityBombardRange'.", sourceObject = null)
+            lines.add(lineText("baseCityBombardRange", "Minimum 1"), sourceObject = null)
+        with(constants.policyCultureCost) {
+            if (initial < 0f)
+                lines.add(lineText("policyCultureCost.initial", "Minimum 0"))
+            if (multiplier < 0f)
+                lines.add(lineText("policyCultureCost.multiplier", "Minimum 0"))
+            if (exponent > 4f)
+                lines.add(lineText("policyCultureCost.exponent", "Maximum 4.0"))
+        }
 
         if (ruleset.name.isBlank()) return // The rest of these tests don't make sense for combined rulesets
 

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -289,8 +289,6 @@ Legend:
 
 #### UnitUpgradeCost
 
-These values are not merged individually, only the entire sub-structure is.
-
 | Attribute     | Type  |    | Notes |
 |---------------|-------|----|-------|
 | base          | Float | 10 |       |
@@ -307,8 +305,6 @@ The formula for the gold cost of a unit upgrade is (rounded down to a multiple o
 With `civModifier` being the multiplicative aggregate of ["\[relativeAmount\]% Gold cost of upgrading"](../uniques.md#global-uniques) uniques that apply.
 
 #### PolicyCultureCost
-
-These values are not merged individually, only the entire sub-structure is.
 
 | Attribute  | Type  | Default | Restrictions | Notes                                          |
 |------------|-------|---------|--------------|------------------------------------------------|

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -232,7 +232,7 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | religionLimitMultiplier                  | Float     | 0.5                             | [^K]  |
 | pantheonBase                             | Int       | 10                              | [^L]  |
 | pantheonGrowth                           | Int       | 5                               | [^L]  |
-| policyCultureCost                        | Object    | [See below](#policyculturecost) |       |
+| policyCultureCost                        | Object    | [See below](#policyculturecost) | [^J]  |
 | workboatAutomationSearchMaxTiles         | Int       | 20                              | [^M]  |
 | maxSpyRank                               | Int       | 3                               | [^N]  |
 | spyRankSkillPercentBonus                 | Float     | 30                              | [^O]  |
@@ -272,7 +272,7 @@ Legend:
 - [^G]: MapGenerator.spawnIce: spawn Ice where T < this, with T calculated from temperatureExtremeness, latitude and perlin noise.
 - [^H]: MapGenerator.spawnLakesAndCoasts: Water bodies up to this tile count become Lakes
 - [^I]: RiverGenerator: river frequency and length bounds
-- [^J]: A [UnitUpgradeCost](#unitupgradecost) sub-structure.
+- [^J]: When using multiple mods that change this sub-structure, then the values are not merged individually, only the entire sub-structure is.
 - [^K]: Maximum foundable Religions = religionLimitBase + floor(MajorCivCount * religionLimitMultiplier)
 - [^L]: Cost of pantheon = pantheonBase + CivsWithReligion * pantheonGrowth
 - [^M]: When the AI decides whether to build a work boat, how many tiles to search from the city center for an improvable tile

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -203,46 +203,46 @@ Stored in ModOptions.constants, this is a collection of constants used internall
 This is the only structure that is _merged_ field by field from mods, not overwritten, so you can change XP from Barbarians in one mod
 and city distance in another. In case of conflicts, there is no guarantee which mod wins, only that _default_ values are ignored.
 
-| Attribute                                | Type   | Default                       | Notes |
-|------------------------------------------|--------|-------------------------------|-------|
-| maxXPfromBarbarians                      | Int    | 30                            | [^A]  |
-| cityStrengthBase                         | Float  | 8.0                           | [^B]  |
-| cityStrengthPerPop                       | Float  | 0.4                           | [^B]  |
-| cityStrengthFromTechsMultiplier          | Float  | 5.5                           | [^B]  |
-| cityStrengthFromTechsExponent            | Float  | 2.8                           | [^B]  |
-| cityStrengthFromTechsFullMultiplier      | Float  | 1.0                           | [^B]  |
-| cityStrengthFromGarrison                 | Float  | 0.2                           | [^B]  |
-| baseCityBombardRange                     | Int    | 2                             | [^S]  |
-| cityWorkRange                            | Int    | 3                             | [^T]  |
-| cityExpandRange                          | Int    | 5                             | [^U]  |
-| cityAirUnitCapacity                      | Int    | 6                             | [^W]  |
-| unitSupplyPerPopulation                  | Float  | 0.5                           | [^C]  |
-| minimalCityDistance                      | Int    | 3                             | [^D]  |
-| minimalCityDistanceOnDifferentContinents | Int    | 2                             | [^D]  |
-| unitUpgradeCost                          | Object | [See below](#unitupgradecost) | [^J]  |
-| naturalWonderCountMultiplier             | Float  | 0.124                         | [^E]  |
-| naturalWonderCountAddedConstant          | Float  | 0.1                           | [^E]  |
-| ancientRuinCountMultiplier               | Float  | 0.02                          | [^F]  |
-| spawnIceBelowTemperature                 | Float  | -0.8                          | [^G]  |
-| maxLakeSize                              | Int    | 10                            | [^H]  |
-| riverCountMultiplier                     | Float  | 0.01                          | [^I]  |
-| minRiverLength                           | Int    | 5                             | [^I]  |
-| maxRiverLength                           | Int    | 666                           | [^I]  |
-| religionLimitBase                        | Int    | 1                             | [^K]  |
-| religionLimitMultiplier                  | Float  | 0.5                           | [^K]  |
-| pantheonBase                             | Int    | 10                            | [^L]  |
-| pantheonGrowth                           | Int    | 5                             | [^L]  |
-| policyCostExponent                       | Float  | 1.7                           | [^X]  |
-| workboatAutomationSearchMaxTiles         | Int    | 20                            | [^M]  |
-| maxSpyRank                               | Int    | 3                             | [^N]  |
-| spyRankSkillPercentBonus                 | Float  | 30                            | [^O]  |
-| minimumWarDuration                       | Int    | 10                            | [^P]  |
-| baseTurnsUntilRevolt                     | Int    | 4                             | [^Q]  |
-| cityStateElectionTurns                   | Int    | 15                            | [^R]  |
-| maxImprovementTechErasForward            | Int    | None                          | [^S]  |
-| goldGiftMultiplier                       | Float  | 1                             | [^T]  |
-| goldGiftTradeMultiplier                  | Float  | 0.8                           | [^U]  |
-| goldGiftDegradationMultiplier            | Float  | 1.0                           | [^V]  |
+| Attribute                                | Type      | Default                         | Notes |
+|------------------------------------------|-----------|---------------------------------|-------|
+| maxXPfromBarbarians                      | Int       | 30                              | [^A]  |
+| cityStrengthBase                         | Float     | 8.0                             | [^B]  |
+| cityStrengthPerPop                       | Float     | 0.4                             | [^B]  |
+| cityStrengthFromTechsMultiplier          | Float     | 5.5                             | [^B]  |
+| cityStrengthFromTechsExponent            | Float     | 2.8                             | [^B]  |
+| cityStrengthFromTechsFullMultiplier      | Float     | 1.0                             | [^B]  |
+| cityStrengthFromGarrison                 | Float     | 0.2                             | [^B]  |
+| baseCityBombardRange                     | Int       | 2                               | [^S]  |
+| cityWorkRange                            | Int       | 3                               | [^T]  |
+| cityExpandRange                          | Int       | 5                               | [^U]  |
+| cityAirUnitCapacity                      | Int       | 6                               | [^W]  |
+| unitSupplyPerPopulation                  | Float     | 0.5                             | [^C]  |
+| minimalCityDistance                      | Int       | 3                               | [^D]  |
+| minimalCityDistanceOnDifferentContinents | Int       | 2                               | [^D]  |
+| unitUpgradeCost                          | Object    | [See below](#unitupgradecost)   | [^J]  |
+| naturalWonderCountMultiplier             | Float     | 0.124                           | [^E]  |
+| naturalWonderCountAddedConstant          | Float     | 0.1                             | [^E]  |
+| ancientRuinCountMultiplier               | Float     | 0.02                            | [^F]  |
+| spawnIceBelowTemperature                 | Float     | -0.8                            | [^G]  |
+| maxLakeSize                              | Int       | 10                              | [^H]  |
+| riverCountMultiplier                     | Float     | 0.01                            | [^I]  |
+| minRiverLength                           | Int       | 5                               | [^I]  |
+| maxRiverLength                           | Int       | 666                             | [^I]  |
+| religionLimitBase                        | Int       | 1                               | [^K]  |
+| religionLimitMultiplier                  | Float     | 0.5                             | [^K]  |
+| pantheonBase                             | Int       | 10                              | [^L]  |
+| pantheonGrowth                           | Int       | 5                               | [^L]  |
+| policyCultureCost                        | Object    | [See below](#policyculturecost) |       |
+| workboatAutomationSearchMaxTiles         | Int       | 20                              | [^M]  |
+| maxSpyRank                               | Int       | 3                               | [^N]  |
+| spyRankSkillPercentBonus                 | Float     | 30                              | [^O]  |
+| minimumWarDuration                       | Int       | 10                              | [^P]  |
+| baseTurnsUntilRevolt                     | Int       | 4                               | [^Q]  |
+| cityStateElectionTurns                   | Int       | 15                              | [^R]  |
+| maxImprovementTechErasForward            | Int       | None                            | [^S]  |
+| goldGiftMultiplier                       | Float     | 1                               | [^T]  |
+| goldGiftTradeMultiplier                  | Float     | 0.8                             | [^U]  |
+| goldGiftDegradationMultiplier            | Float     | 1.0                             | [^V]  |
 
 Legend:
 
@@ -286,7 +286,6 @@ Legend:
 - [^U]: The multiplier of the gold value of a regular trade to be stored as gifts. Set to 0 to disable gold gifting in two-sided trades.
 - [^U]: Modifies how quickly the GaveUsGifts dimplomacy modifier runs out. A higher value makes it run out quicker. Normally the gifts reduced by ~2.5% per turn depending on the diplomatic relations with the default value.
 - [^W]: Number of air units that can be stationed in a city, not including carried/transported air units.
-- [^X]: The base policy cost is calculated as follows: `25 + (numberOfAdoptedPolicies * 6) ^ policyCostExponent`
 
 #### UnitUpgradeCost
 
@@ -306,6 +305,18 @@ The formula for the gold cost of a unit upgrade is (rounded down to a multiple o
             \* (1 + eraNumber \* `eraMultiplier`) \* `civModifier`
         ) ^ `exponent`
 With `civModifier` being the multiplicative aggregate of ["\[relativeAmount\]% Gold cost of upgrading"](../uniques.md#global-uniques) uniques that apply.
+
+#### PolicyCultureCost
+
+These values are not merged individually, only the entire sub-structure is.
+
+| Attribute  | Type  | Default | Restrictions | Notes                                          |
+|------------|-------|---------|--------------|------------------------------------------------|
+| initial    | Float | 25      | Minimum 0    | Cost of the first policy                       |
+| multiplier | Float | 6       | Minimum 0    | Multiplied with the number of policies adopted |
+| exponent   | Float | 1.7     | Maximum 4    | Significant impact on late game policy costs   |
+
+The formula for policy culture cost is: `initial` + (`multiplier` * number_of_policies_adopted) ^ `exponent`
 
 ## GlobalUniques.json
 

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -232,6 +232,7 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | religionLimitMultiplier                  | Float  | 0.5                           | [^K]  |
 | pantheonBase                             | Int    | 10                            | [^L]  |
 | pantheonGrowth                           | Int    | 5                             | [^L]  |
+| policyCostExponent                       | Float  | 1.7                           | [^X]  |
 | workboatAutomationSearchMaxTiles         | Int    | 20                            | [^M]  |
 | maxSpyRank                               | Int    | 3                             | [^N]  |
 | spyRankSkillPercentBonus                 | Float  | 30                            | [^O]  |
@@ -285,6 +286,7 @@ Legend:
 - [^U]: The multiplier of the gold value of a regular trade to be stored as gifts. Set to 0 to disable gold gifting in two-sided trades.
 - [^U]: Modifies how quickly the GaveUsGifts dimplomacy modifier runs out. A higher value makes it run out quicker. Normally the gifts reduced by ~2.5% per turn depending on the diplomatic relations with the default value.
 - [^W]: Number of air units that can be stationed in a city, not including carried/transported air units.
+- [^X]: The base policy cost is calculated as follows: `25 + (numberOfAdoptedPolicies * 6) ^ policyCostExponent`
 
 #### UnitUpgradeCost
 


### PR DESCRIPTION
Can now make culture victory feasible without affecting early game policy costs or making overhauls to culture production.

Edit: More broadly, constants for changing the policy cost formula.