### PR TITLE
Improve language handling and slightly ease use of language picker

### DIFF
--- a/android/src/com/unciv/app/AndroidGame.kt
+++ b/android/src/com/unciv/app/AndroidGame.kt
@@ -18,6 +18,7 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.UncivStage
 import com.unciv.utils.Concurrency
 import com.unciv.utils.isUUID
+import java.util.Locale
 
 class AndroidGame(private val activity: Activity) : UncivGame() {
 
@@ -91,4 +92,8 @@ class AndroidGame(private val activity: Activity) : UncivGame() {
 
     override fun getGcCount(): Int = 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) Debug.getRuntimeStat("art.gc.gc-count").toInt() else 0
+
+    override fun getDefaultLocale(): Locale =
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) super.getDefaultLocale()
+        else activity.resources.configuration.locales.get(0)
 }

--- a/core/src/com/unciv/models/metadata/LocaleCode.kt
+++ b/core/src/com/unciv/models/metadata/LocaleCode.kt
@@ -1,36 +1,47 @@
 package com.unciv.models.metadata
 
+import com.unciv.UncivGame
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.Readonly
 import java.text.NumberFormat
 import java.util.Locale
 
 /** Map Unciv language key to Java locale, for the purpose of getting a Collator for sorting.
+ *  Can also be used to list all available languages ([getSupportedLanguages]).
+ *  Can translate Java [Locale] to/from an Unciv language as stored in [GameSettings] using [find] followed by [locale] or [languageName] calls.
+ *
  *  - Effect depends on the Java libraries and may not always conform to expectations.
  *    If in doubt, debug and see what Locale instance you get and compare its properties with `Locale.getDefault()`.
- *    (`Collator.getInstance(LocaleCode.*.run { Locale(language, country) }) to Collator.getInstance()`, drill to both `rules`, compare hashes - if equal and other properties equal, then Java doesn't know your Language))
+ *    (`Collator.getInstance(LocaleCode.*.run { Locale(language, country) }) to Collator.getInstance()`, drill to both `rules`, compare hashes - if equal and other properties equal, then Java doesn't know your Language)
  *  - For languages without an easy predefined Locale, collation or numeric formats can be forced using [Unicode Extensions for BCP 47](https://www.unicode.org/reports/tr35/#Locale_Extension_Key_and_Type_Data).
  *
- *  @property name **Must** be the same as the translation file name with ' ', '_', '-', '(', ')' removed
+ *  @property name **Should** be the same as the translation file name with ' ', '_', '-', '(', ')' removed
  *  @property languageTag IETF BCP 47 language tag - see [forLanguageTag][Locale.forLanguageTag] or [Android reference][https://developer.android.com/reference/java/util/Locale#forLanguageTag(java.lang.String)]
  *                        Usually the ISO 639-1 code for the language, a dash, and the ISO 3166 code for the nation this is predominantly spoken in
- *  @property fastlaneFolder If set, it's used instead of the language part of [languageTag] as fastlane folder name
+ *  @property fastlaneFolder If set, it's used instead of the language part of [languageTag] as fastlane folder name. Query via [fastlaneFolder] method.
+ *  @property languageName The Unciv language setting and file name, if different from [name]. Query via [languageName] method.
  */
