### PR TITLE
Json deserialization interns all strings

### DIFF
--- a/core/src/com/unciv/json/UncivJson.kt
+++ b/core/src/com/unciv/json/UncivJson.kt
@@ -3,6 +3,7 @@ package com.unciv.json
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.Json
+import com.badlogic.gdx.utils.JsonValue
 import com.badlogic.gdx.utils.JsonWriter
 import com.badlogic.gdx.utils.SerializationException
 import com.unciv.logic.map.HexCoord
@@ -24,6 +25,7 @@ fun json() = Json(JsonWriter.OutputType.json).apply {
     setSerializer(Duration::class.java, DurationSerializer())
     setSerializer(KeyCharAndCode::class.java, KeyCharAndCode.Serializer())
     setSerializer(HexCoord::class.java, HexCoord.Serializer())
+    //setSerializer(String::class.java, StringInterningSerializer())
 }
 
 /**
@@ -49,4 +51,12 @@ fun <T> Json.fromJsonFile(tClass: Class<T>, file: FileHandle): T {
         val jsonText = file.readString(Charsets.UTF_8.name())
         throw Exception("Could not parse json of file ${file.name()}", exception)
     }
+}
+
+private class StringInterningSerializer : Json.Serializer<String> {
+    override fun write(json: Json, key: String, knownType: Class<*>?) = json.writeValue(key as Any?, String::class.java, null)
+
+    override fun read(json: Json, jsonData: JsonValue, type: Class<*>?): String
+    = if (jsonData.type() == JsonValue.ValueType.`object`) (json.readValue("value", type, jsonData) as String)
+        else jsonData.asString().intern()
 }


### PR DESCRIPTION
After a load on my Pixel3a, this reduces the number of strings from ~116,474 to ~58,295 (-49.95%), and total memory from 95.0M to 88.0M (-7.3%), but loading was ~8.80% (CI95:2.71-14.9%) slower (loaded 40 times in a tight loop).

Civilization.setTransients was 14% slower, MapUnit.updateVisibleTiles was 11% faster, automateUnitMoves was 7% faster, and moveToTile was 5% faster. Total GameInfo.nextTurn performance improved,but not statistically significantly.

https://docs.google.com/spreadsheets/d/1yzMdTuirXmAoZd7v0CAr3QItoWMTtJPVOjmKJtlAAvE/edit?gid=1346917422#gid=1346917422