### PR TITLE
Fixed warnings caused by timeThis

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -342,7 +342,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
      *  @param progressBar Optional reference to UI widget either provided by [WorldScreen.nextTurn][com.unciv.ui.screens.worldscreen.WorldScreen.nextTurn] or `null` when simulating
      *  @param shouldGainTime on a multiplayer game, if true, makes the player who's turn is ended recover time to play before risking to get forced to resign, 'false' by default 
      */
-    fun nextTurn(progressBar: NextTurnProgress? = null, shouldGainTime: Boolean = false) = timeThis("GameInfo.nextTurn") {
+    fun nextTurn(progressBar: NextTurnProgress? = null, shouldGainTime: Boolean = false):Unit = timeThis("GameInfo.nextTurn") {
         var player = currentPlayerCiv
         var playerIndex = civilizations.indexOf(player)
 
@@ -772,7 +772,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         combinedGlobalUniques = GlobalUniques.combine(ruleset.globalUniques, speed, difficultyObject)
     }
 
-    private fun updateCivilizationState() = timeThis("GameInfo.updateCivilizationState") {
+    private fun updateCivilizationState():Unit = timeThis("GameInfo.updateCivilizationState") {
         for (civInfo in civilizations.asSequence()
             // update city-state resource first since the happiness of major civ depends on it.
             // See issue: https://github.com/yairm210/Unciv/issues/7781

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -114,7 +114,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
     }
 
 
-    fun chooseNextConstruction() = timeThis("ConstructionAutomation.chooseNextConstruction") {
+    fun chooseNextConstruction(): Unit = timeThis("ConstructionAutomation.chooseNextConstruction") {
         if (cityConstructions.getCurrentConstruction() !is PerpetualConstruction) return  // don't want to be stuck on these forever
         
         addBuildingChoices()

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -37,7 +37,7 @@ object NextTurnAutomation {
     /** Top-level AI turn task list */
     fun automateCivMoves(civInfo: Civilization,
                          /** set false for 'forced' automation, such as skip turn */
-                         tradeAndChangeState: Boolean = true) = timeThis("automateCivMoves") {
+                         tradeAndChangeState: Boolean = true): Unit = timeThis("automateCivMoves") {
         if (civInfo.isBarbarian) return BarbarianAutomation(civInfo).automate()
         if (civInfo.isSpectator()) return // When there's a spectator in multiplayer games, it's processed automatically, but shouldn't be able to actually do anything
 

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -31,7 +31,7 @@ object UnitAutomation {
     private const val CLOSE_ENEMY_TILES_AWAY_LIMIT = 5
     private const val CLOSE_ENEMY_TURNS_AWAY_LIMIT = 3f
 
-    fun automateUnitMoves(unit: MapUnit) = timeThis("automateUnitMoves") {
+    fun automateUnitMoves(unit: MapUnit):Unit = timeThis("automateUnitMoves") {
         check(!unit.civ.isBarbarian) { "Barbarians is not allowed here." }
 
         // Might die next turn - move!

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -428,7 +428,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
      *
      *  If the next City.startTurn is soon enough, then use [reassignPopulationDeferred] instead.
      */
-    fun reassignPopulation(resetLocked: Boolean = false) = timeThis("reassignPopulation") {
+    fun reassignPopulation(resetLocked: Boolean = false):Unit = timeThis("reassignPopulation") {
         if (resetLocked) {
             workedTiles = hashSetOf()
             lockedTiles = hashSetOf()

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -358,7 +358,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         inProgressConstructions[constructionName] = inProgressConstructions[constructionName]!! + productionToAdd
     }
 
-    fun constructIfEnough() = timeThis("constructIfEnough") {
+    fun constructIfEnough():Unit = timeThis("constructIfEnough") {
         validateConstructionQueue()
 
         // Update InProgressConstructions for any available refunds
@@ -816,7 +816,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     private fun removeCurrentConstruction() = removeFromQueue(0, true)
 
-    fun chooseNextConstruction() = timeThis("chooseNextConstruction") {
+    fun chooseNextConstruction():Unit = timeThis("chooseNextConstruction") {
         if (!isQueueEmptyOrIdle()) {
             // If the USER set a perpetual construction, then keep it!
             if (getConstruction( currentConstructionName()) !is PerpetualConstruction || currentConstructionIsUserSet) return

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -346,7 +346,7 @@ class CityStats(val city: City) {
     //endregion
     //region State-Changing Methods
 
-    fun updateTileStats(localUniqueCache: LocalUniqueCache = LocalUniqueCache()) = timeThis("updateTileStats") {
+    fun updateTileStats(localUniqueCache: LocalUniqueCache = LocalUniqueCache()):Unit = timeThis("updateTileStats") {
         val stats = Stats()
         val workedTiles = city.tilesInRange.asSequence()
             .filter {

--- a/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
@@ -155,7 +155,7 @@ class CityPopulationManager : IsPartOfGameInfoSerialization {
     }
 
     /** Only assigns free population */
-    internal fun autoAssignPopulation() = timeThis("CityPopulationManager.autoAssignPopulation") {
+    internal fun autoAssignPopulation():Unit = timeThis("CityPopulationManager.autoAssignPopulation") {
         city.cityStats.update()  // calculate current stats with current assignments
         val freePopulation = getFreePopulation()
         if (freePopulation <= 0) return

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -18,7 +18,7 @@ import kotlin.math.roundToInt
 class CityTurnManager(val city: City) {
 
 
-    fun startTurn() = timeThis("CityTurnManager.startTurn") {
+    fun startTurn():Unit = timeThis("CityTurnManager.startTurn") {
         city.clearCaches()
         
         for (resource in city.getResourcesGeneratedByCity()) {
@@ -136,7 +136,7 @@ class CityTurnManager(val city: City) {
     }
 
 
-    fun endTurn() = timeThis("CityTurnManager.endTurn") {
+    fun endTurn():Unit = timeThis("CityTurnManager.endTurn") {
         for (unique in city.getTriggeredUniques(UniqueType.TriggerUponTurnEnd, includeCivUniques = false).toList()) {
             UniqueTriggerActivation.triggerUnique(unique, city)
         }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -863,7 +863,7 @@ class Civilization : IsPartOfGameInfoSerialization {
                 ?: throw MissingNationException("Nation $civName is not found!", gameInfo.ruleset.mods)
     }
 
-    fun setTransients() = timeThis("Civilization.setTransients") {
+    fun setTransients():Unit = timeThis("Civilization.setTransients") {
         goldenAges.civInfo = this
         greatPeople.civInfo = this
         civConstructions.setTransients(civInfo = this)

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -17,7 +17,7 @@ import kotlin.math.min
 
 object DiplomacyTurnManager {
 
-    fun DiplomacyManager.nextTurn() = timeThis("DiplomacyManager.nextTurn") {
+    fun DiplomacyManager.nextTurn():Unit = timeThis("DiplomacyManager.nextTurn") {
         nextTurnTrades()
         removeUntenableTrades()
         updateHasOpenBorders()

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -25,7 +25,7 @@ import com.unciv.logic.automation.Timers.Companion.timeThis
 class TurnManager(val civInfo: Civilization) {
 
 
-    fun startTurn(progressBar: NextTurnProgress? = null) = timeThis("TurnManager.startTurn") {
+    fun startTurn(progressBar: NextTurnProgress? = null):Unit = timeThis("TurnManager.startTurn") {
         if (civInfo.isSpectator()) return
 
         civInfo.threatManager.clear()
@@ -238,7 +238,7 @@ class TurnManager(val civInfo: Civilization) {
             * civInfo.gameInfo.speed.modifier.coerceAtLeast(1f)).toInt()
 
 
-    fun endTurn(progressBar: NextTurnProgress? = null) = timeThis("TurnManager.endTurn") {
+    fun endTurn(progressBar: NextTurnProgress? = null):Unit = timeThis("TurnManager.endTurn") {
         if (UncivGame.Current.settings.citiesAutoBombardAtEndOfTurn)
             NextTurnAutomation.automateCityBombardment(civInfo) // Bombard with all cities that haven't, maybe you missed one
 

--- a/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
@@ -83,7 +83,7 @@ class CapitalConnectionsFinder(private val civInfo: Civilization) {
         )
     }
 
-    private fun checkHarbor(cityToConnectFrom: City) = timeThis("CapitalConnectionsFinder.checkHarbor") {
+    private fun checkHarbor(cityToConnectFrom: City):Unit = timeThis("CapitalConnectionsFinder.checkHarbor") {
         check(
             cityToConnectFrom,
             transportType = if (cityToConnectFrom.wasPreviouslyReached(CapitalConnectionMedium.Railroad,null))
@@ -102,7 +102,7 @@ class CapitalConnectionsFinder(private val civInfo: Civilization) {
                       transportType: CapitalConnectionMedium,
                       overridingTransportType: CapitalConnectionMedium? = null,
                       tileFilter: (Tile) -> Boolean,
-                      cityFilter: (City) -> Boolean = { true })  = timeThis("CapitalConnectionsFinder.check") {
+                      cityFilter: (City) -> Boolean = { true }):Unit  = timeThis("CapitalConnectionsFinder.check") {
         // This is the time-saving mechanism we discussed earlier - If I arrived at this city via a certain BFS,
         // then obviously I already have all the cities that can be reached via that BFS so I don't need to run it again.
         if (cityToConnectFrom.wasPreviouslyReached(transportType, overridingTransportType))

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -92,7 +92,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         }
     }
 
-    fun updateSightAndResources() = timeThis("updateSightAndResources") {
+    fun updateSightAndResources():Unit = timeThis("updateSightAndResources") {
         updateViewableTiles()
         updateHasActiveEnemyMovementPenalty()
         updateCivResources()
@@ -169,7 +169,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
     /** Our tiles update pretty infrequently - most 'viewable tile' changes are due to unit movements,
      * which means we can store this separately and use it 'as is' so we don't need to find the neighboring tiles every time
      * a unit moves */
-    fun updateOurTiles() = timeThis("CivInfoTransientCache.updateOurTiles")  {
+    fun updateOurTiles():Unit = timeThis("CivInfoTransientCache.updateOurTiles")  {
         ourTilesAndNeighboringTiles = civInfo.cities.asSequence()
             .flatMap { it.getTiles() } // our owned tiles, still distinct
             .flatMap { sequenceOf(it) + it.neighbors }
@@ -289,7 +289,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
                 civInfo.getMatchingUniques(UniqueType.EnemyUnitsSpendExtraMovement)
     }
 
-    fun updateCitiesConnectedToCapital(initialSetup: Boolean = false) = timeThis("CivInfoTransientCache.updateCitiesConnectedToCapital") {
+    fun updateCitiesConnectedToCapital(initialSetup: Boolean = false):Unit = timeThis("CivInfoTransientCache.updateCitiesConnectedToCapital") {
         if (civInfo.cities.isEmpty()) return // No cities to connect
 
         val oldConnectedCities = if (initialSetup)
@@ -317,7 +317,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             city.connectedToCapitalStatus = city in newConnectedCities
     }
 
-    fun updateCivResources() = timeThis("CivInfoTransientCache.updateCivResources") {
+    fun updateCivResources():Unit = timeThis("CivInfoTransientCache.updateCivResources") {
         val newDetailedCivResources = ResourceSupplyList()
         for (city in civInfo.cities) newDetailedCivResources.add(city.getResourcesGeneratedByCity())
 

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -765,7 +765,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     /**
      * Update this unit's cache of viewable tiles and its civ's as well.
      */
-    fun updateVisibleTiles(updateCivViewableTiles: Boolean = true, explorerPosition: HexCoord? = null) = timeThis("MapUnit.updateVisibleTiles") {
+    fun updateVisibleTiles(updateCivViewableTiles: Boolean = true, explorerPosition: HexCoord? = null):Unit = timeThis("MapUnit.updateVisibleTiles") {
         val oldViewableTiles = viewableTiles
 
         viewableTiles = when {

--- a/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
@@ -136,7 +136,7 @@ class UnitTurnManager(val unit: MapUnit) {
     }
 
 
-    fun startTurn() = timeThis("UnitTurnManager.startTurn") {
+    fun startTurn():Unit = timeThis("UnitTurnManager.startTurn") {
         unit.movement.clearPathfindingCache()
         unit.currentMovement = unit.getMaxMovement().toFloat()
         unit.attacksThisTurn = 0


### PR DESCRIPTION
Eliminating "Return in function with expression body and without explicit return type. Use block body '{...}' or add an explicit return type. This will become an error in language version 2.4. See https://youtrack.jetbrains.com/issue/KTLC-288." warnings