### PR TITLE
AStar checks tiles near target first.

### DIFF
--- a/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
+++ b/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
@@ -17,6 +17,9 @@ import com.unciv.logic.map.RouteNode.Companion.MAX_UNDERESTIMATED_TOTAL
 import com.unciv.logic.map.RouteNode.Companion.TILE_IDX_LO_MASK
 import com.unciv.logic.map.RouteNode.Companion.TILE_IDX_OFFSET
 import com.unciv.logic.map.RouteNode.Companion.UNDERESTIMATED_TOTAL_HI_MASK
+import com.unciv.logic.map.RouteNode.Companion.PBM_MOVE_THIS_TURN_HI_MASK
+import com.unciv.logic.map.RouteNode.Companion.MOVE_THIS_TURN_HI_MASK
+import com.unciv.logic.map.RouteNode.Companion.TURNS_HI_MASK
 import com.unciv.logic.map.RouteNode.Companion.UNDERESTIMATED_TOTAL_LO_MASK
 import com.unciv.logic.map.RouteNode.Companion.UNDERESTIMATED_TOTAL_OFFSET
 import com.unciv.logic.map.tile.RoadStatus
@@ -35,7 +38,8 @@ import yairm210.purity.annotations.Readonly
 value class PrioritizedNode(val bits: Long) {
     constructor(node: RouteNode, underestimatedTotal: FixedPointMovement)
         : this(
-        (node.bits and UNDERESTIMATED_TOTAL_HI_MASK.inv()) or
+        (node.bits and SAME_BITS) or
+            (node.bits.inv() and NEGATED_BITS) or
             toUnderestimatedTotalbits(underestimatedTotal)
     ) {
         require(underestimatedTotal > 0) { "underestimatedTotal $underestimatedTotal must be positive" }
@@ -55,6 +59,10 @@ value class PrioritizedNode(val bits: Long) {
     override fun toString(): String = "PrioritizedNode[underestimatedTotal=$underestimatedTotal ${RouteNode(bits)}]"
 
     companion object {
+        private const val OVERLOADED_BITS = UNDERESTIMATED_TOTAL_HI_MASK
+        private val NEGATED_BITS = PBM_MOVE_THIS_TURN_HI_MASK or MOVE_THIS_TURN_HI_MASK or TURNS_HI_MASK
+        private val SAME_BITS = (OVERLOADED_BITS or NEGATED_BITS).inv()
+
         @Pure
         private fun toUnderestimatedTotalbits(priority: FixedPointMovement): Long
             = priority.bits.toLong() shl UNDERESTIMATED_TOTAL_OFFSET

--- a/core/src/com/unciv/logic/map/PathingMapCache.kt
+++ b/core/src/com/unciv/logic/map/PathingMapCache.kt
@@ -184,16 +184,18 @@ value class RouteNode(val bits: Long=0L) {
         private const val PBM_MOVE_THIS_TURN_OFFSET = RELATIONSHIP_LEVEL_OFFSET + RELATIONSHIP_LEVEL_BIT_COUNT
         private const val PBM_MOVE_THIS_TURN_BIT_COUNT = 9
         private const val PBM_MOVE_THIS_TURN_LO_MASK = (0x1L shl PBM_MOVE_THIS_TURN_BIT_COUNT) - 1L
-        private const val PBM_MOVE_THIS_TURN_HI_MASK = PBM_MOVE_THIS_TURN_LO_MASK shl PBM_MOVE_THIS_TURN_OFFSET
+        internal const val PBM_MOVE_THIS_TURN_HI_MASK = PBM_MOVE_THIS_TURN_LO_MASK shl PBM_MOVE_THIS_TURN_OFFSET
         // bits 32-40 (9b = 512values = 25.55move) are the base-30 movement used on this turn.
         private const val MOVE_THIS_TURN_OFFSET = PBM_MOVE_THIS_TURN_OFFSET + PBM_MOVE_THIS_TURN_BIT_COUNT
         private const val MOVE_THIS_TURN_BIT_COUNT = 9
         private const val MOVE_THIS_TURN_LO_MASK = (0x1L shl MOVE_THIS_TURN_BIT_COUNT) - 1L
+        internal const val MOVE_THIS_TURN_HI_MASK = MOVE_THIS_TURN_LO_MASK shl MOVE_THIS_TURN_OFFSET
         val MAX_MOVE_THIS_TURN = FixedPointMovement.fpmFromFixedPointBits(MOVE_THIS_TURN_LO_MASK.toInt())
         // bits 41-46 (6b = 63turns) are the number of turns to get to this tile. 0=This turn.
         private const val TURNS_OFFSET = MOVE_THIS_TURN_OFFSET + MOVE_THIS_TURN_BIT_COUNT
         private const val TURNS_BIT_COUNT = 6
         private const val TURNS_LO_MASK = (0x1L shl TURNS_BIT_COUNT) - 1L
+        internal const val TURNS_HI_MASK = TURNS_LO_MASK shl TURNS_OFFSET
         const val MAX_TURNS = TURNS_LO_MASK.toInt()
         const val MAX_VALID_TURNS = MAX_TURNS - 1
         // [PrioritizedNode] bits 47-60 (14b) are the underestimated total movement from the initial tile toward the target. 
@@ -208,7 +210,7 @@ value class RouteNode(val bits: Long=0L) {
         private const val PARENT_TILE_LO_MASK = (0x1L shl PARENT_TILE_BIT_COUNT) - 1L
         private const val NO_PARENT_TILE_BITS = 7L
         private const val NO_PARENT_TILE_VALUE = 14
-        // [RouteNode] bit 50 (1b = 2values) tracks if we can we can "move to" a tile.
+        // [RouteNode] bit 50 (1b = 2values) tracks if we can "move to" a tile.
         // Aka either we can path through it, or it contains an enemy.
         private const val MOVE_TO_OFFSET = PARENT_TILE_OFFSET + PARENT_TILE_BIT_COUNT
         private const val MOVE_TO_BIT_COUNT = 1

--- a/tests/src/com/unciv/logic/map/PathingMapTest.kt
+++ b/tests/src/com/unciv/logic/map/PathingMapTest.kt
@@ -82,12 +82,13 @@ class PathingMapTest {
         assertEquals(underestimatedTotal, prioritized.underestimatedTotal)
         
         val reRouteNode = RouteNode(prioritized.bits)
+        val invertedReRouteNode = RouteNode(prioritized.bits.inv())
         assertEquals(tile.zeroBasedIndex, reRouteNode.tileIdx)
         assertEquals(tile, reRouteNode.tile(testGame.tileMap))
         // PrioritizedNode drops parentTile
-        assertEquals(moveThisTurn, reRouteNode.moveUsedThisTurn)
-        assertEquals(pbmMoveThisTurn, reRouteNode.pbmMoveThisTurn)
-        assertEquals(turns, reRouteNode.turns)
+        assertEquals(moveThisTurn, invertedReRouteNode.moveUsedThisTurn)
+        assertEquals(pbmMoveThisTurn, invertedReRouteNode.pbmMoveThisTurn)
+        assertEquals(turns, invertedReRouteNode.turns)
         assertEquals(damagingTiles, reRouteNode.damagingTiles)
         assertEquals(relationship, reRouteNode.relationshipLevel)
         assertEquals(true, reRouteNode.initialized)
@@ -212,7 +213,6 @@ class PathingMapTest {
         val path = pathing.getMovementToTilesAtPosition()
 
         assertEquals(path.toString(), 18, path.size)
-//        assertNotEquals(path.toString(), path.firstEntry(), path.lastEntry())
         assertEquals("""
         -2     -1     +0     +1     +2    
   +2     /      /     1/1.0  0/2.0  0/2.0 
@@ -344,5 +344,50 @@ class PathingMapTest {
         assertEquals(expected, attackableTiles.map {it.position})
         // And affirm full recalculation using cached tiles has same result.
         assertEquals(expected, pathing.bfsAllMatchingTilesThisTurn { tile, _ -> tile.civilianUnit?.civ == civInfo}.map {it.position})
+    }
+
+    @Test
+    fun getShortestPath_multipleRoutes_choosesShortest() {
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 2
+        testGame.setTileTerrain(HexCoord(1,1), "Hill")
+        testGame.setTileTerrain(HexCoord(2,1), "Hill")
+        testGame.setTileTerrain(HexCoord(1,2), "Hill")
+        testGame.setTileTerrain(HexCoord(2,2), "Hill")
+        val targetTile = testGame.getTile(HexCoord(8, 8))
+        val unit = testGame.addUnit(baseUnit.name, civInfo, originTile)
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val path = pathing.getShortestPath(targetTile)
+
+        /*
+        assertEquals(listOf(
+            HexCoord(1, 2),
+            HexCoord(3, 3),
+            HexCoord(5, 5),
+            HexCoord(7, 7),
+            HexCoord(8, 8),
+        ), path?.map { it.position })*/
+        assertEquals("""
+        -7     -6     -5     -4     -3     -2     -1     +0     +1     +2     +3     +4     +5     +6     +7     +8    
+  +8                                                     3/2.0  3/2.0  3/2.0  3/2.0  3/2.0  3/2.0  3/2.0  3/2.0  4/1.0D
+  +7                                              3/2.0  3/1.0  3/1.0  3/1.0  3/1.0  3/1.0  3/1.0  3/1.0  3/2.0  3/2.0 
+  +6                                       3/2.0  3/1.0  2/2.0  2/2.0  2/2.0  2/2.0  2/2.0  2/2.0  3/1.0  3/1.0  3/2.0 
+  +5                                3/2.0  3/1.0  2/2.0  2/1.0  2/1.0  2/1.0  2/1.0  2/1.0  2/2.0  2/2.0  3/1.0  3/2.0 
+  +4                          /     3/1.0  2/2.0  2/1.0  1/2.0  1/2.0  1/2.0  1/2.0  2/1.0  2/1.0  2/2.0  3/1.0  3/2.0 
+  +3                   /     3/1.0  2/2.0  2/1.0  1/2.0  1/1.0  1/1.0  1/1.0  1/2.0  1/2.0  2/1.0  2/2.0  3/1.0  3/2.0 
+  +2            /     3/1.0  2/2.0  2/1.0  1/2.0  1/1.0  0/2.0  0/3.0  1/2.0  1/1.0  1/2.0  2/1.0  2/2.0  3/1.0  3/2.0 
+  +1     /     3/1.0  2/2.0  2/1.0  1/2.0  1/1.0  0/2.0  0/1.0  0/2.0  0/3.0  1/1.0  1/2.0  2/1.0  2/2.0  3/1.0  3/2.0 
+  +0    3/1.0  2/2.0  2/1.0  1/2.0  1/1.0  0/2.0  0/1.0  0/0.0S 0/1.0  0/2.0  1/1.0  1/2.0  2/1.0  2/2.0  3/1.0  3/2.0 
+  -1    3/1.0  2/2.0  2/1.0  1/2.0  1/1.0  0/2.0  0/1.0  0/1.0  0/2.0  1/1.0  1/2.0  2/1.0  2/2.0  3/1.0  3/2.0        
+  -2    3/1.0  2/2.0  2/1.0  1/2.0  1/1.0  0/2.0  0/2.0  0/2.0  1/1.0  1/2.0  2/1.0  2/2.0  3/1.0  3/2.0               
+  -3    3/1.0  2/2.0  2/1.0  1/2.0  1/1.0  1/1.0  1/1.0  1/1.0  1/2.0  2/1.0  2/2.0  3/1.0  3/2.0                      
+  -4    3/1.0  2/2.0  2/1.0  1/2.0  1/2.0  1/2.0  1/2.0  1/2.0  2/1.0  2/2.0  3/1.0   /                                
+  -5    3/1.0  2/2.0  2/1.0  2/1.0  2/1.0  2/1.0  2/1.0  2/1.0  2/2.0  3/1.0   /                                       
+  -6    3/1.0  2/2.0  2/2.0  2/2.0  2/2.0  2/2.0  2/2.0  2/2.0  3/1.0   /                                              
+  -7    3/1.0  3/1.0  3/1.0  3/1.0  3/1.0  3/1.0  3/1.0  3/1.0   /                                                     
+""", pathing.toDebugString(testGame.tileMap[8,8]))
+        // And affirm cache
+        assertEquals(path?.map { it.position }, pathing.getShortestPath(targetTile)!!.map {it.position })
     }
 }


### PR DESCRIPTION
Previously, it prioritized TotalEstimatedMovement, then CurrentTurns, then CurrentMovement. This seems reasonable, but means of tiles with the same TotalEstimatedMovement, AStar picked ones furthest from the target first.

Now prioritization inverts CurrentTurns and CurrentMovement, so it prioritizes ones tiles with more of those, which must be closer to the target.

This results in *very slightly* fewer tiles analyzed when searching for a path