### PR TITLE
Fix edge case where Great Prophet costs are wrong

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -199,8 +199,9 @@ class ReligionManager : IsPartOfGameInfoSerialization {
 
     private fun generateProphet() {
         val prophetUnit = getGreatProphetEquivalent() ?: return // No prophet units in this mod
+        val prophetCost = faithForNextGreatProphet()
 
-        val prophetSpawnChange = (5f + storedFaith - faithForNextGreatProphet()) / 100f
+        val prophetSpawnChange = (5f + storedFaith - prophetCost) / 100f
 
         if (Random(civInfo.gameInfo.turns).nextFloat() < prophetSpawnChange) {
             val birthCity =
@@ -212,7 +213,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
                 }
             val prophet = civInfo.units.addUnit(prophetUnit, birthCity) ?: return
             prophet.religion = religion!!.name
-            storedFaith -= faithForNextGreatProphet()
+            storedFaith -= prophetCost
             civInfo.civConstructions.boughtItemsWithIncreasingPrice.add(prophetUnit.name, 1)
         }
     }


### PR DESCRIPTION
It's possible that a mod will want to change the cost of a Great Prophet after spawning x Prophet. If this is before the Industrial era (or an equivalent for said mod), the only window to properly set that up is immediately after spawning a prophet. In such cases the faith  cost applied will be different from what the expected cost would be

This PR fixes that by locking in the faith cost at the start of the function and only referring to that instead of recalculating it