### PR TITLE
Eliminating known unseeded Randomness.

### DIFF
--- a/.github/workflows/detekt_config/detekt-warnings.yml
+++ b/.github/workflows/detekt_config/detekt-warnings.yml
@@ -595,6 +595,10 @@ style:
         value: 'java.util.Random.<init>()'
       - reason: 'Unciv prefers pseudorandom. Instead, use GameContext.random'
         value: 'java.util.Random.Default.*'
+      - reason: 'Unciv prefers pseudorandom. Instead, use GameContext.random'
+        value: 'kotlin.ranges.randomOrNull()'
+      - reason: 'Unciv prefers pseudorandom. Instead, use GameContext.random'
+        value: 'java.util.UUID.randomUUID()'
   ForbiddenSuppress:
     active: false
     rules: []

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.BackwardCompatibility.guaranteeUnitPromotions
 import com.unciv.logic.BackwardCompatibility.migrateGreatGeneralPools
 import com.unciv.logic.BackwardCompatibility.migrateToTileHistory
 import com.unciv.logic.BackwardCompatibility.removeMissingModReferences
+import com.unciv.logic.GameInfoPreview.Companion.randomGameId
 import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.automation.civilization.BarbarianManager
 import com.unciv.logic.city.City
@@ -39,11 +40,12 @@ import com.unciv.ui.screens.savescreens.Gzip
 import com.unciv.ui.screens.worldscreen.status.NextTurnProgress
 import com.unciv.utils.DebugUtils
 import com.unciv.utils.debug
+import com.unciv.utils.pseudoRandomUuid
 import yairm210.purity.annotations.Readonly
 import java.security.MessageDigest
+import java.security.SecureRandom
 import java.time.Duration
 import java.time.Instant
-import java.util.UUID
 import java.util.*
 
 
@@ -110,7 +112,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     var oneMoreTurnMode = false
     var currentPlayer = ""
     var currentTurnStartTime = System.currentTimeMillis()
-    var gameId = UUID.randomUUID().toString() // random string
+    var gameId = randomGameId()
     var checksum = ""
     var lastUnitId = 0
 
@@ -863,4 +865,8 @@ class GameInfoPreview() {
     @Readonly fun getCivilization(civID: String) = civilizations.first { it.civID == civID }
     @Readonly fun getCurrentPlayerCiv() = getCivilization(currentPlayer)
     @Readonly fun getPlayerCiv(playerId: String) = civilizations.firstOrNull { it.playerId == playerId }
+    
+    companion object {
+        fun randomGameId() = pseudoRandomUuid(SecureRandom()).toString()
+    }
 }

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -27,6 +27,13 @@ import com.unciv.utils.debug
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
 
