### PR TITLE
Add missing table row in city stats table

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -159,7 +159,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
             tableWithIcons.add(Table().apply {
                 add(ImageGetter.getImage("StatIcons/Resistance")).size(20f).padRight(2f)
                 add("In resistance for another [${city.getFlag(CityFlags.Resistance)}] turns".toLabel())
-            })
+            }).row()
         }
 
         val resourceTable = Table()


### PR DESCRIPTION
"In resistance for ... turns" did not add a row to the table, which meant that the next entry was displayed on the same line in the city stats table. For example if a city is both in resistance and demands a WLTK resource.