### PR TITLE
keepandroidopen.org - raise user awareness about google policies

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -149,6 +149,7 @@ tasks.register<Exec>("run") {
 dependencies {
     implementation(libs.android.ktx.core)
     implementation(libs.android.ktx.runtime)
+    implementation(libs.android.free.droid.warn)
     // Needed to convert e.g. Android 26 API calls to Android 21
     // If you remove this run `./gradlew :android:lintDebug` to ensure everything's okay.
     // If you want to upgrade this, check it's working by building an apk,

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -6,15 +6,15 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.work.WorkManager
 import com.badlogic.gdx.backends.android.AndroidApplication
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration
+import com.unciv.UncivGame
 import com.unciv.logic.IdChecker
 import com.unciv.logic.files.UncivFiles
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.screens.multiplayerscreens.AddFriendScreen
 import com.unciv.utils.Concurrency.runOnGLThread
-import com.unciv.utils.Dispatcher
 import com.unciv.utils.Display
 import com.unciv.utils.Log
-import com.unciv.utils.launchOnGLThread
+import org.woheller69.freeDroidWarn.FreeDroidWarn
 import java.io.File
 import java.lang.Exception
 import kotlinx.coroutines.CoroutineScope
@@ -59,12 +59,13 @@ open class AndroidLauncher : AndroidApplication() {
         game = AndroidGame(this)
         initialize(game, config)
 
+        FreeDroidWarn.showWarningOnUpgrade(this, UncivGame.VERSION.number)
+
         // can be triggered via `adb shell am start -a android.intent.action.VIEW -d https://unciv.app/g/G-ef0f5e5a-f1db-4a54-9d94-92ca986afe8a-9 com.unciv.app`
         // or whatever your game id is
         game!!.setDeepLinkedGame(intent)
         game!!.addScreenObscuredListener()
         processPossibleFriendDeepLink(intent)
-        
     }
 
     /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ allprojects {
         google()
         maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
         maven { url = uri("https://oss.sonatype.org/content/repositories/releases/") }
-        maven { url = uri("https://jitpack.io") } // for java-discord-rpc
+        maven { url = uri("https://jitpack.io") } // for java-discord-rpc and freedroidwarn
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ ktxCore = "1.16.0"
 ktxRuntime = "2.10.3"
 desugar = "2.1.5"
 
+# https://github.com/woheller69/FreeDroidWarn
+free-droid-warn = "V1.12"
 
 [libraries]
 #note - thanks to the subproject problem Studio won't properly recognize what is used or not:
@@ -77,6 +79,7 @@ android-ktx-runtime = { group = "androidx.work", name = "work-runtime-ktx", vers
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 
+android-free-droid-warn = { group = "com.github.woheller69", name = "FreeDroidWarn", version.ref = "free-droid-warn" }
 
 [bundles]
 jna = ["jna", "jna-platform"]


### PR DESCRIPTION
#14820 redone. Copy of text:

https://keepandroidopen.org/
(or https://cybernews.com/privacy/keep-android-open-campaign-opposes-google-restrictive-policy/ or https://duckduckgo.com?q=keepandroidopen etc...)

This uses a standard library implementing a warning. Not quite pure coincidence it's the same lib as used by the currently best free-friendly weather app on F-Droid and by the "secuso" apps which started out as academic demo promoting privacy.

- Since it's so much more intuitive this is based on #14264 - merging that one first then cherry-picking from this would be the way if approved: Just read the last commit diff, ignore the long history: 4a096f96ae29e335b8d29b83951ffa047662fe4e
- Con: Not going through our translation system // Pro: works before our i10n code is ready, even before a Language is chosen // Con: Their English isn't the best.
- Con: Code doesn't actually test whether the device is affected (one would have to query for presence of the proprietary Google Services, and in a way that can distinguish it from microG).
- Con: Dialog pops once per release - could easily be changed. Persistence happens outside our own settings json.

- Ultimately Yair's personal feeling about the matter counts!

<details><summary>Screenshot</summary>

<img width="1080" height="2400" alt="Screenshot_20260505_Unciv" src="https://github.com/user-attachments/assets/70ed5504-402d-4621-8d5f-f4e0ecf19965" />

Yes one already enjoys the music while the dialog shows.
The "Details" button opens keepandroidopen.org, the "Solution" button leads to [an anchor in the lib's readme](https://github.com/woheller69/FreeDroidWarn#solutions).

</details>