### PR TITLE
Fix camera notch padding issue on Android 15+

### DIFF
--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -2,7 +2,10 @@ package com.unciv.app
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.work.WorkManager
 import com.badlogic.gdx.backends.android.AndroidApplication
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration
@@ -59,12 +62,31 @@ open class AndroidLauncher : AndroidApplication() {
         game = AndroidGame(this)
         initialize(game, config)
 
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView, ::insetsListener)
+
         // can be triggered via `adb shell am start -a android.intent.action.VIEW -d https://unciv.app/g/G-ef0f5e5a-f1db-4a54-9d94-92ca986afe8a-9 com.unciv.app`
         // or whatever your game id is
         game!!.setDeepLinkedGame(intent)
         game!!.addScreenObscuredListener()
         processPossibleFriendDeepLink(intent)
-        
+    }
+
+    private fun insetsListener(view: View, insets: WindowInsetsCompat): WindowInsetsCompat {
+        val settings = try {
+            game!!.settings // settings is a lateinit, and this listener *will* be called before it's done
+        } catch (_: Throwable) {
+            UncivFiles.getSettingsForPlatformLaunchers(filesDir.path)
+        }
+
+        // If settings.androidCutout is false, padding is applied
+        if (!settings.androidCutout) {
+            val cutoutInsets = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
+            view.setPadding(cutoutInsets.left, cutoutInsets.top, cutoutInsets.right, cutoutInsets.bottom)
+        } else {
+            view.setPadding(0, 0, 0, 0)
+        }
+
+        return insets
     }
 
     /**
@@ -127,9 +149,9 @@ open class AndroidLauncher : AndroidApplication() {
         game?.setDeepLinkedGame(intent)
         processPossibleFriendDeepLink(intent)
     }
-    
+   
     private fun processPossibleFriendDeepLink(intent: Intent) {
-        // can be triggered via 
+        // can be triggered via
         // `adb shell am start -a android.intent.action.VIEW -d https://unciv.app/p/P-63971008-a533-47f6-ad6a-57b616626138-9?name=Yairm210 com.unciv.app`
         // or whatever your friend id and name are
         if (intent.data != null && IdChecker.isFriendDeepLink(intent.data.toString())) {


### PR DESCRIPTION
Hi! Since Android 15, apps are now forced to be "edge-to-edge," which unfortunately broke the setting in Unciv that hides the notch.

I’ve added a listener in AndroidLauncher.kt to manually apply padding to the screen when the "Enable using display cutout areas" setting is turned off. This restores the black bar behavior.

Tested on: OnePlus Nord running Android 16 (/e/OS, derived from LineageOS)

fixes #12982 