+/*
+ * Starts a new game
+ *
+ * Map terrain is determinisic, but game setup, including start locations, resources, and other 
+ * details, are random, based on GameContext.stateBasedRandom, which is based on the gameId, which
+ *  is fully random per game.
+ */
 object GameStarter {
     // temporary instrumentation while tuning/debugging
     private const val consoleTimings = false
@@ -70,7 +77,7 @@ object GameStarter {
             // The MapGen needs to know what civs are in the game to generate regions, starts and resources
             phaseOneChosenCivs = chooseCivilizations(gameSetupInfo.gameParameters, gameInfo, ruleset, existingMap = false)
             addCivilizations(gameSetupInfo.gameParameters, gameInfo, ruleset, phaseOneChosenCivs)
-            tileMap = mapGen.generateMap(gameSetupInfo.mapParameters, gameSetupInfo.gameParameters, gameInfo.civilizations)
+            tileMap = mapGen.generateMap(gameSetupInfo.mapParameters, gameSetupInfo.gameParameters, gameInfo)
             tileMap.mapParameters = gameSetupInfo.mapParameters
             // Now forget them for a moment! MapGen can silently fail to place some city states, so then we'll use the old fallback method to place those.
             gameInfo.civilizations.clear()
@@ -244,6 +251,7 @@ object GameStarter {
         ruleset: Ruleset,
         existingMap: Boolean
     ): List<Player> {
+        val rng = GameContext(gameInfo = gameInfo).stateBasedRandom("GameStarter.chooseCivilizations")
         val selectedPlayerNames = newGameParameters.players
             .map { it.chosenCiv }.toSet()
         @LocalState val randomNationsPool = (
@@ -277,7 +285,7 @@ object GameStarter {
             val nonAICount = newGameParameters.players.count {
                 it.playerType === PlayerType.Human || it.chosenCiv === Constants.spectator
             }
-            val desiredNumberOfPlayers = (min.coerceAtLeast(nonAICount)..max.coerceAtLeast(nonAICount)).random()
+            val desiredNumberOfPlayers = (min.coerceAtLeast(nonAICount)..max.coerceAtLeast(nonAICount)).random(rng)
 
             if (desiredNumberOfPlayers > newGameParameters.players.size) {
                 extraRandomAIPlayers = desiredNumberOfPlayers - newGameParameters.players.size
@@ -327,7 +335,7 @@ object GameStarter {
             // This swaps min and max if the user accidentally swapped min and max
             val min = newGameParameters.minNumberOfCityStates.coerceAtMost(newGameParameters.maxNumberOfCityStates)
             val max = newGameParameters.maxNumberOfCityStates.coerceAtLeast(newGameParameters.minNumberOfCityStates)
-            (min..max).random()
+            (min..max).random(rng)
         } else {
             newGameParameters.numberOfCityStates
         }
@@ -473,6 +481,7 @@ object GameStarter {
         eraUnitReplacement: String,
         settlerLikeUnits: Map<String, BaseUnit>
     ): BaseUnit? {
+        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.getEquivalentUnit($unitParam,$eraUnitReplacement)")
         var unit = unitParam // We want to change it and this is the easiest way to do so
         if (unit == Constants.eraSpecificUnit) unit = eraUnitReplacement
         if (unit == Constants.settler && Constants.settler !in ruleset.units) {
@@ -482,7 +491,7 @@ object GameStarter {
                         && it.value.isCivilian()
                 }
             if (buildableSettlerLikeUnits.isEmpty()) return null // No settlers in this mod
-            return civ.getEquivalentUnit(buildableSettlerLikeUnits.keys.random())
+            return civ.getEquivalentUnit(buildableSettlerLikeUnits.keys.random(rng))
         }
         if (unit == "Worker" && "Worker" !in ruleset.units) {
             val buildableWorkerLikeUnits = ruleset.units.filter {
@@ -490,7 +499,7 @@ object GameStarter {
                     it.value.isBuildable(civ) && it.value.isCivilian()
             }
             if (buildableWorkerLikeUnits.isEmpty()) return null // No workers in this mod
-            return civ.getEquivalentUnit(buildableWorkerLikeUnits.keys.random())
+            return civ.getEquivalentUnit(buildableWorkerLikeUnits.keys.random(rng))
         }
         return civ.getEquivalentUnit(unit)
     }
@@ -501,12 +510,13 @@ object GameStarter {
         startingUnits: MutableList<String>,
         settlerLikeUnits: Map<String, BaseUnit>
     ) {
+        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.adjustStartingUnitsForCityStatesAndOneCityChallenge")
         // Adjust starting units for city states
         if (civ.isCityState && !gameInfo.ruleset.modOptions.hasUnique(UniqueType.AllowCityStatesSpawnUnits)) {
             val startingSettlers = startingUnits.filter { settlerLikeUnits.contains(it) }
 
             startingUnits.clear()
-            startingUnits.add(startingSettlers.random())
+            startingUnits.add(startingSettlers.random(rng))
         }
 
         // Adjust starting units for one city challenge
@@ -514,7 +524,7 @@ object GameStarter {
             val startingSettlers = startingUnits.filter { settlerLikeUnits.contains(it) }
 
             startingUnits.removeAll(startingSettlers)
-            startingUnits.add(startingSettlers.random())
+            startingUnits.add(startingSettlers.random(rng))
         }
     }
 
@@ -622,9 +632,10 @@ object GameStarter {
         freeTiles: MutableList<Tile>,
         startScores: HashMap<Tile, Float>,
     ): Tile? {
-        var startingLocation = tileMap.startingLocationsByNation[civ.civID]?.randomOrNull()
+        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.getCivStartingLocation")
+        var startingLocation = tileMap.startingLocationsByNation[civ.civID]?.randomOrNull(rng)
         if (startingLocation == null) {
-            startingLocation = tileMap.startingLocationsByNation[Constants.spectator]?.randomOrNull()
+            startingLocation = tileMap.startingLocationsByNation[Constants.spectator]?.randomOrNull(rng)
             if (startingLocation != null) {
                 tileMap.startingLocationsByNation[Constants.spectator]?.remove(startingLocation)
             }
@@ -642,8 +653,9 @@ object GameStarter {
         freeTiles: MutableList<Tile>,
         startScores: HashMap<Tile, Float>
     ): Tile {
+        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.getOneStartingLocation")
         if (gameSetupInfo.gameParameters.noStartBias) {
-            return freeTiles.random()
+            return freeTiles.random(rng)
         }
         if (civ.nation.startBias.any { it in tileMap.naturalWonders }) {
             // startPref wants Natural wonder neighbor: Rare and very likely to be outside getDistanceFromEdge
@@ -673,6 +685,6 @@ object GameStarter {
                 }
             }
         }
-        return preferredTiles.randomOrNull() ?: freeTiles.random()
+        return preferredTiles.randomOrNull(rng) ?: freeTiles.random(rng)
     }
 }

--- a/core/src/com/unciv/logic/HolidayDates.kt
+++ b/core/src/com/unciv/logic/HolidayDates.kt
@@ -153,11 +153,12 @@ object HolidayDates {
     fun getHolidayByYear(holiday: Holidays, year: Int) = holiday.getByYear(year)
 
     fun getHolidayByDate(date: LocalDate = LocalDate.now()): Holidays? {
+        val rng = Random(date.hashCode())
         return System.getProperty("easterEgg")?.let {
             Holidays.safeValueOf(it)
         } ?: Holidays.entries.firstOrNull {
             val range = it.getByYear(date.year)
-            date in range && Random.nextFloat() <= it.chance
+            date in range && rng.nextFloat() <= it.chance
         }
     }
 

--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.utils.randomWeighted
@@ -279,8 +280,9 @@ class Encampment() : IsPartOfGameInfoSerialization {
         // Civ V weights its list by FAST_ATTACK or ATTACK_SEA AI types, we'll do it a bit differently
         // getForceEvaluation is already conveniently biased towards fast units and against ranged naval
         val weightings = unitList.map { it.getForceEvaluation().toFloat() }
+        val rng = GameContext(gameInfo = gameInfo).stateBasedRandom("BarbarianManager.chooseBarbarianUnit")
 
-        return unitList.randomWeighted(weightings)
+        return unitList.randomWeighted(weightings, rng)
     }
 
     /** When a barbarian is spawned, seed the counter for next spawn */

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -237,6 +237,8 @@ object NextTurnAutomation {
     }
 
     private fun chooseTechToResearch(civInfo: Civilization) {
+        val rng = civInfo.state.stateBasedRandom("NextTurnAutomation.chooseTechToResearch")
+
         @Readonly
         fun getGroupedResearchableTechs(): List<List<Technology>> {
             val researchableTechs = civInfo.gameInfo.ruleset.technologies.values
@@ -255,7 +257,7 @@ object NextTurnAutomation {
                 // Ignore rows where all techs have 0 weight
                 it.any { it.getWeightForAiDecision(stateForConditionals) > 0 }
             } ?: costs.last()
-            val chosenTech = mostExpensiveTechs.randomWeighted { it.getWeightForAiDecision(stateForConditionals) }
+            val chosenTech = mostExpensiveTechs.randomWeighted(rng) { it.getWeightForAiDecision(stateForConditionals) }
             civInfo.tech.getFreeTechnology(chosenTech.name)
         }
         if (civInfo.tech.techsToResearch.isEmpty()) {
@@ -268,11 +270,11 @@ object NextTurnAutomation {
             //Do not consider advanced techs if only one tech left in cheapest group
             val techToResearch: Technology =
                 if (cheapestTechs.size == 1 || costs.size == 1) {
-                    cheapestTechs.randomWeighted { it.getWeightForAiDecision(stateForConditionals) }
+                    cheapestTechs.randomWeighted(rng) { it.getWeightForAiDecision(stateForConditionals) }
                 } else {
                     //Choose randomly between cheapest and second cheapest group
                     val techsAdvanced = costs[1]
-                    (cheapestTechs + techsAdvanced).randomWeighted { it.getWeightForAiDecision(stateForConditionals) }
+                    (cheapestTechs + techsAdvanced).randomWeighted(rng) { it.getWeightForAiDecision(stateForConditionals) }
                 }
 
             civInfo.tech.techsToResearch.add(techToResearch.name)
@@ -337,7 +339,7 @@ object NextTurnAutomation {
             val policyToAdopt: Policy =
                 if (civInfo.policies.isAdoptable(targetBranch)) targetBranch
                 else targetBranch.policies.filter { civInfo.policies.isAdoptable(it) }
-                    .randomWeighted { it.getWeightForAiDecision(civInfo.state) }
+                    .randomWeighted(rng) { it.getWeightForAiDecision(civInfo.state) }
 
             civInfo.policies.adopt(policyToAdopt)
         }
@@ -417,6 +419,7 @@ object NextTurnAutomation {
                 // Restrict Human automated units from promotions via setting
                 (UncivGame.Current.settings.automatedUnitsChoosePromotions || unit.civ.isAI())
             ) {
+                val rng = unit.cache.state.stateBasedRandom("NextTurnAutomation.automateUnits")
                 val promotions = unit.promotions.getAvailablePromotions()
                 val availablePromotions = if (unit.health <= 60
                     && promotions.any { it.hasUnique(UniqueType.OneTimeUnitHeal) }
@@ -431,11 +434,11 @@ object NextTurnAutomation {
                 val stateForConditionals = unit.cache.state
 
                 val chosenPromotion =
-                    if (freePromotions.isNotEmpty()) freePromotions.randomWeighted {
+                    if (freePromotions.isNotEmpty()) freePromotions.randomWeighted(rng) {
                         it.getWeightForAiDecision(stateForConditionals)
                     }
                     else availablePromotions.toList()
-                        .randomWeighted { it.getWeightForAiDecision(stateForConditionals) }
+                        .randomWeighted(rng) { it.getWeightForAiDecision(stateForConditionals) }
 
                 unit.promotions.addPromotion(chosenPromotion.name)
             }

--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -213,18 +213,22 @@ object ReligionAutomation {
 
         for (city in civInfo.cities) {
             for (tile in city.getCenterTile().getTilesInDistance(city.getWorkRange())) {
+                val tileRng = tile.stateThisTile.stateBasedRandom("ReligionAutomation.rateBelief")
                 val tileScore = beliefBonusForTile(belief, tile, city)
+                
                 score += tileScore * when {
                     city.workedTiles.contains(tile.position) -> 1f // worked
                     tile.getCity() == city -> 0.7f // workable
                     else -> 0.5f // unavailable - for now
-                } * (Random.nextFloat() * 0.05f + 0.975f)
+                } * (tileRng.nextFloat() * 0.05f + 0.975f)
             }
 
-            score += beliefBonusForCity(civInfo, belief, city) * (Random.nextFloat() * 0.1f + 0.95f)
+            val cityRng = city.state.stateBasedRandom("ReligionAutomation.rateBelief")
+            score += beliefBonusForCity(civInfo, belief, city) * (cityRng.nextFloat() * 0.1f + 0.95f)
         }
 
-        score += beliefBonusForPlayer(civInfo, belief) * (Random.nextFloat() * 0.3f + 0.85f)
+        val civRng = civInfo.state.stateBasedRandom("ReligionAutomation.rateBelief")
+        score += beliefBonusForPlayer(civInfo, belief) * (civRng.nextFloat() * 0.3f + 0.85f)
 
         // All of these Random.nextFloat() don't exist in the original, but I've added them to make things a bit more random.
 

--- a/core/src/com/unciv/logic/battle/AirInterception.kt
+++ b/core/src/com/unciv/logic/battle/AirInterception.kt
@@ -149,8 +149,11 @@ object AirInterception {
         interceptingCiv: Civilization,
         defender: ICombatant?
     ): Battle.DamageDealt {
-        if (attacker.unit.hasUnique(UniqueType.CannotBeIntercepted, GameContext(attacker.getCivInfo(), ourCombatant = attacker, theirCombatant = defender, attackedTile = attackedTile)))
+        val attackContext = GameContext(attacker, defender, attackedTile, CombatAction.Intercept)
+        if (attacker.unit.hasUnique(UniqueType.CannotBeIntercepted, attackContext))
             return Battle.DamageDealt.None
+        val rng = attackContext.stateBasedRandom("AirInterception.tryInterceptAirAttack")
+
 
         // Pick highest chance interceptor
         val interceptor = interceptingCiv.units.getCivUnits()
@@ -168,7 +171,7 @@ object AirInterception {
 
         interceptor.attacksThisTurn++  // even if you miss, you took the shot
         // Does Intercept happen? If not, exit
-        if (Random.Default.nextFloat() > interceptor.interceptChance() / 100f)
+        if (rng.nextFloat() > interceptor.interceptChance() / 100f)
             return Battle.DamageDealt.None
 
         var damage = BattleDamage.calculateDamageToDefender(

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -371,8 +371,10 @@ object Battle {
     }
 
     internal fun takeDamage(attacker: ICombatant, defender: ICombatant): DamageDealt {
+        val attackContext = GameContext(attacker, defender, defender.getTile(), CombatAction.Attack)
         var potentialDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender)
         var potentialDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender)
+        val rng = attackContext.stateBasedRandom("Battle.takeDamage")
 
         val attackerHealthBefore = attacker.getHealth()
         val defenderHealthBefore = defender.getHealth()
@@ -386,7 +388,7 @@ object Battle {
             //so...for each round, we randomize who gets the attack in. Seems to be a good way to work for now.
 
             while (potentialDamageToDefender + potentialDamageToAttacker > 0) {
-                if (Random.Default.nextInt(potentialDamageToDefender + potentialDamageToAttacker) < potentialDamageToDefender) {
+                if (rng.nextInt(potentialDamageToDefender + potentialDamageToAttacker) < potentialDamageToDefender) {
                     potentialDamageToDefender--
                     defender.takeDamage(1)
                     if (defender.isDefeated()) break
@@ -750,6 +752,8 @@ object Battle {
         // Promotions have no effect as per what I could find in available documentation
         val fromTile = defender.getTile()
         val attackerTile = attacker.getTile()
+        val attackContext = GameContext(attacker, defender, fromTile, CombatAction.Defend)
+        val rng = attackContext.stateBasedRandom("Battle.doWithdrawFromMeleeAbility")
 
         @Readonly
         fun canNotWithdrawTo(tile: Tile): Boolean { // if the tile is what the defender can't withdraw to, this fun will return true
@@ -763,8 +767,8 @@ object Battle {
         val secondCandidateTiles = fromTile.neighbors.filter { it in attackerTile.neighbors }
                 .filterNot { canNotWithdrawTo(it) }
         val toTile: Tile = when {
-            firstCandidateTiles.any() -> firstCandidateTiles.toList().random()
-            secondCandidateTiles.any() -> secondCandidateTiles.toList().random()
+            firstCandidateTiles.any() -> firstCandidateTiles.toList().random(rng)
+            secondCandidateTiles.any() -> secondCandidateTiles.toList().random(rng)
             else -> return false
         }
         // Withdraw success: Do it - move defender to toTile for no cost

--- a/core/src/com/unciv/logic/battle/Nuke.kt
+++ b/core/src/com/unciv/logic/battle/Nuke.kt
@@ -6,6 +6,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.screens.worldscreen.bottombar.BattleTable
@@ -201,6 +202,7 @@ object Nuke {
         // https://www.carlsguides.com/strategy/civilization5/units/aircraft-nukes.ph
         // Testing done by Ravignir
         // original source code: GenerateNuclearExplosionDamage(), ApplyNuclearExplosionDamage()
+        val tileContext = attacker.unit.cache.state.copy(tile = tile)
 
         var damageModifierFromMissingResource = 1f
         val civResources = attacker.getCivInfo().getCivResourcesByName()
@@ -215,22 +217,25 @@ object Nuke {
         // Damage city and reduce its population
         val city = tile.getCity()
         if (city != null && tile.position.toHexCoord() == city.location.toHexCoord()) {
+            val attackContext = GameContext(attacker.getCivInfo(), ourCombatant = attacker, theirCombatant = CityCombatant(city), tile = tile)
             buildingModifier = city.getAggregateModifier(UniqueType.GarrisonDamageFromNukes)
-            doNukeExplosionDamageToCity(city, nukeStrength, damageModifierFromMissingResource)
+            doNukeExplosionDamageToCity(city, nukeStrength, damageModifierFromMissingResource, attackContext)
             Battle.postBattleNotifications(attacker, CityCombatant(city), city.getCenterTile())
             Battle.destroyIfDefeated(city.civ, attacker.getCivInfo(), city.location.toHexCoord())
         }
 
         // Damage and/or destroy units on the tile
         for (unit in tile.getUnits().toList()) { // toList so if it's destroyed there's no concurrent modification
+            val defender = MapUnitCombatant(unit)
+            val attackContext = GameContext(attacker.getCivInfo(), ourCombatant = attacker, theirCombatant = defender, tile = tile)
+            val rng = attackContext.stateBasedRandom("Nuke.doNukeExplosionForTile")
             val damage = (when {
                 isGroundZero || nukeStrength >= 2 -> 100
                 // The following constants are NUKE_UNIT_DAMAGE_BASE / NUKE_UNIT_DAMAGE_RAND_1 / NUKE_UNIT_DAMAGE_RAND_2 in Civ5
-                nukeStrength == 1 -> 30 + Random.Default.nextInt(40) + Random.Default.nextInt(40)
+                nukeStrength == 1 -> 30 + rng.nextInt(40) + rng.nextInt(40)
                 // Level 0 does not exist in Civ5 (it treats units same as level 2)
-                else -> 20 + Random.Default.nextInt(30)
+                else -> 20 + rng.nextInt(30)
             } * buildingModifier * damageModifierFromMissingResource + 1f.ulp).toInt()
-            val defender = MapUnitCombatant(unit)
             if (unit.isCivilian()) {
                 if (unit.health - damage <= 40) unit.destroy()  // Civ5: NUKE_NON_COMBAT_DEATH_THRESHOLD = 60
             } else {
@@ -243,18 +248,19 @@ object Nuke {
         // Pillage improvements, pillage roads, add fallout
         if (tile.isCityCenter()) return  // Never touch city centers - if they survived
 
+        val tileRng = tileContext.stateBasedRandom("Nuke.doExplosionForTile")
         if (tile.terrainHasUnique(UniqueType.DestroyableByNukesChance)) {
             // Note: Safe from concurrent modification exceptions only because removeTerrainFeature
             // *replaces* terrainFeatureObjects and the loop will continue on the old one
             for (terrainFeature in tile.terrainFeatureObjects) {
                 for (unique in terrainFeature.getMatchingUniques(UniqueType.DestroyableByNukesChance)) {
                     val chance = unique.params[0].toFloat() / 100f
-                    if (!(chance > 0f && isGroundZero) && Random.Default.nextFloat() >= chance) continue
+                    if (!(chance > 0f && isGroundZero) && tileRng.nextFloat() >= chance) continue
                     tile.removeTerrainFeature(terrainFeature.name)
                     applyPillageAndFallout(tile)
                 }
             }
-        } else if (isGroundZero || Random.Default.nextFloat() < 0.5f) {  // Civ5: NUKE_FALLOUT_PROB
+        } else if (isGroundZero || tileRng.nextFloat() < 0.5f) {  // Civ5: NUKE_FALLOUT_PROB
             applyPillageAndFallout(tile)
         }
     }
@@ -272,7 +278,7 @@ object Nuke {
     }
 
     /** @return the "protection" modifier from buildings (Bomb Shelter, UniqueType.PopulationLossFromNukes) */
-    private fun doNukeExplosionDamageToCity(targetedCity: City, nukeStrength: Int, damageModifierFromMissingResource: Float) {
+    private fun doNukeExplosionDamageToCity(targetedCity: City, nukeStrength: Int, damageModifierFromMissingResource: Float, context: GameContext) {
         // Original Capitals must be protected, `canBeDestroyed` is responsible for that check.
         // The `justCaptured = true` parameter is what allows other Capitals to suffer normally.
         if ((nukeStrength > 2 || nukeStrength > 1 && targetedCity.population.population < 5)
@@ -282,6 +288,7 @@ object Nuke {
         }
 
         val cityCombatant = CityCombatant(targetedCity)
+        val rng = context.stateBasedRandom("Nuke.doNukeExplosionDamageToCity")
         cityCombatant.takeDamage((cityCombatant.getHealth() * 0.5f * damageModifierFromMissingResource).toInt())
 
         // Difference to original: Civ5 rounds population loss down twice - before and after bomb shelters
@@ -290,8 +297,8 @@ object Nuke {
                 targetedCity.getAggregateModifier(UniqueType.PopulationLossFromNukes) *
                 when (nukeStrength) {
                     0 -> 0f
-                    1 -> (30 + Random.Default.nextInt(20) + Random.Default.nextInt(20)) / 100f
-                    2 -> (60 + Random.Default.nextInt(10) + Random.Default.nextInt(10)) / 100f
+                    1 -> (30 + rng.nextInt(20) + rng.nextInt(20)) / 100f
+                    2 -> (60 + rng.nextInt(10) + rng.nextInt(10)) / 100f
                     else -> 1f  // hypothetical nukeStrength 3 -> always to 1 pop
                 }
             ).toInt()

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -31,12 +31,12 @@ import com.unciv.models.stats.GameResource
 import com.unciv.models.stats.INamed
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.SubStat
+import com.unciv.utils.pseudoRandomUuid
 import com.unciv.utils.withoutItem
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
 import java.util.EnumSet
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
 
@@ -67,7 +67,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     var hasJustBeenConquered = false
 
     var location = HexCoord()
-    var id: String = UUID.randomUUID().toString()
+    var id: String = NO_ID
     override var name: String = ""
     /** Serialization field for [foundingCivObject]. Is equivalent to `foundingCivObject.civName` */
     private var foundingCiv = ""
@@ -163,7 +163,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     fun clone(): City {
         val toReturn = City()
         toReturn.location = location
-        toReturn.id = id
+        toReturn.id = if (id != NO_ID) id else pseudoRandomId(civ)
         toReturn.name = name
         toReturn.health = health
         toReturn.population = population.clone()
@@ -386,6 +386,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     //region state-changing functions
     fun setTransients(civInfo: Civilization) {
         this.civ = civInfo
+        this.id = if (id != NO_ID) id else pseudoRandomId(civ)
         tileMap = civInfo.gameInfo.tileMap
         centerTile = tileMap[location]
         state = GameContext(this)
@@ -678,4 +679,9 @@ class City : IsPartOfGameInfoSerialization, INamed {
     }
 
     //endregion
+    
+    companion object {
+        const val NO_ID = "00000000-0000-0000-0000-000000000000"
+        fun pseudoRandomId(civ: Civilization) = pseudoRandomUuid(GameContext(civ).stateBasedRandom("City.Id", civ.cities.size)).toString()
+    }
 }

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -4,6 +4,8 @@ import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.logic.battle.Battle
 import com.unciv.logic.city.City
+import com.unciv.logic.city.City.Companion.NO_ID
+import com.unciv.logic.city.City.Companion.pseudoRandomId
 import com.unciv.logic.city.CityFlags
 import com.unciv.logic.city.CityFocus
 import com.unciv.logic.civilization.Civilization
@@ -295,6 +297,7 @@ class CityConquestFunctions(val city: City) {
         oldCiv.cities = oldCiv.cities.withoutItem(city)
         newCiv.cities = newCiv.cities.withItem(city)
         city.civ = newCiv
+        city.id = if (city.id != NO_ID) city.id else pseudoRandomId(newCiv)
         city.state = GameContext(city)
         city.hasJustBeenConquered = false
         city.turnAcquired = city.civ.gameInfo.turns

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -64,7 +64,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         if (uniqueTypes.contains(UniqueType.CityStateMilitaryUnits)) {
             val possibleUnits = possibleUnits()
             if (possibleUnits.isNotEmpty())
-                civInfo.cityStateUniqueUnit = possibleUnits.random().name
+                civInfo.cityStateUniqueUnit = possibleUnits.random(rng).name
         }
 
         // TODO: Return false if attempting to put a religious city-state in a game without religion
@@ -636,13 +636,15 @@ class CityStateFunctions(val civInfo: Civilization) {
     fun cityStateAttacked(attacker: Civilization) {
         if (!civInfo.isCityState) return // What are we doing here?
         if (attacker.isCityState) return // City states can't be upset with each other
+        val context = GameContext(civInfo, attacker)
+        val rng = context.stateBasedRandom("CityStateFunctions.cityStateAttacked")
 
         // We might become wary!
         if (attacker.isMinorCivWarmonger()) { // They've attacked a lot of city-states
             civInfo.getDiplomacyManager(attacker)!!.becomeWary()
         }
         else if (attacker.isMinorCivAggressor()) { // They've attacked a few
-            if (Random.Default.nextBoolean()) { // 50% chance
+            if (rng.nextBoolean()) { // 50% chance
                 civInfo.getDiplomacyManager(attacker)!!.becomeWary()
             }
         }
@@ -660,6 +662,8 @@ class CityStateFunctions(val civInfo: Civilization) {
     }
 
     private fun makeOtherCityStatesWaryOfAttacker(attacker: Civilization) {
+        val context = GameContext(civInfo, attacker)
+        val rng = context.stateBasedRandom("CityStateFunctions.makeOtherCityStatesWaryOfAttacker")
         for (cityState in civInfo.gameInfo.getAliveCityStates()) {
             if (cityState == civInfo) // Must be a different minor
                 continue
@@ -692,7 +696,7 @@ class CityStateFunctions(val civInfo: Civilization) {
             if (cityState.isAtWarWith(attacker))
                 probability += 50
 
-            if (Random.nextInt(100) <= probability) {
+            if (rng.nextInt(100) <= probability) {
                 cityState.getDiplomacyManager(attacker)!!.becomeWary()
             }
         }

--- a/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
@@ -173,11 +173,12 @@ class QuestManager : IsPartOfGameInfoSerialization {
         if (globalQuestCountdown != UNSET)
             return
 
+        val rng = civ.state.stateBasedRandom("QuestManager.seedGlobalQuestCooldown")
         val countdown =
                 if (civ.gameInfo.turns == GLOBAL_QUEST_FIRST_POSSIBLE_TURN)
-                    Random.nextInt(GLOBAL_QUEST_FIRST_POSSIBLE_TURN_RAND)
+                    rng.nextInt(GLOBAL_QUEST_FIRST_POSSIBLE_TURN_RAND)
                 else
-                    GLOBAL_QUEST_MIN_TURNS_BETWEEN + Random.nextInt(GLOBAL_QUEST_RAND_TURNS_BETWEEN)
+                    GLOBAL_QUEST_MIN_TURNS_BETWEEN + rng.nextInt(GLOBAL_QUEST_RAND_TURNS_BETWEEN)
 
         globalQuestCountdown = (countdown * civ.gameInfo.speed.modifier).toInt()
     }
@@ -193,11 +194,12 @@ class QuestManager : IsPartOfGameInfoSerialization {
     }
 
     private fun seedIndividualQuestsCountdown(challenger: Civilization) {
+        val rng = civ.state.copy(otherCiv = challenger).stateBasedRandom("QuestManager.seedIndividualQuestCooldown")
         val countdown: Int =
                 if (civ.gameInfo.turns == INDIVIDUAL_QUEST_FIRST_POSSIBLE_TURN)
-                    Random.nextInt(INDIVIDUAL_QUEST_FIRST_POSSIBLE_TURN_RAND)
+                    rng.nextInt(INDIVIDUAL_QUEST_FIRST_POSSIBLE_TURN_RAND)
                 else
-                    INDIVIDUAL_QUEST_MIN_TURNS_BETWEEN + Random.nextInt(
+                    INDIVIDUAL_QUEST_MIN_TURNS_BETWEEN + rng.nextInt(
                         INDIVIDUAL_QUEST_RAND_TURNS_BETWEEN
                     )
 

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -278,7 +278,8 @@ class TurnManager(val civInfo: Civilization) {
             // Set turns to elections to a random number so not every city-state has the same election date
             // May be called at game start or when migrating a game from an older version
             if (civInfo.gameInfo.isEspionageEnabled() && !civInfo.hasFlag(CivFlags.TurnsTillCityStateElection.name)) {
-                civInfo.addFlag(CivFlags.TurnsTillCityStateElection.name, Random.nextInt(civInfo.gameInfo.ruleset.modOptions.constants.cityStateElectionTurns + 1))
+                val rng = civInfo.state.stateBasedRandom("TurnManager.endTurn(Espianage)")
+                civInfo.addFlag(CivFlags.TurnsTillCityStateElection.name, rng.nextInt(civInfo.gameInfo.ruleset.modOptions.constants.cityStateElectionTurns + 1))
             }
         }
 

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -23,6 +23,7 @@ import yairm210.purity.annotations.Readonly
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
 import kotlin.math.max
+import kotlin.random.Random
 
 /** An Unciv map with all properties as produced by the [map editor][com.unciv.ui.screens.mapeditorscreen.MapEditorScreen]
  * or [MapGenerator][com.unciv.logic.map.mapgenerator.MapGenerator]; or as part of a running [game][GameInfo].
@@ -759,7 +760,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
      *  @throws Exception when `mode==Assign` and any land tile already has a continent ID
      *  @return A map of continent sizes (continent ID to tile count)
      */
-    fun assignContinents(mode: AssignContinentsMode) {
+    fun assignContinents(mode: AssignContinentsMode, rng: Random = GameContext(gameInfo = gameInfo).stateBasedRandom("TileMap.assignContinents")) {
         if (mode == AssignContinentsMode.Clear) {
             values.forEach { it.clearContinent() }
             continentSizes.clear()
@@ -784,7 +785,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             values.forEach { it.clearContinent() }
 
         while (landTiles.any()) {
-            val bfs = BFS(landTiles.random()) { it.isLand && !it.isImpassible() }
+            val bfs = BFS(landTiles.random(rng)) { it.isLand && !it.isImpassible() }
             bfs.stepToEnd()
             bfs.getReachedTiles().forEach {
                 it.setContinent(currentContinent)

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -3,7 +3,7 @@ package com.unciv.logic.map.mapgenerator
 import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
 import com.unciv.UncivGame
-import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.GameInfo
 import com.unciv.logic.map.*
 import com.unciv.logic.map.mapgenerator.mapregions.MapRegions
 import com.unciv.logic.map.tile.Tile
@@ -133,7 +133,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             .map { unique -> TerrainOccursRange(this, unique) }
             .ifEmpty { sequenceOf(TerrainOccursRange(this)) }
 
-    fun generateMap(mapParameters: MapParameters, gameParameters: GameParameters = GameParameters(), civilizations: List<Civilization> = emptyList()): TileMap {
+    fun generateMap(mapParameters: MapParameters, gameParameters: GameParameters = GameParameters(), gameInfo: GameInfo? = null): TileMap {
         val mapSize = mapParameters.mapSize
         val mapType = mapParameters.type
 
@@ -182,7 +182,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             spawnIce(map)
         }
         runAndMeasure("assignContinents") {
-            map.assignContinents(TileMap.AssignContinentsMode.Assign)
+            map.assignContinents(TileMap.AssignContinentsMode.Assign, randomness.RNG)
         }
         runAndMeasure("RiverGenerator") {
             RiverGenerator(map, randomness, ruleset).spawnRivers()
@@ -190,7 +190,9 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
         convertTerrains(map.values)
 
         // Region based map generation - not used when generating maps in map editor
-        if (civilizations.isNotEmpty()) {
+        val civilizations = gameInfo?.civilizations
+        if (civilizations?.isNotEmpty() ?: false) {
+            map.gameInfo = gameInfo
             val regions = MapRegions(ruleset)
             runAndMeasure("generateRegions") {
                 regions.generateRegions(map, civilizations.count { ruleset.nations[it.civName]!!.isMajorCiv })
@@ -285,7 +287,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
                 MapGeneratorSteps.Vegetation -> spawnVegetation(map)
                 MapGeneratorSteps.RareFeatures -> spawnRareFeatures(map)
                 MapGeneratorSteps.Ice -> spawnIce(map)
-                MapGeneratorSteps.Continents -> map.assignContinents(TileMap.AssignContinentsMode.Reassign)
+                MapGeneratorSteps.Continents -> map.assignContinents(TileMap.AssignContinentsMode.Reassign, randomness.RNG)
                 MapGeneratorSteps.NaturalWonders -> NaturalWonderGenerator(ruleset, randomness).spawnNaturalWonders(map)
                 MapGeneratorSteps.Rivers -> {
                     val resultingTiles = mutableSetOf<Tile>()
@@ -418,7 +420,8 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
                 suitableTiles,
                 map.mapParameters.mapSize.radius)
         for (tile in locations) {
-            val ruins = ruinsEquivalents.values.filter { isPlaceable(it, tile) }.random()
+            val rng = GameContext(tile = tile).stateBasedRandom("MapGenerator.spreadAncientRuins")
+            val ruins = ruinsEquivalents.values.filter { isPlaceable(it, tile) }.random(rng)
             tile.setImprovementBasic(ruins)
         }
     }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -186,9 +186,9 @@ class MapLandmassGenerator(
                 spawnLandOrWater(tile, elevation)
                 tile.setTerrainTransients() // necessary for assignContinents
             }
-            tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign) // to support largeContinents above
+            tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign, randomness.RNG) // to support largeContinents above
         }
-        tileMap.assignContinents(TileMap.AssignContinentsMode.Clear)
+        tileMap.assignContinents(TileMap.AssignContinentsMode.Clear, randomness.RNG)
     }
 
     private fun createInnerSea() {

--- a/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.map.mapgenerator.RiverGenerator.Companion.continueRiverOn
 import com.unciv.logic.map.mapgenerator.RiverGenerator.RiverCoordinate
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.utils.debug
 import kotlin.math.roundToInt
@@ -280,10 +281,11 @@ class RiverGenerator(
             // Greatly encourage connecting to sea unless the tile already has a river to sea, in which case slightly discourage another one
             val edgeToSeaPriority = if (viableNeighbors.none { it.isConnectedByRiver && it.edgeLeadsToSea }) 9 else -1
 
+            val rng = GameContext(tile = tile).stateBasedRandom("RiverGenerator.continueRiverOn")
             val choice = viableNeighbors
                 .groupBy { it.getPriority(edgeToSeaPriority) } // Assign and group by priorities
                 .maxBy { it.key }.value // Get the List with best priority - can't be empty
-                .random()
+                .random(rng)
 
             return tile.setConnectedByRiver(choice.otherTile, newValue = true, convertTerrains = true)
         }

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
@@ -24,6 +24,7 @@ import com.unciv.utils.Tag
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.random.Random
 
 class TileDataMap : HashMap<HexCoord, MapGenTileData>() {
 
@@ -371,8 +372,9 @@ class MapRegions (val ruleset: Ruleset) {
 
         // Finally assign the remaining civs randomly
         for (civ in randomCivs) {
+            val rng = civ.state.stateBasedRandom("MapRegions.assignRegions")
             // throws if regions.size < civilizations.size or if the assigning mismatched - leads to popup on newgame screen
-            val startRegion = unpickedRegions.random()
+            val startRegion = unpickedRegions.random(rng)
             logAssignRegion(true, BiasTypes.Random, civ, startRegion)
             assignCivToRegion(civ, startRegion)
             unpickedRegions.remove(startRegion)

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import yairm210.purity.annotations.Readonly
 import kotlin.math.min
@@ -168,7 +169,8 @@ object MinorCivPlacer {
         )
         // Fallback to a random region for civs that couldn't be placed in the wilderness
         for (unplacedCiv in civAssignedToUninhabited) {
-            regions.random().assignedMinorCivs.add(unplacedCiv)
+            val rng = unplacedCiv.state.stateBasedRandom("MinorCivPlacer.placeAssignedMinorCivs")
+            regions.random(rng).assignedMinorCivs.add(unplacedCiv)
         }
 
         // Now place the ones assigned to specific regions.
@@ -210,7 +212,8 @@ object MinorCivPlacer {
      *  Will modify both [civsToPlace] and [tileList] as it goes! */
     private fun tryPlaceMinorCivsInTiles(civsToPlace: MutableList<Civilization>, tileMap: TileMap, tileList: MutableList<Tile>, tileData: TileDataMap, ruleset: Ruleset) {
         while (tileList.isNotEmpty() && civsToPlace.isNotEmpty()) {
-            val chosenTile = tileList.random()
+            val rng = GameContext(gameInfo = tileMap.gameInfo).stateBasedRandom("MinorCivPlcer.tryPlaceMinorCivsInTiles")
+            val chosenTile = tileList.random(rng)
             tileList.remove(chosenTile)
             val data = tileData[chosenTile.position]!!
             // If the randomly chosen tile is too close to a player or a city state, discard it

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/StartNormalizer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/StartNormalizer.kt
@@ -49,6 +49,7 @@ object StartNormalizer {
         ruleset: Ruleset,
         tileData: TileDataMap
     ) {
+        val rng = GameContext(civInfo = startTile.getOwner(), tile = startTile).stateBasedRandom("StartNormalizer.normalizeProduction")
         // evaluate production potential
         val innerProduction =
             startTile.neighbors.sumOf { getPotentialYield(it, Stat.Production).toInt() }
@@ -68,7 +69,7 @@ object StartNormalizer {
         if (innerProduction == 0 || (innerProduction < 2 && outerProduction < 8) || (isMinorCiv && innerProduction < 4)) {
             val hillSpot = startTile.neighbors
                 .filter { it.isLand && it.terrainFeatures.isEmpty() && !it.isAdjacentTo(Constants.freshWater) && !it.isImpassible() }
-                .toList().randomOrNull()
+                .toList().randomOrNull(rng)
             val hillEquivalent = ruleset.terrains.values
                 .firstOrNull {
                     it.type == TerrainType.TerrainFeature && it.production >= 2 && !it.hasUnique(
@@ -136,6 +137,7 @@ object StartNormalizer {
 
     /** Check for very food-heavy starts that might still need some stone to help with production */
     private fun addProductionBonuses(startTile: Tile, ruleset: Ruleset) {
+        val rng = GameContext(gameInfo = startTile.tileMap.gameInfo).stateBasedRandom("StartNormalizer.addProductionBonuses")
         val grassTypePlots = startTile.getTilesInDistanceRange(1..2).filter {
             it.isLand &&
                 getPotentialYield(it, Stat.Food, unimproved = true) >= 2f && // Food neutral natively
@@ -156,12 +158,12 @@ object StartNormalizer {
 
         if (productionBonuses.isNotEmpty()) {
             while (productionBonusesNeeded > 0 && grassTypePlots.isNotEmpty()) {
-                val plot = grassTypePlots.random()
+                val plot = grassTypePlots.random(rng)
                 grassTypePlots.remove(plot)
 
                 if (plot.tileResource != null) continue
 
-                val bonusToPlace = productionBonuses.filter { it.generatesNaturallyOn(plot) }.randomOrNull()
+                val bonusToPlace = productionBonuses.filter { it.generatesNaturallyOn(plot) }.randomOrNull(rng)
                 if (bonusToPlace != null) {
                     plot.tileResource = bonusToPlace
                     productionBonusesNeeded--
@@ -244,6 +246,7 @@ object StartNormalizer {
         ruleset: Ruleset,
         foodBonusesNeeded: Int
     ) {
+        val rng = GameContext(tile = startTile).stateBasedRandom("StartNormalizer.placeFoodBonuses")
         var bonusesStillNeeded = foodBonusesNeeded
         val oasisEquivalent = ruleset.terrains.values.firstOrNull {
             it.type == TerrainType.TerrainFeature &&
@@ -269,7 +272,7 @@ object StartNormalizer {
             candidatePlots.remove(plot) // remove the plot as it has now been tried, whether successfully or not
             if (plot.getBaseTerrain().hasUnique(
                     UniqueType.BlocksResources,
-                    GameContext(attackedTile = plot, gameInfo = null)
+                    GameContext(attackedTile = plot)
                 )
             )
                 continue // Don't put bonuses on snow hills
@@ -287,7 +290,7 @@ object StartNormalizer {
                     plot.addTerrainFeature(oasisEquivalent!!.name)
                     canPlaceOasis = false
                 } else {
-                    plot.setTileResource(validBonuses.random())
+                    plot.setTileResource(validBonuses.random(rng))
                 }
 
                 if (plot.aerialDistanceTo(startTile) == 1) {

--- a/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/LuxuryResourcePlacementLogic.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/LuxuryResourcePlacementLogic.kt
@@ -25,6 +25,7 @@ object LuxuryResourcePlacementLogic {
      *  Some luxuries are earmarked for city states. The rest are randomly distributed or
      *  don't occur at all in the map */
     fun assignLuxuries(regions: ArrayList<Region>, tileData: TileDataMap, ruleset: Ruleset): Pair<List<String>, List<String>> {
+        val globalRng = GameContext(gameInfo = regions[0].tileMap.gameInfo).stateBasedRandom("LuxuryResourcePlacementLogic.assignLuxuries")
 
         // If there are any weightings defined in json, assume they are complete. If there are none, use flat weightings instead
         val fallbackWeightings = ruleset.tileResources.values.none {
@@ -47,6 +48,7 @@ object LuxuryResourcePlacementLogic {
             .forEach { amountRegionsWithLuxury[it.name] = 0 }
 
         for (region in regions.sortedBy { getRegionPriority(ruleset.terrains[it.type]) } ) {
+            val regionRng = GameContext(gameInfo = region.tileMap.gameInfo, region = region).stateBasedRandom("LuxuryResourcePlacementLogic.assignLuxuries")
             val candidateLuxuries = getCandidateLuxuries(
                 assignableLuxuries,
                 amountRegionsWithLuxury,
@@ -60,20 +62,20 @@ object LuxuryResourcePlacementLogic {
 
             // Pick a luxury at random. Weight is reduced if the luxury has been picked before
             val regionConditional = GameContext(region = region)
-            region.luxury = candidateLuxuries.randomWeighted {
+            region.luxury = candidateLuxuries.randomWeighted(regionRng) {
                 val weightingUnique = it.getMatchingUniques(UniqueType.ResourceWeighting, regionConditional).firstOrNull()
                 val relativeWeight = if (weightingUnique == null) 1f else weightingUnique.params[0].toFloat()
                 relativeWeight / (1f + amountRegionsWithLuxury[it.name]!!)
             }.name
             amountRegionsWithLuxury[region.luxury!!] = amountRegionsWithLuxury[region.luxury]!! + 1
         }
-
-
+        
         val cityStateLuxuries = assignCityStateLuxuries(
             4, // was probably intended to be "if (tileData.size > 5000) 4 else 3",
             assignableLuxuries,
             amountRegionsWithLuxury,
-            fallbackWeightings
+            fallbackWeightings,
+            globalRng
         )
 
         val randomLuxuries = getLuxuriesForRandomPlacement(assignableLuxuries, amountRegionsWithLuxury, tileData, ruleset)
@@ -144,7 +146,8 @@ object LuxuryResourcePlacementLogic {
         targetCityStateLuxuries: Int,
         assignableLuxuries: List<TileResource>,
         amountRegionsWithLuxury: HashMap<String, Int>,
-        fallbackWeightings: Boolean
+        fallbackWeightings: Boolean,
+        rng: Random,
     ): ArrayList<String> {
         val cityStateLuxuries = ArrayList<String>()
         repeat(targetCityStateLuxuries) {
@@ -154,7 +157,7 @@ object LuxuryResourcePlacementLogic {
             }
             if (candidateLuxuries.isEmpty()) return@repeat
 
-            val luxury = candidateLuxuries.randomWeighted {
+            val luxury = candidateLuxuries.randomWeighted(rng) {
                 val weightingUnique =
                     it.getMatchingUniques(UniqueType.LuxuryWeightingForCityStates).firstOrNull()
                 if (weightingUnique == null)
@@ -267,10 +270,11 @@ object LuxuryResourcePlacementLogic {
         ruleset: Ruleset
     ) {
         if (randomLuxuries.isEmpty()) return
+        val rng = GameContext(gameInfo = tileMap.gameInfo).stateBasedRandom("LuxuryResourcePlacementLogic.addRandomLuxuries")
         var targetRandomLuxuries = tileData.size.toFloat().pow(0.45f).toInt() // Approximately
         targetRandomLuxuries *= tileMap.mapParameters.getMapResources().randomLuxuriesPercent
         targetRandomLuxuries /= 100
-        targetRandomLuxuries += Random.nextInt(regions.size) // Add random number based on number of civs
+        targetRandomLuxuries += rng.nextInt(regions.size) // Add random number based on number of civs
         val minimumRandomLuxuries = tileData.size.toFloat().pow(0.2f).toInt() // Approximately
         val worldTiles = tileMap.values.asSequence().shuffled()
         for ((index, luxury) in randomLuxuries.shuffled().withIndex()) {
@@ -336,6 +340,7 @@ object LuxuryResourcePlacementLogic {
         cityStateLuxuries: List<String>,
         tileData: TileDataMap
     ) {
+        val rng = GameContext(gameInfo = tileMap.gameInfo).stateBasedRandom("LuxuryResourcePlacementLogic.placeLuxuriesAtMinorCivStartLocations")
         for (startLocation in tileMap.startingLocationsByNation
             .filterKeys { ruleset.nations[it]!!.isCityState }.map { it.value.first() }) {
             val region = regions.firstOrNull { startLocation in it.tiles }
@@ -344,7 +349,7 @@ object LuxuryResourcePlacementLogic {
             // 25% probability of going the other way around
             val globalLuxuries =
                 if (region?.luxury != null) randomLuxuries + listOf(region.luxury) else randomLuxuries
-            val candidateLuxuries = if (Random.nextInt(100) >= 25)
+            val candidateLuxuries = if (rng.nextInt(100) >= 25)
                 cityStateLuxuries.shuffled() + globalLuxuries.shuffled()
             else
                 globalLuxuries.shuffled() + cityStateLuxuries.shuffled()

--- a/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/MapRegionResources.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/MapRegionResources.kt
@@ -34,7 +34,7 @@ object MapRegionResources {
             ResourceType.Bonus -> ImpactType.Bonus
             ResourceType.Luxury -> ImpactType.Luxury
         }
-        val conditionalTerrain = GameContext(attackedTile = tileList.firstOrNull(), gameInfo = null)
+        val conditionalTerrain = GameContext(attackedTile = tileList.firstOrNull())
         val weightings = resourceOptions.associateWith {
             val unique = it.getMatchingUniques(UniqueType.ResourceWeighting, conditionalTerrain).firstOrNull()
             val weight = if (unique != null) unique.params[0].toFloat() else 1f
@@ -54,10 +54,11 @@ object MapRegionResources {
             if (tileData[tile.position]!!.impacts.containsKey(impactType)) {
                 fallbackTiles.add(tile) // Taken but might be a viable fallback tile
             } else {
+                val rng = GameContext(tile = tile).stateBasedRandom("MapRegionResources.placeResourcesInTiles")
                 // Add a resource to the tile
-                val resourceToPlace = possibleResourcesForTile.randomWeighted { weightings[it] ?: 0f }
+                val resourceToPlace = possibleResourcesForTile.randomWeighted(rng) { weightings[it] ?: 0f }
                 tile.setTileResource(resourceToPlace, majorDeposit)
-                tileData.placeImpact(impactType, tile, baseImpact + Random.nextInt(randomImpact + 1))
+                tileData.placeImpact(impactType, tile, baseImpact + rng.nextInt(randomImpact + 1))
                 amountPlaced++
                 detailedPlaced[resourceToPlace] = detailedPlaced[resourceToPlace]!! + 1
                 if (amountPlaced >= amountToPlace) {
@@ -69,11 +70,12 @@ object MapRegionResources {
         while (amountPlaced < amountToPlace && fallbackTiles.isNotEmpty()) {
             // Sorry, we do need to re-sort the list for every pass since new impacts are made with every placement
             val bestTile = fallbackTiles.minByOrNull { tileData[it.position]!!.impacts[impactType]!! }!!
+            val rng = GameContext(tile = bestTile).stateBasedRandom("MapRegionResources.placeResourcesInTiles")
             fallbackTiles.remove(bestTile)
             val possibleResourcesForTile = resourceOptions.filter { it.generatesNaturallyOn(bestTile) }
-            val resourceToPlace = possibleResourcesForTile.randomWeighted { weightings[it] ?: 0f }
+            val resourceToPlace = possibleResourcesForTile.randomWeighted(rng) { weightings[it] ?: 0f }
             bestTile.setTileResource(resourceToPlace, majorDeposit)
-            tileData.placeImpact(impactType, bestTile, baseImpact + Random.nextInt(randomImpact + 1))
+            tileData.placeImpact(impactType, bestTile, baseImpact + rng.nextInt(randomImpact + 1))
             amountPlaced++
             detailedPlaced[resourceToPlace] = detailedPlaced[resourceToPlace]!! + 1
         }
@@ -102,11 +104,10 @@ object MapRegionResources {
                     tile.setTileResource(resource, majorDeposit)
                     ratioProgress -= 1f
                     amountAdded++
-                    if (baseImpact + randomImpact >= 0)
-                        tileData.placeImpact(impactType, tile, baseImpact + Random.nextInt(
-                            randomImpact + 1
-                        )
-                        )
+                    if (baseImpact + randomImpact >= 0) {
+                        val rng = GameContext(tile = tile).stateBasedRandom("MapRegionResources.tryAddingResourceToTiles")
+                        tileData.placeImpact(impactType, tile, baseImpact + rng.nextInt(randomImpact + 1))
+                    }
                     if (amountAdded >= amount) break
                 }
                 ratioProgress += ratio

--- a/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/StrategicBonusResourcePlacementLogic.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/StrategicBonusResourcePlacementLogic.kt
@@ -56,7 +56,7 @@ object StrategicBonusResourcePlacementLogic {
         
         // Now go through the entire map to build lists
         for (tile in tileMap.values.asSequence().shuffled()) {
-            val terrainCondition = GameContext(attackedTile = tile, region = regions.firstOrNull { tile in it.tiles }, gameInfo = null)
+            val terrainCondition = GameContext(attackedTile = tile, region = regions.firstOrNull { tile in it.tiles })
             if (tile.getBaseTerrain().hasUnique(UniqueType.BlocksResources, terrainCondition)) continue // Don't count snow hills
             if (tile.isLand) landList.add(tile)
             for ((rule, list) in ruleLists) {
@@ -83,6 +83,7 @@ object StrategicBonusResourcePlacementLogic {
         tileMap: TileMap,
         tileData: TileDataMap
     ) {
+        val rng = GameContext(gameInfo = tileMap.gameInfo).stateBasedRandom("StrategicBonusResourcePlacementLogic.placeBonusInThirdRingOfStart")
         for (region in regions) {
             val terrain = if (region.type == "Hybrid") region.terrainCounts.filterNot { it.key == "Coastal" }
                 .maxByOrNull { it.value }!!.key
@@ -95,7 +96,7 @@ object StrategicBonusResourcePlacementLogic {
                 val possibleResources =
                     ruleset.tileResources.values.filter { it.resourceType == ResourceType.Bonus && terrain in it.terrainsCanBeFoundOn }
                 if (possibleResources.isEmpty()) continue
-                possibleResources.random()
+                possibleResources.random(rng)
             }
             val candidateTiles = tileMap[region.startPosition!!].getTilesAtDistance(3).shuffled()
             val amount = if (resourceUnique != null) 2 else 1 // Place an extra if the region type requests it
@@ -105,7 +106,7 @@ object StrategicBonusResourcePlacementLogic {
                     it.resourceType == ResourceType.Bonus &&
                             it.terrainsCanBeFoundOn.any { terrainName -> ruleset.terrains[terrainName]!!.type == TerrainType.Water }
                 }
-                    .randomOrNull()
+                    .randomOrNull(rng)
                 if (fishyBonus != null)
                     MapRegionResources.tryAddingResourceToTiles(tileData, fishyBonus, 1, candidateTiles)
             }
@@ -223,6 +224,7 @@ object StrategicBonusResourcePlacementLogic {
         fallbackStrategic: Boolean,
         totalPlaced: HashMap<TileResource, Int>
     ) {
+        val rng = GameContext(gameInfo = landList[0].tileMap.gameInfo).stateBasedRandom("StrategicBonusResourcePlacementLogic.placeMinorDepositsOnLand")
         val frequency = (baseMinorDepositFrequency * bonusMultiplier).toInt()
         val minorDepositsToAdd =
             (landList.size / frequency) + 1 // I sometimes have division by zero errors on this line
@@ -243,9 +245,9 @@ object StrategicBonusResourcePlacementLogic {
             }
             if (weightings.sum() <= 0) continue
 
-            val resourceToPlace = strategicResources.randomWeighted(weightings)
+            val resourceToPlace = strategicResources.randomWeighted(weightings, rng)
             tile.setTileResource(resourceToPlace, majorDeposit = false)
-            tileData.placeImpact(ImpactType.Strategic, tile, Random.nextInt(2) + Random.nextInt(2))
+            tileData.placeImpact(ImpactType.Strategic, tile, rng.nextInt(2) + rng.nextInt(2))
             totalPlaced[resourceToPlace] = totalPlaced[resourceToPlace]!! + 1
             minorDepositsAdded++
             if (minorDepositsAdded >= minorDepositsToAdd)
@@ -260,6 +262,7 @@ object StrategicBonusResourcePlacementLogic {
         totalPlaced: HashMap<TileResource, Int>,
         tileData: TileDataMap
     ) {
+        val rng = GameContext(gameInfo = tileMap.gameInfo).stateBasedRandom("StrategicBonusResourcePlacementLogic.placeSmallDepositsOfModernStrategicResourcesOnCityStates")
         val lastEra = ruleset.eras.values.maxOf { it.eraNumber }
         val modernOptions = strategicResources.filter {
             it.revealedBy != null &&
@@ -269,7 +272,7 @@ object StrategicBonusResourcePlacementLogic {
         if (modernOptions.any())
             for (cityStateLocation in tileMap.startingLocationsByNation
                 .filterKeys { ruleset.nations[it]!!.isCityState }.values.map { it.first() }) {
-                val resourceToPlace = modernOptions.random()
+                val resourceToPlace = modernOptions.random(rng)
                 totalPlaced[resourceToPlace] =
                     totalPlaced[resourceToPlace]!! + MapRegionResources.tryAddingResourceToTiles(
                         tileData,

--- a/core/src/com/unciv/logic/multiplayer/apiv2/ApiV2.kt
+++ b/core/src/com/unciv/logic/multiplayer/apiv2/ApiV2.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import java.security.SecureRandom
 import java.time.Instant
 import java.util.Random
 import java.util.UUID
@@ -287,7 +288,7 @@ class ApiV2(private val baseUrl: String) : ApiV2Wrapper(baseUrl), Disposable {
      */
     private suspend fun sendPing(size: Int = 0): Boolean {
         val body = ByteArray(size)
-        Random().nextBytes(body)
+        SecureRandom().nextBytes(body)
         return sendPing(body)
     }
 
@@ -339,7 +340,7 @@ class ApiV2(private val baseUrl: String) : ApiV2Wrapper(baseUrl), Disposable {
     suspend fun awaitPing(size: Int = 2, timeout: Duration? = null): Double? {
         require(size < 2) { "Size too small to identify ping responses uniquely" }
         val body = ByteArray(size)
-        Random().nextBytes(body)
+        SecureRandom().nextBytes(body)
 
         val key = body.toHex()
         val channel = Channel<Exception?>(capacity = Channel.RENDEZVOUS)

--- a/core/src/com/unciv/logic/multiplayer/apiv2/EndpointImplementations.kt
+++ b/core/src/com/unciv/logic/multiplayer/apiv2/EndpointImplementations.kt
@@ -17,9 +17,12 @@ import io.ktor.client.statement.request
 import io.ktor.http.*
 import io.ktor.util.network.*
 import java.io.IOException
+import java.security.SecureRandom
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
+import kotlin.random.Random
+import kotlin.random.asKotlinRandom
 
 /**
  * List of HTTP status codes which are considered to [ApiErrorResponse]s by the specification
@@ -974,7 +977,7 @@ class LobbyApi(private val client: HttpClient, private val authHelper: AuthHelpe
     suspend fun openPrivate(name: String, maxPlayers: Int = DEFAULT_LOBBY_MAX_PLAYERS, suppress: Boolean = false): CreateLobbyResponse? {
         val charset = ('a'..'z') + ('A'..'Z') + ('0'..'9')
         val password = (1..DEFAULT_RANDOM_PASSWORD_LENGTH)
-            .map { charset.random() }
+            .map { charset.random(SecureRandom().asKotlinRandom()) }
             .joinToString("")
         return open(CreateLobbyRequest(name, password, maxPlayers), suppress)
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -103,6 +103,7 @@ object UniqueTriggerActivation {
         }
 
         val gameContext = GameContext(civInfo, city, unit, tile)
+        val rng = gameContext.stateBasedRandom("UniqueTriggerActivation.getTriggerFunction", unique.text.hashCode())
 
         val chosenCity = relevantCity ?:
             civInfo.cities.firstOrNull { it.isCapital() }
@@ -118,7 +119,7 @@ object UniqueTriggerActivation {
                 val choices = event.getMatchingChoices(gameContext)
                     ?: return null
                 if (civInfo.isAI() || event.presentation == Event.Presentation.None) return {
-                    val choice = choices.toList().randomWeighted { it.getWeightForAiDecision(gameContext) }
+                    val choice = choices.toList().randomWeighted(rng) { it.getWeightForAiDecision(gameContext) }
                     choice.triggerChoice(civInfo, unit)
                 }
                 if (event.presentation == Event.Presentation.Alert) return {

--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -15,6 +15,7 @@ import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.nation.Nation
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.audio.MusicMood
@@ -559,11 +560,12 @@ class GameOptionsTable(
         update()
 
         var desiredCiv = ""
+        val rng = GameContext(gameInfo = UncivGame.Current.gameInfo).stateBasedRandom("GameOptionsTable.onChooseMod", mod.hashCode())
         if (gameParameters.mods.contains(mod)) {
             val modNations = RulesetCache[mod]?.nations?.values?.filter { it.isMajorCiv }
 
             if (modNations != null && modNations.any())
-                desiredCiv = modNations.random().name
+                desiredCiv = modNations.random(rng).name
 
             val music = UncivGame.Current.musicController
             if (!music.chooseTrack(mod, MusicMood.Theme, MusicTrackChooserFlags.setSelectNation) && desiredCiv.isNotEmpty())

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -18,6 +18,7 @@ import com.unciv.logic.map.TileMap
 import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.nation.Nation
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.SmallButtonStyle
@@ -261,6 +262,7 @@ class MapFileSelectTable(
         newGameScreen.gameSetupInfo.gameParameters.baseRuleset = mapMods.first.firstOrNull()
             ?: selection.mapPreview.mapParameters.baseRuleset
         val success = newGameScreen.tryUpdateRuleset(updateUI = true)
+        val rng = GameContext().stateBasedRandom("MapFileSelectTable.onFileSelectBoxChange", System.currentTimeMillis().toInt())
 
         if (success) {
             mapNations = selection.mapPreview.getDeclaredNations()
@@ -269,7 +271,7 @@ class MapFileSelectTable(
                 .toList()
             mapHumanPick = selection.mapPreview.getNationsForHumanPlayer()
                 .filter { newGameScreen.ruleset.nations[it]?.isMajorCiv == true }
-                .toList().randomOrNull()
+                .toList().randomOrNull(rng)
         } else {
             mapNations = emptyList()
             mapHumanPick = null

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.map.mapgenerator.MapGenerator
 import com.unciv.logic.map.mapgenerator.MapResourceSetting
 import com.unciv.models.metadata.GameParameters
 import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.ui.components.extensions.*
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
@@ -111,14 +112,15 @@ class MapParametersTable(
 
     private fun addMapShapeSelectBox() {
         val mapShapes = MapShape.allValues
+        val rng = GameContext().stateBasedRandom("MapParametersTable.addMapShapeSelectBox", System.currentTimeMillis().toInt())
 
         if (mapGeneratedMainType == MapGeneratedMainType.randomGenerated) {
             mapShapesOptionsValues = mapShapes.toHashSet()
             val optionsTable = MultiCheckboxTable("{Enabled Map Shapes}", "NewGameMapShapes", mapShapesOptionsValues) {
                 if (mapShapesOptionsValues.isEmpty()) {
-                    mapParameters.shape = mapShapes.random()
+                    mapParameters.shape = mapShapes.random(rng)
                 } else {
-                    mapParameters.shape = mapShapesOptionsValues.random()
+                    mapParameters.shape = mapShapesOptionsValues.random(rng)
                 }
             }
             add(optionsTable).colspan(2).grow().row()
@@ -140,7 +142,7 @@ class MapParametersTable(
         val ruleset = if (previousScreen is NewGameScreen) previousScreen.ruleset else RulesetCache.getVanillaRuleset()
         Concurrency.run("Generate example map") {
             val mapParametersForExample = if (forMapEditor) mapParameters else mapParameters.clone().apply { seed = 0 }
-            val exampleMap = MapGenerator(ruleset).generateMap(mapParametersForExample, GameParameters(), emptyList())
+            val exampleMap = MapGenerator(ruleset).generateMap(mapParametersForExample, GameParameters())
             Concurrency.runOnGLThread {
                 mapTypeExample.clear()
                 val mapPreview = LoadMapPreview(exampleMap, maxMapSize, maxMapSize)
@@ -158,6 +160,7 @@ class MapParametersTable(
 
     private fun addMapTypeSelectBox() {
         // MapType is not an enum so we can't simply enumerate. //todo: make it so!
+        val rng = GameContext().stateBasedRandom("MapParametersTable.addMapTypeSelectBox", System.currentTimeMillis().toInt())
         var mapTypes = MapType.allValues
         if (forMapEditor && mapGeneratedMainType != MapGeneratedMainType.randomGenerated) mapTypes = mapTypes + MapType.empty
 
@@ -165,9 +168,9 @@ class MapParametersTable(
             mapTypesOptionsValues = mapTypes.toHashSet()
             val optionsTable = MultiCheckboxTable("{Enabled Map Generation Types}", "NewGameMapGenerationTypes", mapTypesOptionsValues) {
                 if (mapTypesOptionsValues.isEmpty()) {
-                    mapParameters.type = mapTypes.random()
+                    mapParameters.type = mapTypes.random(rng)
                 } else {
-                    mapParameters.type = mapTypesOptionsValues.random()
+                    mapParameters.type = mapTypesOptionsValues.random(rng)
                 }
             }
             add(optionsTable).colspan(2).grow().row()
@@ -192,14 +195,15 @@ class MapParametersTable(
     }
 
     private fun addWorldSizeTable() {
+        val rng = GameContext().stateBasedRandom("MapParametersTable.addWorldSizeTable", System.currentTimeMillis().toInt())
         if (mapGeneratedMainType == MapGeneratedMainType.randomGenerated) {
             val mapSizes = MapSize.names()
             mapSizesOptionsValues = mapSizes.toHashSet()
             val optionsTable = MultiCheckboxTable("{Enabled World Sizes}", "NewGameWorldSizes", mapSizesOptionsValues) {
                 if (mapSizesOptionsValues.isEmpty()) {
-                    mapParameters.mapSize = MapSize(mapSizes.random())
+                    mapParameters.mapSize = MapSize(mapSizes.random(rng))
                 } else {
-                    mapParameters.mapSize = MapSize(mapSizesOptionsValues.random())
+                    mapParameters.mapSize = MapSize(mapSizesOptionsValues.random(rng))
                 }
             }
             add(optionsTable).colspan(2).grow().row()
@@ -287,15 +291,16 @@ class MapParametersTable(
     }
 
     private fun addResourceSelectBox() {
+        val rng = GameContext().stateBasedRandom("MapParametersTable.addResourceSelectBox", System.currentTimeMillis().toInt())
         val mapResources = MapResourceSetting.activeLabels()
 
         if (mapGeneratedMainType == MapGeneratedMainType.randomGenerated) {
             mapResourcesOptionsValues = mapResources.toHashSet()
             val optionsTable = MultiCheckboxTable("{Enabled Resource Settings}", "NewGameResourceSettings", mapResourcesOptionsValues) {
                 if (mapResourcesOptionsValues.isEmpty()) {
-                    mapParameters.mapResources = mapResources.random()
+                    mapParameters.mapResources = mapResources.random(rng)
                 } else {
-                    mapParameters.mapResources = mapResourcesOptionsValues.random()
+                    mapParameters.mapResources = mapResourcesOptionsValues.random(rng)
                 }
             }
             add(optionsTable).colspan(2).grow().row()

--- a/core/src/com/unciv/utils/CollectionExtensions.kt
+++ b/core/src/com/unciv/utils/CollectionExtensions.kt
@@ -13,7 +13,7 @@ import kotlin.random.Random
  * The probability for each element is proportional to the value of its corresponding element in the [weights] List.
  */
 @Readonly 
-fun <T> List<T>.randomWeighted(weights: List<Float>, random: Random = Random): T {
+fun <T> List<T>.randomWeighted(weights: List<Float>, random: Random): T {
     if (this.isEmpty()) throw NoSuchElementException("Empty list.")
     if (this.size != weights.size) throw UnsupportedOperationException("Weights size does not match this list size.")
 
@@ -34,7 +34,7 @@ fun <T> List<T>.randomWeighted(weights: List<Float>, random: Random = Random): T
  * The probability for each element is proportional to the result of [getWeight] (evaluated only once).
  */
 @Readonly
-fun <T> List<T>.randomWeighted(random: Random = Random, getWeight: (T) -> Float): T =
+fun <T> List<T>.randomWeighted(random: Random, getWeight: (T) -> Float): T =
     randomWeighted(map(getWeight), random)
 
 /** Gets a clone of any [List] as [ArrayList] with an additional item

--- a/core/src/com/unciv/utils/Randomness.kt
+++ b/core/src/com/unciv/utils/Randomness.kt
@@ -1,7 +1,10 @@
 package com.unciv.utils
 
 import yairm210.purity.annotations.Pure
+import java.security.SecureRandom
+import java.util.UUID
 import kotlin.random.Random
+import kotlin.random.asKotlinRandom
 
 @Pure
 fun Int.withHash(hash: Int) = this * 31 + hash
@@ -12,4 +15,14 @@ fun hashOf(vararg hashes: Int): Int {
     hashes.forEach { finalHash = finalHash.withHash(it) } 
     return finalHash
 }
+
+fun pseudoRandomUuid(rng: Random): UUID {
+    // RFC requires the high 4 bits of the 7th byte to be the _version_ 0x4 (aka random),
+    val mostSigBits: Long = (rng.nextLong() and 0xf000L.inv()) or 0x4000L
+    // and the 2 most-significant bits of the ninth byte to be the _variant_ 0x8 (aka OSF DCE).
+    val leastSigBits: Long = (rng.nextLong() and 0x3fffffffffffffffL) or (1L shl 63)
+    return UUID(mostSigBits, leastSigBits)
+}
+fun pseudoRandomUuid(rng: SecureRandom) = pseudoRandomUuid(rng.asKotlinRandom())
+
 

--- a/tests/src/com/unciv/dev/FasterUIDevTesters.kt
+++ b/tests/src/com/unciv/dev/FasterUIDevTesters.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.diplomacy.DiplomacyManager
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.HexMath
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.testing.TestGame
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
@@ -44,8 +45,9 @@ internal enum class FasterUIDevTesters : IFasterUITester {
                 // create random relations
                 for ((j, other) in civs.withIndex()) {
                     if (j <= i || Random.nextInt(3) == 0) continue
+                    val rng = GameContext(civInfo = civ, otherCiv = other).stateBasedRandom("FasterUIDevTesters.testCreateExample")
                     // Do a makeCivilizationsMeet without gifts, notifications, or war joins
-                    val status = DiplomaticStatus.entries.random()
+                    val status = DiplomaticStatus.entries.random(rng)
                     civ.diplomacy[other.civID] = diplomacyManagerFactory(civ, other, status)
                     other.diplomacy[civ.civID] = diplomacyManagerFactory(other, civ, status)
                 }

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -2,6 +2,8 @@
 package com.unciv.logic.map
 
 import com.unciv.logic.city.City
+import com.unciv.logic.city.City.Companion.NO_ID
+import com.unciv.logic.city.City.Companion.pseudoRandomId
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.models.ruleset.tile.TerrainType
@@ -60,6 +62,7 @@ class TileImprovementConstructionTests {
                 for (tech in testGame.ruleset.technologies.values)
                     civInfo.tech.addTechnology(tech.name)
                 city.civ = civInfo
+                city.id = if (city.id != NO_ID) city.id else pseudoRandomId(civInfo)
             }
 
             val canBeBuilt = tile.improvementFunctions.canBuildImprovement(improvement, civInfo.state)
@@ -100,6 +103,7 @@ class TileImprovementConstructionTests {
                 for (tech in testGame.ruleset.technologies.values)
                     civInfo.tech.addTechnology(tech.name)
                 city.civ = civInfo
+                city.id = if (city.id != NO_ID) city.id else pseudoRandomId(civInfo)
             }
             val canBeBuilt = coastalTile.improvementFunctions.canBuildImprovement(improvement, civInfo.state)
             Assert.assertTrue(improvement.name, canBeBuilt)


### PR DESCRIPTION
GameInfo and passwords and such use SecureRandom.
Everything else (except terrain generation) uses GameContext.stateBasedRandom, which includes GameInfo.id.

Loading from the same game ran for 147 and then 159 turns, so there's still critical randomness somewhere.



I totally understand that this PR is probably too large, and if requested, will split it into smaller PRs.