### PR TITLE
Automation can use TransformUnique and UnitTriggableUniques

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/BarbarianAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianAutomation.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.automation.civilization
 
 import com.unciv.Constants
 import com.unciv.logic.automation.unit.BattleHelper
+import com.unciv.logic.automation.unit.UniqueActionQueue
 import com.unciv.logic.automation.unit.UnitAutomation
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.mapunit.MapUnit
@@ -9,6 +10,7 @@ import com.unciv.logic.map.mapunit.MapUnit
 class BarbarianAutomation(val civInfo: Civilization) {
 
     fun automate() {
+        val uniqueActionQueue: UniqueActionQueue
         // ranged go first, after melee and then everyone else
         civInfo.units.getCivUnits().filter { it.baseUnit.isRanged() }.forEach { automateUnit(it) }
         civInfo.units.getCivUnits().filter { it.baseUnit.isMelee() }.forEach { automateUnit(it) }
@@ -18,52 +20,68 @@ class BarbarianAutomation(val civInfo: Civilization) {
     }
 
     private fun automateUnit(unit: MapUnit) {
-        if (unit.isCivilian()) automateCapturedCivilian(unit)
-        else if (unit.currentTile.improvement == Constants.barbarianEncampment) automateUnitOnEncampment(unit)
-        else automateCombatUnit(unit)
+        val uniqueActionQueue = UniqueActionQueue(unit)
+        if (unit.isCivilian()) automateCapturedCivilian(unit, uniqueActionQueue)
+        else if (unit.currentTile.improvement == Constants.barbarianEncampment) automateUnitOnEncampment(unit, uniqueActionQueue)
+        else automateCombatUnit(unit, uniqueActionQueue)
+        uniqueActionQueue.automateRemainingUniqueActions()
     }
 
-    private fun automateCapturedCivilian(unit: MapUnit) {
+    private fun automateCapturedCivilian(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(50f)
         // 1 - Stay on current encampment
         if (unit.currentTile.improvement == Constants.barbarianEncampment) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(25f)
         val campTiles = unit.civ.gameInfo.barbarians.encampments.map { unit.civ.gameInfo.tileMap[it.position] }
             .sortedBy { unit.currentTile.aerialDistanceTo(it) }
         val bestCamp = campTiles.firstOrNull { it.civilianUnit == null && unit.movement.canReach(it)}
         if (bestCamp != null)
             unit.movement.headTowards(bestCamp) // 2 - Head towards an encampment
-        else
+        else {
+            uniqueActionQueue.automateRemainingUniqueActions()
             UnitAutomation.wander(unit) // 3 - Can't find a reachable encampment, wander aimlessly
+        }
     }
 
-    private fun automateUnitOnEncampment(unit: MapUnit) {
+    private fun automateUnitOnEncampment(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        // UnitActionType.Upgrade is useFrequency 120f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(120f)
         // 1 - trying to upgrade
         if (UnitAutomation.tryUpgradeUnit(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(37f)
         // 2 - trying to attack somebody - but don't leave the encampment
         if (BattleHelper.tryAttackNearbyEnemy(unit, stayOnTile = true)) return
 
         // 3 - at least fortifying
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(10f)
         unit.fortifyIfCan()
     }
 
-    private fun automateCombatUnit(unit: MapUnit) {
+    private fun automateCombatUnit(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(200f)
         // 1 - Try pillaging to restore health (barbs don't auto-heal)
         if (unit.health < 50 && UnitAutomation.tryPillageImprovement(unit, true) && !unit.hasMovement()) return
 
+        // UnitActionType.Upgrade is useFrequency 120f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(120f)
         // 2 - trying to upgrade
         if (UnitAutomation.tryUpgradeUnit(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(37f)
         // 3 - trying to attack enemy
         // if a embarked melee unit can land and attack next turn, do not attack from water.
         if (BattleHelper.tryDisembarkUnitToAttackPosition(unit)) return
         if (!unit.isCivilian() && BattleHelper.tryAttackNearbyEnemy(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(27f)
         // 4 - trying to pillage tile or route
         while (UnitAutomation.tryPillageImprovement(unit)) {
             if (!unit.hasMovement()) return
         }
 
+        uniqueActionQueue.automateRemainingUniqueActions()
         // 6 - wander
         UnitAutomation.wander(unit)
     }

--- a/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
@@ -14,9 +14,12 @@ import yairm210.purity.annotations.Readonly
 
 object AirUnitAutomation {
 
-    fun automateFighter(unit: MapUnit) {
+    fun automateFighter(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        // automateBomber called after usePriority=118
+        
         if (unit.health < 75) return // Wait and heal
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(100f)
         val tilesWithEnemyUnitsInRange = unit.civ.threatManager.getTilesWithEnemyUnitsInDistance(unit.getTile(), unit.getRange())
         // TODO: Optimize [friendlyAirUnitsInRange] by creating an alternate [ThreatManager.getTilesWithEnemyUnitsInDistance] that handles only friendly units
         val friendlyAirUnitsInRange = unit.getTile().getTilesInDistance(unit.getRange()).flatMap { it.airUnits }.filter { it.civ == unit.civ }
@@ -30,6 +33,7 @@ object AirUnitAutomation {
         // We need to be on standby in case they attack
         if (friendlyUnusedFighterCount < enemyFighters) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(98f)
         if (friendlyUsedFighterCount <= enemyFighters) {
             @Readonly fun airSweepDamagePercentBonus(): Int {
                 return unit.getMatchingUniques(UniqueType.StrengthWhenAirsweep)
@@ -47,16 +51,21 @@ object AirUnitAutomation {
             }
         }
 
+        // UnitActionType.FortifyUntilHealed is useFrequency 45f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(45f)
         if (unit.health < 80) {
             return // Wait and heal up, no point in moving closer to battle if we aren't healed
         }
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(42f)
         if (BattleHelper.tryAttackNearbyEnemy(unit)) return
 
         if (unit.cache.cannotMove) return // from here on it's all "try to move somewhere else"
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(40f)
         if (tryRelocateToCitiesWithEnemyNearBy(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(38f)
         val pathsToCities = unit.movement.getAerialPathsToCities()
         if (pathsToCities.isEmpty()) return // can't actually move anywhere else
 
@@ -78,8 +87,9 @@ object AirUnitAutomation {
             return
         }
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(36f)
         // no city needs fighters to defend, so let's attack stuff from the closest possible location
-        tryMoveToCitiesToAerialAttackFrom(pathsToCities, unit)
+        tryMoveToCitiesToAerialAttackFrom(pathsToCities, unit, uniqueActionQueue)
     }
 
     private fun tryAirSweep(unit: MapUnit, tilesWithEnemyUnitsInRange: List<Tile>): Boolean {
@@ -91,25 +101,36 @@ object AirUnitAutomation {
         return !unit.hasMovement()
     }
 
-    fun automateBomber(unit: MapUnit) {
+    fun automateBomber(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        // automateBomber called after usePriority=118
+
+        // UnitActionType.FortifyUntilHealed is useFrequency 45f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(45f)
         if (unit.health < 75) return // Wait and heal
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(42f)
         if (BattleHelper.tryAttackNearbyEnemy(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(40f)
         if (unit.health <= 90 || (unit.health < 100 && !unit.civ.isAtWar())) {
             return // Wait and heal
         }
 
         if (unit.cache.cannotMove) return // from here on it's all "try to move somewhere else"
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(38f)
         if (tryRelocateToCitiesWithEnemyNearBy(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(36f)
         val pathsToCities = unit.movement.getAerialPathsToCities()
         if (pathsToCities.isEmpty()) return // can't actually move anywhere else
-        tryMoveToCitiesToAerialAttackFrom(pathsToCities, unit)
+        tryMoveToCitiesToAerialAttackFrom(pathsToCities, unit, uniqueActionQueue)
     }
 
-    private fun tryMoveToCitiesToAerialAttackFrom(pathsToCities: HashMap<Tile, ArrayList<Tile>>, airUnit: MapUnit) {
+    private fun tryMoveToCitiesToAerialAttackFrom(pathsToCities: HashMap<Tile, ArrayList<Tile>>, airUnit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        // automateBomber called after usePriority=36
+        
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(34f)
         val citiesThatCanAttackFrom = pathsToCities.keys
             .filter { destinationCity ->
                 destinationCity != airUnit.currentTile
@@ -120,13 +141,15 @@ object AirUnitAutomation {
 
         //todo: this logic looks similar to some parts of automateFighter, maybe pull out common code
         //todo: maybe group by size and choose highest priority within the same size turns
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(32f)
         val closestCityThatCanAttackFrom =
             citiesThatCanAttackFrom.minByOrNull { pathsToCities[it]!!.size }!!
         val firstStepInPath = pathsToCities[closestCityThatCanAttackFrom]!!.first()
         airUnit.movement.moveToTile(firstStepInPath)
     }
 
-    fun automateNukes(unit: MapUnit) {
+    fun automateNukes(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        // automateBomber called after usePriority=118
         if (!unit.civ.isAtWar()) return
         // We should *Almost* never want to nuke our own city, so don't consider it
         if (unit.type.isAirUnit()) {
@@ -135,8 +158,8 @@ object AirUnitAutomation {
                 .maxByOrNull { it.second }
             if (highestTileNukeValue != null && highestTileNukeValue.second > 0)
                 Nuke.NUKE(MapUnitCombatant(unit), highestTileNukeValue.first)
-
-            tryRelocateMissileToNearbyAttackableCities(unit)
+            
+            tryRelocateMissileToNearbyAttackableCities(unit, uniqueActionQueue)
         } else {
             val attackableTiles = TargetHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
             val highestTileNukeValue = attackableTiles.map { it to getNukeLocationValue(unit, it.tileToAttack) }
@@ -212,12 +235,18 @@ object AirUnitAutomation {
     }
 
     // This really needs to be changed, to have better targeting for missiles
-    fun automateMissile(unit: MapUnit) {
+    fun automateMissile(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        // automateBomber called after usePriority=118
         if (BattleHelper.tryAttackNearbyEnemy(unit)) return
-        tryRelocateMissileToNearbyAttackableCities(unit)
+        
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(50f)
+        tryRelocateMissileToNearbyAttackableCities(unit, uniqueActionQueue)
     }
 
-    private fun tryRelocateMissileToNearbyAttackableCities(unit: MapUnit) {
+    private fun tryRelocateMissileToNearbyAttackableCities(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
+        // automateBomber called after usePriority=118
+        
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(50f)
         val tilesInRange = unit.currentTile.getTilesInDistance(unit.getRange())
         val immediatelyReachableCities = tilesInRange
             .filter { unit.movement.canMoveTo(it) }
@@ -229,9 +258,10 @@ object AirUnitAutomation {
             return
         }
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(48f)
         val pathsToCities = unit.movement.getAerialPathsToCities()
         if (pathsToCities.isEmpty()) return // can't actually move anywhere else
-        tryMoveToCitiesToAerialAttackFrom(pathsToCities, unit)
+        tryMoveToCitiesToAerialAttackFrom(pathsToCities, unit, uniqueActionQueue)
     }
 
     private fun tryRelocateToCitiesWithEnemyNearBy(unit: MapUnit): Boolean {

--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -22,7 +22,10 @@ object CivilianUnitAutomation {
         && !unit.hasUnique(UniqueType.AddInCapital)
         && unit.civ.units.getCivUnits().any { unit.hasUnique(UniqueType.AddInCapital) }
 
-    fun automateCivilianUnit(unit: MapUnit, dangerousTiles: HashSet<Tile>) = timeThis<Unit>("automateCivilianUnit") {
+    fun automateCivilianUnit(unit: MapUnit, uniqueActionQueue: UniqueActionQueue, dangerousTiles: HashSet<Tile>) 
+        = timeThis<Unit>("automateCivilianUnit") {
+        // UnitAutomation calls this after useFrequency 120f.
+        
         // To allow "found city" actions that can only trigger a limited number of times
         
         // Slightly modified getUsableUnitActionUniques() to allow for settlers with *conditional* settling uniques
@@ -33,11 +36,17 @@ object CivilianUnitAutomation {
                 .any { canUse(unit, it) }
         
         val hasSettlerUnique = hasSettlerAction(UniqueType.FoundCity) || hasSettlerAction(UniqueType.FoundPuppetCity)
-        
+
+        // UnitActionType.FoundCity is useFrequency 80f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(80f)
         if (hasSettlerUnique && !(unit.civ.isCityState && unit.isMilitary()))
             return SpecificUnitAutomation.automateSettlerActions(unit, dangerousTiles)
-
+        
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(78f)
+        
         if (tryRunAwayIfNeccessary(unit)) return
+
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(76f)
 
         if (shouldClearTileForAddInCapitalUnits(unit, unit.currentTile)) {
             // First off get out of the way, then decide if you actually want to do something else
@@ -47,18 +56,40 @@ object CivilianUnitAutomation {
                 unit.movement.moveToTile(tilesCanMoveTo.minByOrNull { it.value.totalMovement }!!.key)
         }
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(74f)
+
         if (unit.isAutomatingRoadConnection())
             return unit.civ.getWorkerAutomation().roadToAutomation.automateConnectRoad(unit, dangerousTiles)
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(72f)
+        
         if (unit.cache.hasUniqueToBuildImprovements)
-            return unit.civ.getWorkerAutomation().automateWorkerAction(unit, dangerousTiles)
+            return unit.civ.getWorkerAutomation().automateWorkerAction(unit, uniqueActionQueue, dangerousTiles)
 
+
+        // UnitActionType.RemoveHeresy is useFrequency 69f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(69f)
+        if (unit.civ.religionManager.maySpreadReligionAtAll(unit))
+            return ReligiousUnitAutomation.automateMissionary(unit)
+        
+        // The Actions below this line sacrifice the unit for something big
+        // so they have a high useFrequency, but a low automation priority.
+        // So we'll treat the automation priority as ~10x less than the useFrequency.
+        
+        // UnitActionType.Create(Water)Improvement is useFrequency 82f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(8.2f)
         if (unit.cache.hasUniqueToCreateWaterImprovements) {
-            if (!unit.civ.getWorkerAutomation().automateWorkBoats(unit))
+            if (!unit.civ.getWorkerAutomation().automateWorkBoats(unit)) {
+                // UnitActionType.Explore is useFrequency 5f
+                uniqueActionQueue.automateUniqueActionsUntilUseFrequency(5f)
+                
                 UnitAutomation.tryExplore(unit)
+                }
             return
         }
 
+        // UnitActionType.FoundReligion is useFrequency 80f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(8.0f)
         if (unit.hasUnique(UniqueType.MayFoundReligion)
             && unit.civ.religionManager.religionState < ReligionState.Religion
             && unit.civ.religionManager.mayFoundReligionAtAll()
@@ -72,43 +103,52 @@ object CivilianUnitAutomation {
         }
             
 
+        // UnitActionType.EnhanceReligion is useFrequency 79f 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.9f)            
         if (unit.hasUnique(UniqueType.MayEnhanceReligion)
             && unit.civ.religionManager.religionState < ReligionState.EnhancedReligion
             && unit.civ.religionManager.mayEnhanceReligionAtAll()
         )
             return ReligiousUnitAutomation.enhanceReligion(unit)
 
+        // UnitActionType.AddInCapital is useFrequency 80f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.88f)
         // We try to add any unit in the capital we can, though that might not always be desirable
         // For now its a simple option to allow AI to win a science victory again
         if (unit.hasUnique(UniqueType.AddInCapital))
             return SpecificUnitAutomation.automateAddInCapital(unit)
+
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.86f)
 
         //todo this now supports "Great General"-like mod units not combining 'aura' and citadel
         // abilities, but not additional capabilities if automation finds no use for those two
         if (unit.cache.hasStrengthBonusInRadiusUnique
             && SpecificUnitAutomation.automateGreatGeneral(unit))
             return
+        
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.86f)
+        
         if (unit.cache.hasCitadelPlacementUnique && SpecificUnitAutomation.automateCitadelPlacer(unit))
             return
-
-        if (unit.civ.religionManager.maySpreadReligionAtAll(unit))
-            return ReligiousUnitAutomation.automateMissionary(unit)
-
-        if (unit.hasUnique(UniqueType.PreventSpreadingReligion) || unit.hasUnique(UniqueType.CanRemoveHeresy))
-            return ReligiousUnitAutomation.automateInquisitor(unit)
 
         val isLateGame = isLateGame(unit.civ)
         // Great scientist -> Hurry research if late game
         // Great writer -> Hurry policy  if late game
         if (isLateGame) {
+            // UnitActionType.HurryResearch is useFrequency 76f
+            uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.6f)
             val hurriedResearch = UnitActions.invokeUnitAction(unit, UnitActionType.HurryResearch)
             if (hurriedResearch) return
-
+            
+            // UnitActionType.HurryPolicy is useFrequency 76f :(
+            uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.4f)
             val hurriedPolicy = UnitActions.invokeUnitAction(unit, UnitActionType.HurryPolicy)
             if (hurriedPolicy) return
             //TODO: save up great scientists/writers for late game (8 turns after research labs/broadcast towers resp.)
         }
 
+        // UnitActionType.ConductTradeMission is useFrequency 70f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.0f)
         // Great merchant -> Conduct trade mission if late game and if not at war.
         // TODO: This could be more complex to walk to the city state that is most beneficial to
         //  also have more influence.
@@ -124,6 +164,8 @@ object CivilianUnitAutomation {
                 return
         }
 
+        // UnitActionType.HurryWonder is useFrequency 75f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(7.5f)
         // Great engineer -> Try to speed up wonder construction
         if (unit.hasUnique(UniqueType.CanSpeedupConstruction)
                 || unit.hasUnique(UniqueType.CanSpeedupWonderConstruction)) {
@@ -131,7 +173,14 @@ object CivilianUnitAutomation {
             if (wonderCanBeSpedUpEventually)
                 return
         }
+        
+        // UnitActionType.RemoveHeresy is useFrequency 69f 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(6.9f)
+        if (unit.hasUnique(UniqueType.PreventSpreadingReligion) || unit.hasUnique(UniqueType.CanRemoveHeresy))
+            return ReligiousUnitAutomation.automateInquisitor(unit)
 
+        // UnitActionType.TriggerUnique(GainFreeBuildings) is useFrequency 80f :(
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(6.6f)
         if (unit.hasUnique(UniqueType.GainFreeBuildings)) {
             val unique = unit.getMatchingUniques(UniqueType.GainFreeBuildings).first()
             val buildingName = unique.params[0]
@@ -161,8 +210,12 @@ object CivilianUnitAutomation {
         //  (depending on number of cities) and after that they should just be used to start golden
         //  ages?
 
+        // UnitActionType.ConstructImprovement is useFrequency 85f :(
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(6.4f)
         if (SpecificUnitAutomation.automateImprovementPlacer(unit)) return
-        
+
+        // UnitActionType.TriggerUnique(OneTimeEnterGoldenAgeTurns) is useFrequency 80f :(
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(6.2f)
         val goldenAgeAction = UnitActions.getUnitActions(unit, UnitActionType.TriggerUnique)
             .filter { it.action != null && it.associatedUnique?.type in listOf(UniqueType.OneTimeEnterGoldenAge,
                 UniqueType.OneTimeEnterGoldenAgeTurns) }.firstOrNull()
@@ -171,7 +224,7 @@ object CivilianUnitAutomation {
             return
         }
 
-        return // The AI doesn't know how to handle unknown civilian units
+        return
     }
 
     @Readonly

--- a/core/src/com/unciv/logic/automation/unit/UniqueActionQueue.kt
+++ b/core/src/com/unciv/logic/automation/unit/UniqueActionQueue.kt
@@ -1,0 +1,37 @@
+package com.unciv.logic.automation.unit
+
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.models.getTargetableUnitActions
+
+/**
+ * Queue of actions available for a unit 
+ */
+class UniqueActionQueue(val unit: MapUnit) {
+    val actions = ArrayDeque(getTargetableUnitActions(unit)
+        .sortedWith { l, r -> r.useFrequency.compareTo(l.useFrequency) }
+        .toList())
+    
+    fun automateRemainingUniqueActions(turnsToMove: Int = 0) = automateUniqueActionsUntilUseFrequency(-Float.MAX_VALUE, turnsToMove)
+    
+    fun automateUniqueActionsUntilUseFrequency(useFrequency: Float, turnsToMove: Int = 0): Boolean {
+        while (unit.hasMovement() && actions.isNotEmpty() && actions.first().useFrequency > useFrequency) {
+            val action = actions.removeFirst()
+            // if tile specific, then search for a valid tile
+            if (action.targetIsTileSpecific()) {
+                // search for a target
+                val target = unit.movement.bfsUntilMatchingTile(turnsToMove) { tile, _ -> action.validTarget(tile) }
+                if (target == null) continue // failed to find valid target. try next action
+                // found a target. Move toward it.
+                unit.movement.headTowards(target)
+                if (unit.movement.canUnitSwapTo(target)) {
+                    unit.movement.swapMoveToTile(target)
+                }
+            }
+            // if we can use the Action, then do so
+            if (action.canUse() && action.validTarget(unit.currentTile)) {
+                action.invokeAction()
+            }
+        }
+        return !unit.hasMovement() || unit.isDestroyed
+    }
+}

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -32,85 +32,123 @@ object UnitAutomation {
     private const val CLOSE_ENEMY_TURNS_AWAY_LIMIT = 3f
 
     fun automateUnitMoves(unit: MapUnit) = timeThis("automateUnitMoves") {
+        val uniqueActionQueue = UniqueActionQueue(unit)
+        automateUnitMovesImpl(unit, uniqueActionQueue)
+        uniqueActionQueue.automateRemainingUniqueActions()
+    }
+    
+    fun automateUnitMovesImpl(unit: MapUnit, uniqueActionQueue: UniqueActionQueue) {
         check(!unit.civ.isBarbarian) { "Barbarians is not allowed here." }
-
+        
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(200f)
         // Might die next turn - move!
         if (unit.getDamageFromTerrain() > 0 && tryHealUnit(unit)) return
-
+        
+        // UnitActionType.Promote is useFrequency 150f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(150f)
 
         if (unit.isCivilian()) {
-            CivilianUnitAutomation.automateCivilianUnit(unit, getDangerousTiles(unit))
+            CivilianUnitAutomation.automateCivilianUnit(unit, uniqueActionQueue, getDangerousTiles(unit))
             return
         }
-
+        
+        // UnitActionType.Upgrade is useFrequency 120f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(120f)
         // AI upgrades units via UseGoldAutomation in NextTurnAutomation
         if (unit.civ.isHuman() && tryUpgradeUnit(unit)) return
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(118f)
 
         //This allows for military units with certain civilian abilities to behave as civilians in peace and soldiers in war
         if ((unit.hasUnique(UniqueType.BuildImprovements) || unit.hasUnique(UniqueType.FoundCity) || 
                     unit.hasUnique(UniqueType.FoundPuppetCity) ||
                     unit.hasUnique(UniqueType.ReligiousUnit) || unit.hasUnique(UniqueType.CreateWaterImprovements))
             && !unit.civ.isAtWar()){
-            CivilianUnitAutomation.automateCivilianUnit(unit, getDangerousTiles(unit))
+            CivilianUnitAutomation.automateCivilianUnit(unit, uniqueActionQueue, getDangerousTiles(unit))
             return
         }
 
         // Note that not all nukes have to be air units
         if (unit.isNuclearWeapon()) {
-            return AirUnitAutomation.automateNukes(unit)
+            return AirUnitAutomation.automateNukes(unit, uniqueActionQueue)
         }
 
         if (unit.baseUnit.isAirUnit()) {
             if (unit.canIntercept())
-                return AirUnitAutomation.automateFighter(unit)
+                return AirUnitAutomation.automateFighter(unit, uniqueActionQueue)
 
             if (unit.hasUnique(UniqueType.SelfDestructs))
-                return AirUnitAutomation.automateMissile(unit)
+                return AirUnitAutomation.automateMissile(unit, uniqueActionQueue)
 
-            return AirUnitAutomation.automateBomber(unit)
+            return AirUnitAutomation.automateBomber(unit, uniqueActionQueue)
         }
-
+        
+        // UnitActionType.EscortFormation is useFrequency 50f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(50f)
         // Accompany settlers
         if (tryAccompanySettlerOrGreatPerson(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(48f)
         if (tryGoToRuin(unit) && !unit.hasMovement()) return
 
+        // UnitActionType.FortifyUntilHealed is useFrequency 45f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(45f)
         if (unit.health < 50 && (tryRetreat(unit) || tryHealUnit(unit))) return // do nothing but heal
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(43f)
         // If there are no enemies nearby and we can heal here, wait until we are at full health
         if (unit.health < 100 && canUnitHealInTurnsOnCurrentTile(unit,2, 3)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(41f)
         if (tryHeadTowardsOurSiegedCity(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(39f)
         // if a embarked melee unit can land and attack next turn, do not attack from water.
         if (BattleHelper.tryDisembarkUnitToAttackPosition(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(37f)
         // if there is an attackable unit in the vicinity, attack!
         if (tryAttacking(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(35f)
         if (tryTakeBackCapturedCity(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(33f)
         // Focus all units without a specific target on the enemy city closest to one of our cities
         if (HeadTowardsEnemyCityAutomation.tryHeadTowardsEnemyCity(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(31f)
         if (tryHeadTowardsEncampment(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(29f)
         if (tryGarrisoningLandUnit(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(27f)
         if (unit.health < 80 && tryHealUnit(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(25f)
         // move towards the closest reasonably attackable enemy unit within 3 turns of movement (and 5 tiles range)
         if (tryAdvanceTowardsCloseEnemy(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(23f)
         if (unit.health < 100 && tryHealUnit(unit)) return
 
+        // UnitActionType.(Un)fortify is useFrequency 10f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(10f)
+
         if (tryPrepare(unit)) return
+
+        // UnitActionType.Explore is useFrequency 5f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(5f)
 
         // else, try to go to unreached tiles
         if (tryExplore(unit)) return
 
+        // UnitActionType.Guard is useFrequency 0f
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(0f)
+        
         if (tryFogBust(unit)) return
 
+        uniqueActionQueue.automateRemainingUniqueActions()
         // Idle CS units should wander so they don't obstruct players so much
         if (unit.civ.isCityState)
             wander(unit, stayInTerritory = true)

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -72,8 +72,9 @@ class WorkerAutomation(
     /**
      * Automate one Worker - decide what to do and where, move, start or continue work.
      */
-    fun automateWorkerAction(unit: MapUnit, dangerousTiles: HashSet<Tile>, localUniqueCache: LocalUniqueCache = LocalUniqueCache())
+    fun automateWorkerAction(unit: MapUnit, uniqueActionQueue: UniqueActionQueue, dangerousTiles: HashSet<Tile>, localUniqueCache: LocalUniqueCache = LocalUniqueCache())
         = timeThis<Unit>("automateWorkerAction") {
+        // calle by CivilianUnitAutomation after useFrequency=72f
         val currentTile = unit.getTile()
         // Must be called before any getPriority checks to guarantee the local road cache is processed
         val citiesToConnect = roadBetweenCitiesAutomation.getNearbyCitiesToConnect(unit)
@@ -82,6 +83,7 @@ class WorkerAutomation(
             && getFullPriority(unit.getTile(), unit, localUniqueCache) >= 2) {
             return
         }
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(70f)
         val tileToWork = findTileToWork(unit, dangerousTiles, localUniqueCache)
 
         if (tileToWork != currentTile && tileToWork != null) {
@@ -97,8 +99,10 @@ class WorkerAutomation(
         // Support Alpha Frontier-Style Workers that _also_ have the "May create improvements on water resources" unique
         if (unit.cache.hasUniqueToCreateWaterImprovements && automateWorkBoats(unit)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(50f)
         if (tryHeadTowardsUndevelopedCity(unit, localUniqueCache, currentTile)) return
 
+        uniqueActionQueue.automateUniqueActionsUntilUseFrequency(25f)
         // Nothing to do, try again to connect cities
         if (roadBetweenCitiesAutomation.tryConnectingCities(unit, citiesToConnect)) return
 
@@ -107,6 +111,7 @@ class WorkerAutomation(
         unit.civ.addNotification("${unit.shortDisplayName()} has no work to do.", MapUnitAction(unit), NotificationCategory.Units, unit.name, "OtherIcons/Sleep")
 
         // Idle CS units should wander so they don't obstruct players so much
+        uniqueActionQueue.automateRemainingUniqueActions()
         if (unit.civ.isCityState)
             wander(unit, stayInTerritory = true, tilesToAvoid = dangerousTiles)
     }

--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -226,8 +226,10 @@ class PathingMap(
      * IMPORTANT NOTE: This does NOT consider obstacles (hills/mountains) in the attack range.
      * Callers have to check for obstacles along the path themselves.
      **/
-    fun bfsUntilMatchingTile(timeLimitTurns: Int = MAX_VALID_TURNS, endSearchPredicate: EndSearchPredicate): Tile?
+    fun bfsUntilMatchingTile(timeLimitTurns: Int, endSearchPredicate: EndSearchPredicate): Tile?
         = bfsStepUntilDestination(fetchCache(), endSearchPredicate, timeLimitTurns)
+    fun bfsUntilMatchingTileThisTurn(endSearchPredicate: EndSearchPredicate): Tile?
+        = bfsStepUntilDestination(fetchCache(), endSearchPredicate, 0)
 
     /**
      * finds all tiles in attack range that match a predicate.

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -10,6 +10,9 @@ import com.unciv.logic.map.BFS
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.HexMath
 import com.unciv.logic.map.PathingMap
+import com.unciv.logic.map.PathingMap.Companion.EndSearchPredicate
+import com.unciv.logic.map.PathingMap.Companion.MAX_VALID_TURNS
+import com.unciv.logic.map.RouteNode
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitActionType
@@ -267,6 +270,57 @@ class UnitMovement(val unit: MapUnit) {
     }
 
     class UnreachableDestinationException(msg: String) : Exception(msg)
+
+
+    /**
+     * finds the closest tile that match a predicate.
+     * 
+     * timeLimitTurns=0 is tiles the unit can reach this turn. timeLimitTurns=1 is tiles the unit can
+     * reach this turn or next turn. Etc.
+     * 
+     * If there are multiple matches with the same movement cost, then this uses 
+     * tile-owner-relationship as a tiebreaker, followed by zeroBasedIndex (roughly, distance from
+     * center of map).
+     *
+     * The results of the method, and the per-tile-predicate-results are NOT cached, and so this has
+     * to check all tiles starting from the origin every call, even if the tiles' nodes have already
+     * been cached from prior pathfinding. However, this uses/generates the same cached nodes as the
+     * other pathfinding (movement cost, relationship level, shortest route, damage numbers, etc),
+     * and so if the nodes were already cached, then this is fast, and if the nodes were not already
+     * cached, then this makes subsequent pathfinding fast.
+     *
+     * IMPORTANT NOTE: This does NOT consider obstacles (hills/mountains) in the attack range.
+     * Callers have to check for obstacles along the path themselves.
+     **/
+    fun bfsUntilMatchingTile(timeLimitTurns: Int, endSearchPredicate: EndSearchPredicate): Tile?
+        = aStarPathing.bfsUntilMatchingTile( timeLimitTurns, endSearchPredicate)
+    fun bfsUntilMatchingTileThisTurn(endSearchPredicate: EndSearchPredicate): Tile?
+        = aStarPathing.bfsUntilMatchingTileThisTurn(endSearchPredicate)
+
+    /**
+     * finds all tiles in attack range that match a predicate.
+     *
+     * This does not cache the results of the predicate matching, and so has to check all tiles
+     * starting from the origin, even if the tiles' nodes have already been cached from prior
+     * pathfinding. However, this uses/generates the same cached nodes as the other pathfinding
+     * (movement cost, relationship level, shortest route, damage numbers, etc), so if any other 
+     * pathing also occurs before or after, then these checks are effectively free.
+     * 
+     * timeLimitTurns=0 is tiles the unit can reach this turn. timeLimitTurns=1 is tiles the unit can
+     * reach this turn or next turn. Etc.
+     * 
+     * If you do not care about movement cost, then the BFS class is probably faster.
+     *
+     * IMPORTANT NOTE: This does NOT consider sight obstacles (hills/mountains) in the attack range.
+     *
+     * IMPORTANT NOTE: The results of this method are not cached.  The *nodes* are cached , but the list of tiles
+     **/
+    // @IgnorableReturnValue
+    fun bfsAllMatchingTiles(timeLimitTurns: Int, tilePredicate: EndSearchPredicate): List<Tile>
+        = aStarPathing.bfsAllMatchingTiles(timeLimitTurns, tilePredicate)
+    // @IgnorableReturnValue
+    fun bfsAllMatchingTilesThisTurn(tilePredicate: EndSearchPredicate): List<Tile>
+        = aStarPathing.bfsAllMatchingTilesThisTurn(tilePredicate)
 
     @Readonly @Suppress("purity")
     fun getTileToMoveToThisTurn(finalDestination: Tile): Tile {

--- a/core/src/com/unciv/models/TargetableUnitAction.kt
+++ b/core/src/com/unciv/models/TargetableUnitAction.kt
@@ -1,0 +1,133 @@
+package com.unciv.models
+
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.unique.GameContext
+import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
+import com.unciv.models.ruleset.unique.UniqueTriggerActivation
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionModifiers
+
+interface TargetableUnitAction {
+    val useFrequency: Float
+    
+    fun targetIsTileSpecific(): Boolean
+
+    fun validTarget(tile: Tile): Boolean
+
+    fun canUse(): Boolean
+
+    fun invokeAction() : Boolean  
+}
+
+abstract class UniqueTargetableAction(val unit: MapUnit, val unique: Unique): TargetableUnitAction {
+    var lastTile = unit.currentTile
+    var lastContext = unit.cache.state
+
+    override val useFrequency: Float = unique.modifiersMap[UniqueType.UnitActionPriority]!!.first().params[0].toFloat()
+
+    override fun targetIsTileSpecific(): Boolean = unique.unitActionModifiersAreTileSpecific(unit.civ.gameInfo)
+
+    override fun validTarget(tile: Tile): Boolean {
+        if (tile != lastTile) {
+            lastContext = GameContext(unit = unit, tile = tile, attackedTile = tile, ignoreFieldsBits = GameContext.CONSIDER_ONLY_TILES_MASK)
+        }
+        return unique.conditionalsApply(lastContext)
+    }
+
+    override fun canUse(): Boolean = UnitActionModifiers.canUse(unit, unique) && 
+        UnitActionModifiers.canActivateSideEffects(unit, unique) &&
+        unique.conditionalsApply(unit.cache.state.copy(ignoreFieldsBits = GameContext.IGNORE_TILE_BIT))
+
+    abstract fun invokeUniqueOnce()
+    
+    override fun invokeAction(): Boolean {
+        repeat(unique.getUniqueMultiplier(lastContext)) {
+            invokeUniqueOnce()
+        }
+        UnitActionModifiers.activateSideEffects(unit, unique)
+        return true
+    }
+}
+
+class TriggerableTargetableAction(unit: MapUnit, unique: Unique): UniqueTargetableAction(unit, unique) {
+    var lastTrigger: (()->Boolean)? = UniqueTriggerActivation.getTriggerFunction(unique, unit.civ, unit = unit, tile = unit.currentTile)
+
+    override fun validTarget(tile: Tile): Boolean {
+        val newTile = tile != lastTile
+        if (!super.validTarget(tile)) return false
+        if (newTile) lastTrigger = UniqueTriggerActivation.getTriggerFunction(unique, lastContext)
+        return lastTrigger != null
+    }
+    
+    override fun invokeUniqueOnce() {
+        lastTrigger!!.invoke()
+    }
+
+    override fun invokeAction(): Boolean {
+        if (lastTrigger == null) return false
+        return super.invokeAction()
+    }
+}
+
+class TransformTargetableAction(unit: MapUnit, unique: Unique): UniqueTargetableAction(unit, unique) {
+
+    override fun validTarget(tile: Tile): Boolean {
+        val unitToTransformTo = unit.civ.getEquivalentUnit(unique.params[0])
+        return super.validTarget(tile) && !unitToTransformTo.getMatchingUniques(UniqueType.Unavailable, lastContext).any()
+    }
+    override fun canUse(): Boolean = !unit.isEmbarked() && super.canUse() 
+
+    override fun invokeUniqueOnce() {
+        val oldMovement = unit.currentMovement
+        val unitToTransformTo = unit.civ.getEquivalentUnit(unique.params[0])
+        unit.destroy()
+        val newUnit =
+            unit.civ.units.placeUnitNearTile(unit.currentTile.position, unitToTransformTo, unit.id, copiedFrom = unit)
+
+        /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
+         * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
+         */
+        if (newUnit == null) {
+            val resurrectedUnit =
+                unit.civ.units.placeUnitNearTile(unit.currentTile.position, unit.baseUnit, unit.id, copiedFrom = unit)!!
+
+        } else { // Managed to upgrade
+            // have to handle movement manually because we killed the old unit
+            // a .destroy() unit has 0 movement
+            // and a new one may have less Max Movement
+            newUnit.currentMovement = oldMovement
+            // adjust if newUnit has lower Max Movement
+            if (newUnit.currentMovement.toInt() > newUnit.getMaxMovement())
+                newUnit.currentMovement = newUnit.getMaxMovement().toFloat()
+            // execute any side effects, Stat and Movement adjustments
+        }
+    }
+}
+
+fun getTargetableUnitActions(unit: MapUnit): List<TargetableUnitAction> {
+    val results = mutableListOf<TargetableUnitAction>()
+    // TriggerableTargetableAction
+    for (unique in unit.getUniques()) {
+        if (!unique.hasModifier(UniqueType.UnitActionPriority)) continue
+        when (unique.type) {
+            UniqueType.CanTransform -> {
+                if (unit.isEmbarked() || !UnitActionModifiers.canActivateSideEffects(unit, unique))
+                    continue;
+                results.add(TransformTargetableAction(unit, unique))
+            }
+            else -> { // any other unit triggerable
+                // not a unit action
+                if (unique.modifiers.none { it.type?.targetTypes?.contains(UniqueTarget.UnitActionModifier) == true }) continue
+                // extends an existing unit action
+                if (unique.hasModifier(UniqueType.UnitActionExtraLimitedTimes)) continue
+                if (!unique.isTriggerable) continue
+                if (!UnitActionModifiers.canUse(unit, unique)) continue
+                results.add(TriggerableTargetableAction(unit, unique))
+                
+            }
+        }
+    }
+    return results
+}

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.battle.CombatAction
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.managers.ReligionState
+import com.unciv.models.ruleset.unique.Countables.Companion.getMatching
 import com.unciv.models.ruleset.validation.ModCompatibility
 import com.unciv.models.stats.Stat
 import com.unciv.utils.hashOf
@@ -37,6 +38,7 @@ object Conditionals {
         /** Helper to simplify conditional tests requiring gameInfo */
         @Readonly
         fun checkOnGameInfo(@Readonly predicate: (GameInfo.() -> Boolean)): Boolean {
+            if (!state.considerGameInfo) return true
             if (state.gameInfo == null) return false
             return state.gameInfo.predicate()
         }
@@ -44,6 +46,7 @@ object Conditionals {
         /** Helper to simplify conditional tests requiring a Civilization */
         @Readonly
         fun checkOnCiv(@Readonly predicate: (Civilization.() -> Boolean)): Boolean {
+            if (!state.considerCiv) return true
             if (state.relevantCiv == null) return false
             return state.relevantCiv!!.predicate()
         }
@@ -51,6 +54,7 @@ object Conditionals {
         /** Helper to simplify conditional tests requiring a City */
         @Readonly
         fun checkOnCity(@Readonly predicate: (City.() -> Boolean)): Boolean {
+            if (!state.considerCiv) return true
             if (state.relevantCity == null) return false
             return state.relevantCity!!.predicate()
         }
@@ -58,6 +62,7 @@ object Conditionals {
         /** Helper to simplify the "compare civ's current era with named era" conditions */
         @Readonly
         fun compareEra(eraParam: String, @Readonly compare: (civEra: Int, paramEra: Int) -> Boolean): Boolean {
+            if (!state.considerGameInfo) return true
             if (state.gameInfo == null) return false
             val era = state.gameInfo.ruleset.eras[eraParam] ?: return false
             return compare(state.relevantCiv!!.getEraNumber(), era.eraNumber)
@@ -72,6 +77,7 @@ object Conditionals {
             modifyByGameSpeed: Boolean = false,
             @Readonly compare: (current: Int, lowerLimit: Float, upperLimit: Float) -> Boolean
         ): Boolean {
+            if (!state.considerCiv) return true
             if (state.gameInfo == null) return false
             var gameSpeedModifier = if (modifyByGameSpeed) state.gameInfo.speed.modifier else 1f
 
@@ -90,7 +96,7 @@ object Conditionals {
             first: String,
             second: String,
             @Readonly compare: (first: Int, second: Int) -> Boolean): Boolean {
-
+            if (!state.considerCiv) return true
             val firstNumber = Countables.getCountableAmount(first, state)
             val secondNumber = Countables.getCountableAmount(second, state)
 
@@ -103,7 +109,7 @@ object Conditionals {
         @Readonly
         fun compareCountables(first: String, second: String, third: String,
                               @Readonly compare: (first: Int, second: Int, third: Int) -> Boolean): Boolean {
-
+            if (!state.considerCiv) return true
             val firstNumber = Countables.getCountableAmount(first, state)
             val secondNumber = Countables.getCountableAmount(second, state)
             val thirdNumber = Countables.getCountableAmount(third, state)
@@ -389,6 +395,142 @@ object Conditionals {
                 (gameParameters.mods.asSequence() + gameParameters.baseRuleset).none { ModCompatibility.modNameFilter(it, filter) }
             }
 
+            else -> false
+        }
+    }
+
+    @Readonly
+    fun unitActionModifiersAreTileSpecific(gameInfo: GameInfo, conditional: Unique): Boolean {
+        if (conditional.isOtherModifierType)
+            return false // not a filtering condition, includes e.g. ModifierHiddenFromUsers
+
+        // These are always false today, but makes it easy to add that functionality later, if desired.
+        @Readonly
+        fun countableIsTileSpecific(countable: String): Boolean
+         =  getMatching(countable, gameInfo.ruleset)
+             ?.isTileSpecificForUnitAction 
+            ?: return false
+
+        return when (conditional.type) {
+            UniqueType.ConditionalChance -> false
+            UniqueType.ConditionalEveryTurns -> false
+            UniqueType.ConditionalBeforeTurns -> false
+            UniqueType.ConditionalAfterTurns -> false
+            UniqueType.ConditionalTutorialsEnabled -> false
+            UniqueType.ConditionalTutorialCompleted -> false
+
+            UniqueType.ConditionalCivFilter -> false
+            UniqueType.ConditionalWar -> false
+            UniqueType.ConditionalNotWar -> false
+            UniqueType.ConditionalWithResource -> true
+            UniqueType.ConditionalWithoutResource -> true
+
+            UniqueType.ConditionalWhenAboveAmountStatResource -> true
+            UniqueType.ConditionalWhenBelowAmountStatResource -> true
+            UniqueType.ConditionalWhenBetweenStatResource -> true
+
+            UniqueType.ConditionalHappy -> false
+            UniqueType.ConditionalGoldenAge -> false
+            UniqueType.ConditionalNotGoldenAge -> false
+
+            UniqueType.ConditionalBeforeEra -> false
+            UniqueType.ConditionalStartingFromEra -> false
+            UniqueType.ConditionalDuringEra -> false
+            UniqueType.ConditionalIfStartingInEra -> false
+            UniqueType.ConditionalSpeed -> false
+            UniqueType.ConditionalDifficulty -> false
+            UniqueType.ConditionalDifficultyOrHigher -> false
+            UniqueType.ConditionalDifficultyOrLower -> false
+            UniqueType.ConditionalVictoryEnabled -> false
+            UniqueType.ConditionalVictoryDisabled -> false
+            UniqueType.ConditionalReligionEnabled -> false
+            UniqueType.ConditionalReligionDisabled -> false
+            UniqueType.ConditionalEspionageEnabled -> false
+            UniqueType.ConditionalEspionageDisabled -> false
+            UniqueType.ConditionalNuclearWeaponsEnabled -> false
+            UniqueType.ConditionalNuclearWeaponsDisabled -> false
+            UniqueType.ConditionalTech -> false
+            UniqueType.ConditionalNoTech -> false
+            UniqueType.ConditionalWhileResearching -> false
+            UniqueType.ConditionalNoCivAdopted -> false
+            UniqueType.ConditionalAfterPolicyOrBelief -> false
+            UniqueType.ConditionalBeforePolicyOrBelief -> false
+            UniqueType.ConditionalBeforePantheon -> false
+            UniqueType.ConditionalAfterPantheon -> false
+            UniqueType.ConditionalBeforeReligion -> false
+            UniqueType.ConditionalAfterReligion -> false
+            UniqueType.ConditionalBeforeEnhancingReligion -> false
+            UniqueType.ConditionalAfterEnhancingReligion -> false
+            UniqueType.ConditionalAfterGeneratingGreatProphet -> false
+
+            UniqueType.ConditionalBuildingBuilt -> false
+            UniqueType.ConditionalBuildingNotBuilt -> false
+            UniqueType.ConditionalBuildingBuiltAll -> false
+            UniqueType.ConditionalBuildingBuiltAmount -> false
+            UniqueType.ConditionalBuildingBuiltByAnybody -> false
+            UniqueType.ConditionalBuildingNotBuiltByAnybody -> false
+
+            // Filtered via city.getMatchingUniques
+            UniqueType.ConditionalInThisCity -> true
+            UniqueType.ConditionalCityFilter -> true
+            UniqueType.ConditionalCityConnected -> true
+            UniqueType.ConditionalCityReligion -> true
+            UniqueType.ConditionalCityNotReligion -> true
+            UniqueType.ConditionalCityMajorReligion -> true
+            UniqueType.ConditionalCityEnhancedReligion -> true
+            UniqueType.ConditionalCityThisReligion -> true
+            UniqueType.ConditionalWLTKD -> true
+            UniqueType.ConditionalCityWithBuilding -> true
+            UniqueType.ConditionalCityWithoutBuilding -> true
+            UniqueType.ConditionalPopulationFilter -> true
+            UniqueType.ConditionalExactPopulationFilter -> true
+            UniqueType.ConditionalBetweenPopulationFilter -> true
+            UniqueType.ConditionalBelowPopulationFilter -> true
+            UniqueType.ConditionalWhenGarrisoned -> true
+
+            UniqueType.ConditionalVsCity -> false
+            UniqueType.ConditionalVsUnits,  UniqueType.ConditionalVsCombatant -> false
+            UniqueType.ConditionalOurUnit, UniqueType.ConditionalOurUnitOnUnit -> false
+            UniqueType.ConditionalUnitWithPromotion ->false
+            UniqueType.ConditionalUnitWithoutPromotion -> false
+            UniqueType.ConditionalAttacking -> false
+            UniqueType.ConditionalDefending -> false
+            UniqueType.ConditionalAboveHP -> false
+            UniqueType.ConditionalBelowHP -> false
+            UniqueType.ConditionalAboveMovement -> false /* we can approach the target even if we'll use the ability next turn*/
+            UniqueType.ConditionalBelowMovement -> false /* we can approach the target even if we'll use the ability next turn*/
+            UniqueType.ConditionalHasNotUsedOtherActions -> false
+            UniqueType.ConditionalStackedWithUnit -> true
+            UniqueType.ConditionalNotStackedWithUnit -> true
+
+            UniqueType.ConditionalInTiles -> true
+            UniqueType.ConditionalInTilesNot -> true
+            UniqueType.ConditionalAdjacentTo -> true
+            UniqueType.ConditionalNotAdjacentTo -> true
+            UniqueType.ConditionalFightingInTiles -> true
+            UniqueType.ConditionalNearTiles -> true
+            UniqueType.ConditionalVsLargerCiv -> false
+            UniqueType.ConditionalForeignContinent -> true
+            UniqueType.ConditionalAdjacentUnit -> true
+
+            UniqueType.ConditionalNeighborTiles -> true
+            UniqueType.ConditionalOnWaterMaps -> false
+            UniqueType.ConditionalInRegionOfType -> true
+            UniqueType.ConditionalInRegionExceptOfType -> true
+
+            UniqueType.ConditionalFirstCivToResearch ->false
+            UniqueType.ConditionalFirstCivToAdopt -> false
+            UniqueType.ConditionalCountableEqualTo,
+            UniqueType.ConditionalCountableDifferentThan,
+            UniqueType.ConditionalCountableMoreThan,
+            UniqueType.ConditionalCountableLessThan -> 
+                countableIsTileSpecific(conditional.params[0]) && countableIsTileSpecific(conditional.params[1])
+            UniqueType.ConditionalCountableBetween ->
+                countableIsTileSpecific(conditional.params[0]) && countableIsTileSpecific(conditional.params[1]) && countableIsTileSpecific(conditional.params[2])
+            UniqueType.ConditionalWhenCarriedBy -> false
+
+            UniqueType.ConditionalModEnabled -> false
+            UniqueType.ConditionalModNotEnabled -> false
             else -> false
         }
     }

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -35,7 +35,8 @@ import yairm210.purity.annotations.Readonly
 enum class Countables(
     val text: String = "",
     private val shortDocumentation: String = "",
-    open val documentationStrings: List<String> = emptyList()
+    open val documentationStrings: List<String> = emptyList(),
+    open val isTileSpecificForUnitAction: Boolean = false,
 ) {
     Integer {
         override val documentationHeader = "Integer constant - any positive or negative integer number"

--- a/core/src/com/unciv/models/ruleset/unique/GameContext.kt
+++ b/core/src/com/unciv/models/ruleset/unique/GameContext.kt
@@ -35,7 +35,7 @@ data class GameContext(
         (ourCombatant?.getCivInfo()?.gameInfo) ?: (theirCombatant?.getCivInfo()?.gameInfo) ?: (attackedTile?.tileMap?.gameInfo) ?:
         (otherCiv?.gameInfo),
 
-    val ignoreConditionals: Boolean = false,
+    val ignoreFieldsBits: Int = CONSIDER_ALL_FIELDS_MASK,
 ) {
     constructor(city: City) : this(city.civ, city, tile = city.getCenterTileOrNull(), gameInfo = city.civ.gameInfo)
     constructor(unit: MapUnit) : this(unit.civ, unit = unit, tile = if (unit.hasTile()) unit.getTile() else null, gameInfo = unit.civ.gameInfo)
@@ -53,7 +53,18 @@ data class GameContext(
         theirCombatant?.getCivInfo(),
         gameInfo = ourCombatant.getCivInfo().gameInfo
     )
-
+    
+    val considerCiv get() = ignoreFieldsBits and IGNORE_CIVILIZATION_BIT == 0
+    val considerCity get() = ignoreFieldsBits and IGNORE_CITY_BIT == 0
+    val considerUnit get() = ignoreFieldsBits and IGNORE_UNIT_BIT == 0
+    val considerTile get() = ignoreFieldsBits and IGNORE_TILE_BIT == 0
+    val considerOurCombatant get() = ignoreFieldsBits and IGNORE_OUR_COMBATANT_BIT == 0
+    val considerTheirCombatant get() = ignoreFieldsBits and IGNORE_THEIR_COMBATANT_BIT == 0
+    val considerAttackedTile get() = ignoreFieldsBits and IGNORE_ATTACKED_TILE_BIT == 0
+    val considerAction get() = ignoreFieldsBits and IGNORE_ACTION_BIT == 0
+    val considerRegion get() = ignoreFieldsBits and IGNORE_REGION_BIT == 0
+    val considerGameInfo get() = ignoreFieldsBits and IGNORE_GAME_INFO_BIT == 0
+    val ignoreConditionals get() = ignoreFieldsBits == IGNORE_ALL_CONDITIONALS_MASK
 
     val relevantUnit by lazy {
         if (ourCombatant != null && ourCombatant is MapUnitCombatant) ourCombatant.unit
@@ -109,11 +120,25 @@ data class GameContext(
     }
 
     companion object {
-        val IgnoreConditionals = GameContext(ignoreConditionals = true)
+        const val IGNORE_CIVILIZATION_BIT       = 1 shl 0
+        const val IGNORE_CITY_BIT               = 1 shl 1
+        const val IGNORE_UNIT_BIT               = 1 shl 2
+        const val IGNORE_TILE_BIT               = 1 shl 3
+        const val IGNORE_OUR_COMBATANT_BIT      = 1 shl 4
+        const val IGNORE_THEIR_COMBATANT_BIT    = 1 shl 5
+        const val IGNORE_ATTACKED_TILE_BIT      = 1 shl 6
+        const val IGNORE_ACTION_BIT             = 1 shl 7
+        const val IGNORE_REGION_BIT             = 1 shl 8
+        const val IGNORE_GAME_INFO_BIT          = 1 shl 9
+        const val IGNORE_ALL_CONDITIONALS_MASK  = (1 shl 10) -1
+        const val CONSIDER_ALL_FIELDS_MASK      = 0
+        const val CONSIDER_ONLY_TILES_MASK      = IGNORE_TILE_BIT.inv()
+
+        val IgnoreConditionals = GameContext(ignoreFieldsBits = IGNORE_ALL_CONDITIONALS_MASK)
         val EmptyState = GameContext()
         /** When caching uniques, we need to cache them unmultiplied, and apply multiplication only on retrieval from cache
          * This state lets the multiplication function know that it's always 1:1 */
-        val IgnoreMultiplicationForCaching = GameContext(ignoreConditionals = true)
+        val IgnoreMultiplicationForCaching = GameContext(ignoreFieldsBits = IGNORE_ALL_CONDITIONALS_MASK)
     }
 
     /**  Used ONLY for stateBasedRandom in [Conditionals.conditionalApplies] to prevent save scumming on [UniqueType.ConditionalChance] */
@@ -144,7 +169,7 @@ data class GameContext(
             combatAction.hash(),
             otherCiv.hash(),
             region.hash(),
-            ignoreConditionals.hashCode()
+            ignoreFieldsBits.hashCode()
         )
         return hash
     }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset.unique
 
 import com.unciv.Constants
 import com.unciv.logic.automation.Timers.Companion.timeThis
+import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.GlobalUniques
@@ -93,6 +94,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
         }
         return true
     }
+
+    @Readonly
+    fun unitActionModifiersAreTileSpecific(gameInfo: GameInfo): Boolean = modifiers.any { Conditionals.unitActionModifiersAreTileSpecific(gameInfo, it) }
 
     @Readonly
     fun getUniqueMultiplier(gameContext: GameContext): Int {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -83,11 +83,24 @@ object UniqueTriggerActivation {
         tile: Tile? = city?.getCenterTile() ?: unit?.currentTile,
         notification: String? = null,
         triggerNotificationText: String? = null
-    ): (()->Boolean)? {
+    ): (()->Boolean)? 
+        = getTriggerFunction(unique, GameContext(civInfo, city, unit, tile), notification, triggerNotificationText)
 
-        val relevantCity by lazy {
-            city?: tile?.getCity()
-        }
+    /** @return The action to be performed if possible, else null
+     * This is so the unit actions can be displayed as "disabled" if they won't actually do anything
+     * Even if the action itself is performable, there are still cases where it can fail -
+     *   for example unit placement - which is why the action itself needs to return Boolean to indicate success */
+    fun getTriggerFunction(
+        unique: Unique,
+        gameContext: GameContext,
+        notification: String? = null,
+        triggerNotificationText: String? = null
+    ): (()->Boolean)? {
+        val civInfo = gameContext.relevantCiv!!
+        val city = gameContext.relevantCity
+        val unit = gameContext.relevantUnit
+        val tile = gameContext.relevantTile ?: city?.getCenterTile() ?: unit?.currentTile
+        val relevantCity = city
         @Readonly fun getApplicableCities(cityFilter: String) =
             if (cityFilter == "in this city") sequenceOf(relevantCity).filterNotNull()
             else civInfo.cities.asSequence().filter { it.matchesFilter(cityFilter) }
@@ -101,8 +114,6 @@ object UniqueTriggerActivation {
                 true
             }
         }
-
-        val gameContext = GameContext(civInfo, city, unit, tile)
 
         val chosenCity = relevantCity ?:
             civInfo.cities.firstOrNull { it.isCapital() }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -375,6 +375,7 @@ object UnitActions {
             action = {
                 unit.automated = true
                 UnitAutomation.automateUnitMoves(unit)
+                Unit
             }.takeIf { unit.hasMovement() }
         ))
     }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.map.tile.ImprovementBuildingProblem
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Counter
+import com.unciv.models.TransformTargetableAction
 import com.unciv.models.UncivSound
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
@@ -437,29 +438,8 @@ object UnitActionsFromUniques {
                 title = title,
                 associatedUnique = unique,
                 action = {
-                    val oldMovement = unit.currentMovement
-                    unit.destroy()
-                    val newUnit =
-                        civInfo.units.placeUnitNearTile(unitTile.position, unitToTransformTo, unit.id, copiedFrom = unit)
-
-                    /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
-                     * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
-                     */
-                    if (newUnit == null) {
-                        val resurrectedUnit =
-                            civInfo.units.placeUnitNearTile(unitTile.position, unit.baseUnit, unit.id, copiedFrom = unit)!!
-                        
-                    } else { // Managed to upgrade
-                        // have to handle movement manually because we killed the old unit
-                        // a .destroy() unit has 0 movement
-                        // and a new one may have less Max Movement
-                        newUnit.currentMovement = oldMovement
-                        // adjust if newUnit has lower Max Movement
-                        if (newUnit.currentMovement.toInt() > newUnit.getMaxMovement())
-                            newUnit.currentMovement = newUnit.getMaxMovement().toFloat()
-                        // execute any side effects, Stat and Movement adjustments
-                        UnitActionModifiers.activateSideEffects(newUnit, unique, true)
-                    }
+                    TransformTargetableAction(unit, unique).invokeAction()
+                    Unit
                 }.takeIf {
                     !unit.isEmbarked() && UnitActionModifiers.canActivateSideEffects(unit, unique)
                 }

--- a/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
+++ b/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
@@ -5,12 +5,16 @@ import com.unciv.UncivGame
 import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.managers.TurnManager
+import com.unciv.logic.map.HexCoord
+import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.stats.Stat
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -25,9 +29,17 @@ internal class WorkerAutomationTest {
 
     @Before
     fun setUp() {
+        testGame.ruleset.units["Worker"]!!.uniques.remove("Can transform to [Warrior] <in [Desert] tiles> <with [71] priority>")
+        testGame.ruleset.units["Worker"]!!.uniques.remove("Can transform to [Warrior] <in [Desert] tiles> <with [70] priority>")
+        testGame.ruleset.units["Worker"]!!.uniques.remove("Can transform to [Warrior] <in [Desert] tiles> <with [51] priority>")
+        testGame.ruleset.units["Worker"]!!.uniques.remove("Can transform to [Warrior] <in [Desert] tiles> <with [50] priority>")
+        testGame.ruleset.units["Worker"]!!.uniques.remove("Can transform to [Warrior] <in [Desert] tiles> <with [26] priority>")
+        testGame.ruleset.units["Worker"]!!.uniques.remove("Can transform to [Warrior] <in [Desert] tiles> <with [25] priority>")
         UncivGame.Current.settings.useAStarPathfinding = true
         testGame.makeHexagonalMap(7)
         civInfo = testGame.addCiv()
+        civInfo.tech.addTechnology("The Wheel")
+        civInfo.tech.addTechnology("Railroads")
         workerAutomation = WorkerAutomation(civInfo, 3)
     }
 
@@ -48,7 +60,7 @@ internal class WorkerAutomationTest {
         val mapUnit = testGame.addUnit("Worker", civInfo, currentTile)
 
         // Act
-        workerAutomation.automateWorkerAction(mapUnit, hashSetOf())
+        workerAutomation.automateWorkerAction(mapUnit, UniqueActionQueue(mapUnit), hashSetOf())
 
         // Assert
         assertEquals("Worker should have replaced already existing improvement 'Farm' with 'Mine' to enable 'Iron' resource",
@@ -74,7 +86,7 @@ internal class WorkerAutomationTest {
 
         val mapUnit = testGame.addUnit("Worker", civInfo, currentTile)
 
-        workerAutomation.automateWorkerAction(mapUnit, hashSetOf())
+        workerAutomation.automateWorkerAction(mapUnit, UniqueActionQueue(mapUnit), hashSetOf())
 
         assertEquals("Worker should begun removing the forest to clear a luxury resource but didn't",
             "Remove Forest", currentTile.improvementInProgress
@@ -101,7 +113,7 @@ internal class WorkerAutomationTest {
         val mapUnit = testGame.addUnit("Worker", civInfo, currentTile)
 
         // Act
-        workerAutomation.automateWorkerAction(mapUnit, hashSetOf())
+        workerAutomation.automateWorkerAction(mapUnit, UniqueActionQueue(mapUnit),  hashSetOf())
 
         // Assert
         assertEquals("Worker should be buliding a farm under 'Iron' resource because it can't see it and has nothing else to do",
@@ -129,7 +141,7 @@ internal class WorkerAutomationTest {
 
         val mapUnit = testGame.addUnit("Worker", civInfo, currentTile)
 
-        workerAutomation.automateWorkerAction(mapUnit, hashSetOf())
+        workerAutomation.automateWorkerAction(mapUnit, UniqueActionQueue(mapUnit), hashSetOf())
 
         assertEquals("Worker should be buliding a mine on the Gold Ore luxury resource",
             "Mine", currentTile.improvementInProgress
@@ -351,7 +363,7 @@ internal class WorkerAutomationTest {
         val mapUnit = testGame.addUnit("Worker", civInfo, currentTile)
 
         // Act
-        workerAutomation.automateWorkerAction(mapUnit, hashSetOf())
+        workerAutomation.automateWorkerAction(mapUnit, UniqueActionQueue(mapUnit), hashSetOf())
 
         // Assert
         assertEquals("Worker should try to repair the mine",
@@ -359,6 +371,112 @@ internal class WorkerAutomationTest {
         )
         assertTrue(currentTile.turnsToImprovement > 0)
     }
+    
 
+    @Test
+    fun automateWorkerAction_nearPotentialImprovement_withModdedUnitAction_At71Priority_usesAction() {
+        civInfo.tech.techsResearched.addAll(testGame.ruleset.technologies.keys)
+        testGame.addCity(civInfo, testGame.tileMap[0,0])
+        testGame.setTileTerrain(HexCoord(0,1), "Desert")
 
+        testGame.ruleset.units["Worker"]!!.uniques.add("Can transform to [Warrior] <in [Desert] tiles> <with [71] priority>")
+        val unit: MapUnit = testGame.addUnit("Worker", civInfo, testGame.tileMap[0,0])
+
+        workerAutomation.automateWorkerAction(unit, UniqueActionQueue(unit), hashSetOf())
+        
+        assertTrue(unit.isDestroyed)
+        assertEquals("Warrior", testGame.tileMap[0,1].militaryUnit!!.baseUnit.name)
+        assertNull(testGame.tileMap[0,0].improvementInProgress)
+    }
+
+    @Test
+    fun automateWorkerAction_nearPotentialImprovement_withModdedUnitAction_At70Priority_findsTileToWork() {
+        civInfo.tech.techsResearched.addAll(testGame.ruleset.technologies.keys)
+        testGame.addCity(civInfo, testGame.tileMap[0,0])
+        testGame.setTileTerrain(HexCoord(0,1), "Desert")
+
+        testGame.ruleset.units["Worker"]!!.uniques.add("Can transform to [Warrior] <in [Desert] tiles> <with [70] priority>")
+        val unit = testGame.addUnit("Worker", civInfo, testGame.tileMap[0,0])
+
+        workerAutomation.automateWorkerAction(unit, UniqueActionQueue(unit), hashSetOf())
+
+        assertFalse(unit.isDestroyed)
+        assertEquals("Farm", testGame.tileMap[1,0].improvementInProgress)
+        assertEquals("Worker", unit.baseUnit.name)
+        assertEquals(HexCoord(1, 0), unit.currentTile.position)
+    }
+
+    @Test
+    fun automateWorkerAction_nearUndevelopedCity_withModdedUnitAction_At51Priority_usesAction() {
+        civInfo.tech.techsResearched.addAll(testGame.ruleset.technologies.keys)
+        val city1 = testGame.addCity(civInfo, testGame.tileMap[-6,-6])
+        testGame.addCity(civInfo, testGame.tileMap[6,6])
+        testGame.setTileTerrain(HexCoord(-5,-4), "Desert")
+        for (tile in city1.tilesInRange) tile.setImprovement("Farm", civInfo)
+
+        testGame.ruleset.units["Worker"]!!.uniques.add("Can transform to [Warrior] <in [Desert] tiles> <with [51] priority>")
+        val unit = testGame.addUnit("Worker", civInfo, testGame.tileMap[-5,-5])
+
+        workerAutomation.automateWorkerAction(unit, UniqueActionQueue(unit), hashSetOf())
+
+        assertTrue(unit.isDestroyed)
+        assertEquals("Warrior", testGame.tileMap[-5,-4].militaryUnit!!.baseUnit.name)
+    }
+
+    @Test
+    fun automateWorkerAction_nearUndevelopedCity_withModdedUnitAction_At50Priority_seeksCity() {
+        civInfo.tech.techsResearched.addAll(testGame.ruleset.technologies.keys)
+        val city1 = testGame.addCity(civInfo, testGame.tileMap[-6,-6])
+        testGame.addCity(civInfo, testGame.tileMap[6,6])
+        testGame.setTileTerrain(HexCoord(-5,-4), "Desert")
+        for (tile in city1.tilesInRange) tile.setImprovement("Farm", civInfo)
+
+        testGame.ruleset.units["Worker"]!!.uniques.add("Can transform to [Warrior] <in [Desert] tiles> <with [50] priority>")
+        val unit = testGame.addUnit("Worker", civInfo, testGame.tileMap[-5,-5])
+
+        workerAutomation.automateWorkerAction(unit, UniqueActionQueue(unit), hashSetOf())
+
+        assertFalse(unit.isDestroyed)
+        assertEquals(HexCoord(-3, -3), unit.currentTile.position)
+        assertEquals("Worker", unit.baseUnit.name)
+    }
+
+    @Test
+    fun automateWorkerAction_nearUnconnectedCity_withModdedUnitAction_At26Priority_usesAction() {
+        civInfo.tech.techsResearched.addAll(testGame.ruleset.technologies.keys)
+        val city1 = testGame.addCity(civInfo, testGame.tileMap[0,0])
+        val city2 = testGame.addCity(civInfo, testGame.tileMap[4,4])
+        testGame.setTileTerrain(HexCoord(0,1), "Desert")
+        for (tile in city1.tilesInRange) tile.setImprovement("Farm", civInfo)
+        for (tile in city2.tilesInRange) tile.setImprovement("Farm", civInfo)
+
+        testGame.ruleset.units["Worker"]!!.uniques.add("Can transform to [Warrior] <in [Desert] tiles> <with [26] priority>")
+        val unit = testGame.addUnit("Worker", civInfo, testGame.tileMap[0,0])
+
+        workerAutomation.automateWorkerAction(unit, UniqueActionQueue(unit), hashSetOf())
+
+        assertTrue(unit.isDestroyed)
+        assertEquals("Warrior", testGame.tileMap[0,1].militaryUnit!!.baseUnit.name)
+        assertNull(testGame.tileMap[-1,-1].improvementInProgress)
+    }
+
+    @Test
+    fun automateWorkerAction_nearUnconnectedCity_withModdedUnitAction_At25Priority_connectsCities() {
+        civInfo.tech.techsResearched.addAll(testGame.ruleset.technologies.keys)
+        val city1 = testGame.addCity(civInfo, testGame.tileMap[0,0])
+        val city2 = testGame.addCity(civInfo, testGame.tileMap[4,4])
+        testGame.setTileTerrain(HexCoord(0,1), "Desert")
+        for (tile in city1.tilesInRange) tile.setImprovement("Farm", civInfo)
+        for (tile in city2.tilesInRange) tile.setImprovement("Farm", civInfo)
+        
+        testGame.ruleset.units["Worker"]!!.uniques.add("Can transform to [Warrior] <in [Desert] tiles> <with [25] priority>")
+        val unit = testGame.addUnit("Worker", civInfo, testGame.tileMap[0,0])
+
+        workerAutomation.automateWorkerAction(unit, UniqueActionQueue(unit), hashSetOf())
+        
+        assertFalse(unit.isDestroyed)
+        assertEquals(HexCoord(1, 1), unit.currentTile.position)
+        assertEquals("Worker", unit.baseUnit.name)
+        assertEquals("Railroad", testGame.tileMap[1,1].improvementInProgress)
+    }
 }


### PR DESCRIPTION
Created a TargetableUnitAction interface, which is similar to UnitAction, but has helper functions to search for targetting. These TargetableUnitAction are held in a UniqueActionQueue. As Automation runs, it has UniqueActionQueue check TargetableUnitActions at the current priority level, and search for targets in the current movement range. If a tile is found, the unit moves there, and activates the ability.

Added Conditionals.unitActionModifiersAreTileSpecific so we call tell when we should bother searching for a valid tile or not.

GameContext.ignoreConditionals: Boolean replaced with ignoreFieldsBits bitmask, so we can check tile-agnostic conditions separately from tile-specific conditions.

(Maybe one day UnitAction will be a thin wrapper around TargetableUnitActions?)