### PR TITLE
chore: Add padding to Options-Sound in rare border case

### DIFF
--- a/core/src/com/unciv/ui/popups/options/SoundTab.kt
+++ b/core/src/com/unciv/ui/popups/options/SoundTab.kt
@@ -34,7 +34,7 @@ internal class SoundTab(
 
     private fun addDownloadMusic() {
         val downloadMusicButton = "Download music".toTextButton()
-        add(downloadMusicButton).colspan(2).row()
+        add(downloadMusicButton).colspan(2).padTop(20f).row()
         val errorTable = Table()
         add(errorTable).colspan(2).row()
 


### PR DESCRIPTION
Specifically, between the player controls and the download "thatched villagers" button - having both should be unusual but possible, if you never download the classic default track, but do download some music mod(s). In that situation, the widgets are too close, and there's ample space.

No screenies - borderline case anyway. But tested.

Maybe we should remove the "default track" idea entirely and make it a mod... The button could remain but reroute to a mod DL, possibly reusing the "missing mods" code. Or even - squeeze a checkbox above the language picker - the first-run one, not the options one... Then expand the mod with more Kevin MacLeod oeuvres to reduce boredom...