### PR TITLE
 Hide religion- or espionage-specific demands when the feature is off

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/Demand.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/Demand.kt
@@ -1,10 +1,13 @@
 package com.unciv.logic.civilization.diplomacy
 
+import com.unciv.logic.automation.civilization.DiplomacyAutomation
 import com.unciv.logic.civilization.AlertType
+import com.unciv.logic.civilization.Civilization
 
 /** After creating the required flags, modifiers, and alert type, the only remaining work should be
  * - Adding the new alerts in the when() of AlertPopup.kt
  * - Triggering the violation (adding the violationOccurred flag) from somewhere in the code
+ * (Translation templates are found automatically)
  */
 
 enum class Demand(
@@ -47,7 +50,9 @@ enum class Demand(
         violationNoticedText = "Take back your spy and your broken promises.",
         wePromisedText = "We promised not to send spies to them ([turns] turns remaining)",
         theyPromisedText = "They promised not to send spies to us ([turns] turns remaining)"
-    ),
+    ) {
+        override fun show(civ: Civilization) = civ.gameInfo.isEspionageEnabled()
+    },
     DoNotSpreadReligion(
         agreedToDemand = DiplomacyFlags.AgreedToNotSpreadReligion,
         violationOccurred = DiplomacyFlags.SpreadReligionInOurCities,
@@ -65,7 +70,9 @@ enum class Demand(
         violationNoticedText = "We noticed you have continued spreading your religion to us, despite your promise. This will have....consequences.",
         wePromisedText = "We promised not to spread religion to them ([turns] turns remaining)",
         theyPromisedText = "They promised not to spread religion to us ([turns] turns remaining)",
-    ),
+    ) {
+        override fun show(civ: Civilization) = civ.gameInfo.isReligionEnabled()
+    },
     DoNotSettleNearUs(
         agreedToDemand = DiplomacyFlags.AgreedToNotSettleNearUs,
         violationOccurred = DiplomacyFlags.SettledCitiesNearUs,
@@ -103,5 +110,15 @@ enum class Demand(
         violationNoticedText = "You have exposed yourself as a treacherous warmonger.",
         wePromisedText = "We promised not to attack them ([turns] turns remaining)",
         theyPromisedText = "They promised not to attack us ([turns] turns remaining)"
-    )
+    ) {
+        /** This particular demand can currently only be made by AI to human players
+         * TODO logic for AI to appropriately respond to this ultimatum
+         * additionally, I suggest to only enable the button when there is a genuine military presence
+         * @see DiplomacyAutomation
+         */
+        override fun show(civ: Civilization) = false
+    };
+
+    /** Determines whether to offer the demand to players on the diplomacy screen */
+    open fun show(civ: Civilization) = true
 }

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
@@ -85,7 +85,7 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
 
         if (otherCiv.isHuman())
             diplomacyTable.add(diplomacyScreen.getHumanRelationshipTable(otherCivDiplomacyManager)).row()
-        else { 
+        else {
             diplomacyTable.add(diplomacyScreen.getRelationshipTable(otherCivDiplomacyManager)).row()
             diplomacyTable.add(getDiplomacyModifiersTable(otherCivDiplomacyManager)).row()
         }
@@ -194,7 +194,7 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
                 promisesTable.add(text.toLabel(Color.LIGHT_GRAY)).row()
             }
         }
-        
+
         return if (promisesTable.cells.isEmpty) null else promisesTable
     }
 
@@ -222,13 +222,13 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         demandsTable.defaults().pad(10f)
 
         val diplomacyManager = viewingCiv.getDiplomacyManager(otherCiv)!!
-        
+
         for (demand in Demand.entries) {
             if (!demand.show(viewingCiv))
                 continue
-            
+
             val button = demand.demandText.toTextButton()
-            
+
             if (otherCiv.popupAlerts.any { it.type == demand.demandAlert && it.value == viewingCiv.civID } // Already demanded
                 || diplomacyManager.hasFlag(demand.agreedToDemand)) { // already agreed
                 button.disable()

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
@@ -224,12 +224,7 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         val diplomacyManager = viewingCiv.getDiplomacyManager(otherCiv)!!
         
         for (demand in Demand.entries) {
-            
-            // this particular demand can currently only be made by AI to human players
-            // TODO logic for AI to appropriately respond to this ultimatum
-            // additionally, I suggest to only enable the button when there is a genuine military presence
-            // see DiplomacyAutomation
-            if (demand == Demand.DoNotAttackUs)
+            if (!demand.show(viewingCiv))
                 continue
             
             val button = demand.demandText.toTextButton()


### PR DESCRIPTION
Tangential to that Spy-moving NPE issue: When starting a G&K game in the future era, religion is off. That shows the following minor quirks:
- A player can issue a demand to not spread religion
- You get religious city-states
- You can adopt Piety

This PR treats the first of these, and for good measure also gates the 'stop spying' demand accordingly.
I'm passing the civ and not the GameInfo to the test function intentionally, in case there's demand to gate demands by civ uniques in the future.

The other two may result in a separate PR, but json using UniqueType.OnlyAvailable isn't enough, the corresponding code checks are missing, so it's not trivial.