### PR TITLE
Fix redundant requirement for sending embassies

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -178,7 +178,7 @@ object DiplomacyAutomation {
                 && it.hasUnique(UniqueType.EnablesOpenBorders)
                 && !ourDiploManager.hasOpenBorders
                 && !ourDiploManager.otherCivDiplomacy().hasOpenBorders
-                && civInfo.diplomacyFunctions.hasMutualEmbassyWith(it)
+                && civInfo.diplomacyFunctions.meetsEmbassyRequirementFor(it)
                 && !ourDiploManager.hasFlag(DiplomacyFlags.DeclinedOpenBorders)
                 && !areWeOfferingTrade(civInfo, it, Constants.openBorders)
         }.sortedByDescending { it.getDiplomacyManager(civInfo)!!.relationshipLevel() }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
@@ -134,6 +134,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
             && !ourDiploManager.hasModifier(DiplomaticModifiers.SharedEmbassies)
     }
 
+    @Readonly
     fun meetsEmbassyRequirementFor(otherCiv: Civilization): Boolean {
         return !civInfo.hasUnique(UniqueType.RequiresEmbassiesForDiplomacy) ||
             civInfo.getDiplomacyManager(otherCiv)!!.hasModifier(DiplomaticModifiers.SharedEmbassies)

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
@@ -103,9 +103,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
      */
     @Readonly
     private fun canTradeEmbassies(): Boolean {
-        return civInfo.isMajorCiv()
-            && civInfo.hasUnique(UniqueType.EnablesEmbassies)
-            && civInfo.hasUnique(UniqueType.RequiresEmbassiesForDiplomacy)
+        return civInfo.isMajorCiv() && civInfo.hasUnique(UniqueType.EnablesEmbassies)
     }
 
     /**
@@ -136,16 +134,9 @@ class DiplomacyFunctions(val civInfo: Civilization) {
             && !ourDiploManager.hasModifier(DiplomaticModifiers.SharedEmbassies)
     }
 
-    /**
-     * Test if both civs have embassies established in each others' capital
-     * Returns true if base ruleset or mods don't enable embassies
-     */
-    @Readonly
-    fun hasMutualEmbassyWith(otherCiv: Civilization): Boolean {
-        return if (civInfo.hasUnique(UniqueType.EnablesEmbassies)
-            && civInfo.hasUnique(UniqueType.RequiresEmbassiesForDiplomacy))
+    fun meetsEmbassyRequirementFor(otherCiv: Civilization): Boolean {
+        return !civInfo.hasUnique(UniqueType.RequiresEmbassiesForDiplomacy) ||
             civInfo.getDiplomacyManager(otherCiv)!!.hasModifier(DiplomaticModifiers.SharedEmbassies)
-        else true // Embassies are not enabled
     }
 
     /**
@@ -183,7 +174,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
         val ourDiploManager = civInfo.getDiplomacyManager(otherCiv)!!
         return canSignResearchAgreement()
             && otherCiv.diplomacyFunctions.canSignResearchAgreement()
-            && hasMutualEmbassyWith(otherCiv)
+            && meetsEmbassyRequirementFor(otherCiv)
             && ourDiploManager.hasFlag(DiplomacyFlags.DeclarationOfFriendship)
             && !ourDiploManager.hasFlag(DiplomacyFlags.ResearchAgreement)
             && !ourDiploManager.otherCivDiplomacy().hasFlag(DiplomacyFlags.ResearchAgreement)
@@ -216,7 +207,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
         val ourDiplomacyManager = civInfo.getDiplomacyManager(otherCiv)!!
         return canSignDefensivePact()
             && otherCiv.diplomacyFunctions.canSignDefensivePact()
-            && hasMutualEmbassyWith(otherCiv)
+            && meetsEmbassyRequirementFor(otherCiv)
             && ourDiplomacyManager.hasFlag(DiplomacyFlags.DeclarationOfFriendship)
             && !ourDiplomacyManager.hasFlag(DiplomacyFlags.DefensivePact)
             && !ourDiplomacyManager.otherCivDiplomacy().hasFlag(DiplomacyFlags.DefensivePact)

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -43,7 +43,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
         if (civInfo.isAtWarWith(otherCiv))
             offers.add(TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, speed = civInfo.gameInfo.speed))
         
-        if (civInfo.diplomacyFunctions.hasMutualEmbassyWith(otherCiv)
+        if (civInfo.diplomacyFunctions.meetsEmbassyRequirementFor(otherCiv)
             && !otherCiv.getDiplomacyManager(civInfo)!!.hasOpenBorders
             && civInfo.hasUnique(UniqueType.EnablesOpenBorders)
             && otherCiv.hasUnique(UniqueType.EnablesOpenBorders)) {


### PR DESCRIPTION
Closes #14828

There was multiple mistakes previously in the unique that required Embassies for advanced diplomacy. The most obvious mistake is that it required said unique to send embassies, which seems needlessly redundant. The second is that due to how the implementation worked, both the unique to enable embassies and the unique that required embassies for additional diplomacy options had perfect overlap with each other, leading to one or the other being fully redundant

This PR fixes this by defining clear boundaries with what each unique is supposed to do

- ``EnablesEmbassies`` is for allowing you to send embassies. It has no barring on anything else beyond this. This also means that starts with a ruleset that enabled embassies and then removed it later will not impact any embassies already established. This sounds like a potential issue, however, this is actually how the code worked in all cases prior to this PR, with the one exception of sending advanced Diplomacy options. This PR now makes it consistent and removes even that limitation
- ``RequiresEmbassiesForDiplomacy`` is for specifically limiting access to "advanced" (as Civ 5 defines them) diplomacy options until you establish an embassy. It specifically does nothing else outside of that

---------------
Is it just me, or should we have better definitions of what counts as an "advanced option" for diplomacy than just relying on what Civ5 says? Idk, just feels like something that should be moddable