### PR TITLE
Fix: NPE when Espionage Screen is used to move a spy and the Civs don't know each other

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -212,7 +212,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
             add(getSpyIcon(spy))
     }
 
-    private abstract inner class SpyCityActionButton : Button(SmallButtonStyle()) {
+    private abstract class SpyCityActionButton : Button(SmallButtonStyle()) {
         open fun setDirection(align: Int) {}
     }
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -234,6 +234,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
                 if (city != null
                     && city.civ.civName != civInfo.civName
                     && city.civ.isMajorCiv()
+                    && city.civ.knows(civInfo) // ensures the !! below won't crash
                     && city.civ.getDiplomacyManager(civInfo)!!.hasFlag(DiplomacyFlags.AgreedToNotSendSpies)) {
                     ConfirmPopup(
                         UncivGame.Current.screen!!,


### PR DESCRIPTION
Regression from #14749
Fixes #14782

Raises the question - should we not suppress listing cities that the player has no knowledge of?

Edit: Raises another question - Tech Satellites should prevent the bug from triggering in the specific circumstances the issue names - starting in the future era. Sounds like a bug that triggers won't trigger properly when the gamestarter adds the techs.

Edit: Not kicking off a patch, despite the cause being deterministic - I'm estimating the conditions to be rare enough. I may be wrong.