-enum class LocaleCode(val languageTag: String, private val fastlaneFolder: String? = null) {
+enum class LocaleCode(
+    val languageTag: String,
+    private val fastlaneFolder: String? = null,
+    private val languageName: String? = null,
+    val unused: Boolean = false
+) {
     Afrikaans("af-ZA"),
-    Arabic("ar-IQ"),
+    Arabic("ar-IQ", unused = true),
     Bangla("bn-BD"),
     Belarusian("be-BY"),
     Bosnian("bs-BA"),
-    BrazilianPortuguese("pt-BR"),
+    BrazilianPortuguese("pt-BR", languageName = "Brazilian_Portuguese"),
     Bulgarian("bg-BG"),
     Catalan("ca-ES"),
     Croatian("hr-HR"),
     Czech("cs-CZ"),
-    Danish("da-DK"),
+    Danish("da-DK", unused = true),
     Dutch("nl-NL"),
     English("en-US"),
-    Estonian("et-EE"),
+    Estonian("et-EE", unused = true),
+    Filipino("fil-PH-u-co-search"),
     Finnish("fi-FI"),
     French("fr-FR"),
     Galician("gl-ES"),
@@ -43,26 +54,26 @@ enum class LocaleCode(val languageTag: String, private val fastlaneFolder: Strin
     Japanese("ja-JP"),
     Korean("ko-KR"),
     Latin("la-IT"),
-    Latvian("lv-LV"),
+    Latvian("lv-LV", unused = true),
     Lithuanian("lt-LT"),
     Malay("ms-MY"),
     Maltese("mt-MT"),
     Norwegian("no-NO"),
-    NorwegianNynorsk("nn-NO"),
-    PersianPinglishDIN("fa-IR"), // These might just fall back to default
-    PersianPinglishUN("fa-IR"),
+    NorwegianNynorsk("nn-NO", unused = true),
+    PersianPinglishDIN("fa-IR", languageName = "Persian_(Pinglish-DIN)"), // These might just fall back to default
+    PersianPinglishUN("fa-IR", languageName = "Persian_(Pinglish-UN)"),
     Polish("pl-PL"),
     Portuguese("pt-PT"),
     Romanian("ro-RO"),
     Russian("ru-RU"),
     Rusyn("rue-SK-u-kr-cyrl-latn-digit", "rue"), // No specific locale exists, so use explicit cyrillic collation. Chose country with most speakers.
-    Serbian("sr-RS"),
-    SimplifiedChinese("zh-CN"),
-    Slovak("sk-SK"),
+    Serbian("sr-RS", unused = true),
+    SimplifiedChinese("zh-CN", languageName = "Simplified_Chinese"),
+    Slovak("sk-SK", unused = true),
     Spanish("es-ES"),
     Swedish("sv-SE"),
     Thai("th-TH"),
-    TraditionalChinese("zh-TW"),
+    TraditionalChinese("zh-TW", languageName = "Traditional_Chinese"),
     Turkish("tr-TR"),
     Ukrainian("uk-UA"),
     Vietnamese("vi-VN"),
@@ -70,22 +81,38 @@ enum class LocaleCode(val languageTag: String, private val fastlaneFolder: Strin
     ;
 
     @Readonly fun locale(): Locale = Locale.forLanguageTag(languageTag)
-    fun fastlaneFolder(): String = this.fastlaneFolder ?: locale().language
+    @Readonly fun fastlaneFolder(): String = this.fastlaneFolder ?: locale().language
+    @Readonly fun languageName(): String = this.languageName ?: name
 
     companion object {
-        private val bannedCharacters = listOf(' ', '_', '-', '(', ')') // Things not to have in enum names
-
         /** Find a LocaleCode for a [language] as stored in GameSettings */
         @Readonly
-        fun find(language: String): LocaleCode? {
-            val languageName = language.filterNot { it in bannedCharacters }
-            return LocaleCode.entries.firstOrNull { it.name == languageName }
-        }
+        fun find(language: String) =
+            LocaleCode.entries.firstOrNull { it.languageName() == language }
+
+        @Readonly
+        private fun Locale.softEquals(other: Locale) = language == other.language && country == other.country
+
+        /** Find a LocaleCode with translation file for a java [locale] */
+        @Readonly
+        // Don't use Locale.equals directly - ignore script, variant and extensions
+        fun find(locale: Locale) =
+            LocaleCode.entries.firstOrNull { !it.unused && it.locale().softEquals(locale) }
+
+        /** Return the system default language as setting name = file name,
+         *  but only if we support a translation, otherwise an empty string
+         */
+        fun getSystemLanguage(): String =
+            find(UncivGame.Current.getDefaultLocale())?.takeUnless { it.unused }?.languageName().orEmpty()
 
         /** Get a Java Locale for a [language] as stored in GameSettings */
         @Readonly
         fun getLocale(language: String): Locale =
             find(language)?.locale() ?: Locale.getDefault()
+
+        @Readonly
+        fun getSupportedLanguages() =
+            entries.asSequence().filterNot { it.unused }.map { it.languageName() }
 
         /** Get the fastlane folder name for a [language] as stored in GameSettings */
         fun fastlaneFolder(language: String) =

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -13,7 +13,6 @@ import com.unciv.ui.components.fonts.FontRulesetIcons
 import com.unciv.utils.Log
 import com.unciv.utils.debug
 import com.unciv.utils.hashOf
-import java.util.Locale
 import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Immutable
 import yairm210.purity.annotations.LocalState
@@ -161,32 +160,9 @@ class Translations : LinkedHashMap<String, TranslationEntry>() {
     }
 
     /** Get a list of supported languages for [readAllLanguagesTranslation] */
-    // This function is too strange for me, however, let's keep it "as is" for now. - JackRainy
     private fun getLanguagesWithTranslationFile(): List<String> {
-
-        val languages = HashSet<String>()
-        // So apparently the Locales don't work for everyone, which is horrendous
-        // So for those players, which seem to be Android-y, we try to see what files exist directly...yeah =/
-        try{
-            for (file in Gdx.files.internal("jsons/translations").list())
-                languages.add(file.nameWithoutExtension())
-        }
-        catch (ex: Exception) {
-            Log.error("Failed to add languages", ex)
-        } // Iterating on internal files will not work when running from a .jar
-
-        languages.addAll(Locale.getAvailableLocales() // And this should work for Desktop, meaning from a .jar
-                .map { it.getDisplayName(Locale.ENGLISH) }) // Maybe THIS is the problem, that the DISPLAY locale wasn't english
-        // and then languages were displayed according to the player's locale... *sweatdrop*
-
-        // These should probably be renamed
-        languages.add("Simplified_Chinese")
-        languages.add("Traditional_Chinese")
-
-        languages.remove("template")
-        languages.remove("completionPercentages")
-
-        return languages.filter { Gdx.files.internal("jsons/translations/$it.properties").exists() }
+        val languages = LocaleCode.getSupportedLanguages()
+        return languages.filter { Gdx.files.internal("jsons/translations/$it.properties").exists() }.toList()
     }
 
     /** Ensure _all_ languages are loaded, used by [TranslationFileWriter] and `TranslationTests` only.

--- a/core/src/com/unciv/ui/components/widgets/LanguageTable.kt
+++ b/core/src/com/unciv/ui/components/widgets/LanguageTable.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.models.metadata.LocaleCode
 import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.KeyCharAndCode
@@ -18,7 +19,6 @@ import com.unciv.ui.screens.LanguagePickerScreen
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
-import java.util.Locale
 
 
 /** Represents a row in the Language picker, used both in [OptionsPopup] and in [LanguagePickerScreen]
@@ -67,7 +67,7 @@ internal class LanguageTable(val language: String, val percentComplete: Int) : T
             val tableLanguages = Table()
             tableLanguages.defaults().uniformX().fillX().pad(10.0f)
 
-            val systemLanguage = Locale.getDefault().getDisplayLanguage(Locale.ENGLISH)
+            val systemLanguage = LocaleCode.getSystemLanguage()
 
             val languageCompletionPercentage = UncivGame.Current.translations
                 .percentCompleteOfLanguages

--- a/core/src/com/unciv/ui/screens/LanguagePickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/LanguagePickerScreen.kt
@@ -1,9 +1,12 @@
 package com.unciv.ui.screens
 
-import com.unciv.Constants
+import com.unciv.models.metadata.LocaleCode
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.scrollTo
+import com.unciv.ui.components.input.KeyCharAndCode
+import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.LanguageTable
 import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageKeyShortcuts
@@ -17,7 +20,7 @@ import com.unciv.ui.screens.pickerscreens.PickerScreen
  *  Reusable code is in [LanguageTable] and [addLanguageTables].
  */
 class LanguagePickerScreen : PickerScreen() {
-    private var chosenLanguage = Constants.english
+    private var chosenLanguage: String
 
     private val languageTables: ArrayList<LanguageTable>
 
@@ -26,6 +29,8 @@ class LanguagePickerScreen : PickerScreen() {
     }
 
     init {
+        chosenLanguage = LocaleCode.getSystemLanguage()
+
         closeButton.isVisible = false
 
         languageTables = topTable.addLanguageTables(stage.width - 60f)
@@ -44,13 +49,18 @@ class LanguagePickerScreen : PickerScreen() {
         }
 
         rightSideButton.setText("Pick language".tr())
-        rightSideButton.onClick {
+        rightSideButton.onActivation {
             pickLanguage()
         }
+        rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)
+        if (chosenLanguage.isNotEmpty()) onChoice()
     }
 
     private fun onChoice(choice: String) {
         chosenLanguage = choice
+        onChoice()
+    }
+    private fun onChoice() {
         rightSideButton.enable()
         update()
     }

--- a/core/src/com/unciv/utils/PlatformSpecific.kt
+++ b/core/src/com/unciv/utils/PlatformSpecific.kt
@@ -1,5 +1,7 @@
 package com.unciv.utils
 
+import java.util.Locale
+
 interface PlatformSpecific {
 
     /** Notifies player that his multiplayer turn started */
@@ -15,4 +17,7 @@ interface PlatformSpecific {
     fun getSystemErrorMessage(errorCode: Int): String? = null
 
     fun getGcCount(): Int
+
+    /** Get system locale, on Android 13+ app-specific locale */
+    fun getDefaultLocale(): Locale = Locale.getDefault()
 }


### PR DESCRIPTION
Features:
- Detection of system language on Android 13+ (not worth much without idea 1, but should you like that idea then this would be kinda important)
- First-run language picker pre-selects system language if it exists (currently it only sorts to pos 2 from the top if it's not English anyway)
- First-run language picker accepts Enter key - good synergy with the above and existing letter key support I hope
- Remove need for comment "This function is too strange for me" (almost a pity)
- Retrofit one missing LocaleCode entry for an existing translation file - should improve sort order for Filipino

Open ideas:
- Remember last-seen system language and follow if it changes _or_ re-open language picker
- Unit test to ensure LocaleCode.unused is correctly set
