### PR TITLE
Minor optimizations for class `Counter`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,7 @@ allprojects {
             "kotlin.LongArray.iterator",
 
             "kotlin.collections.List.get",
+            "kotlin.collections.Map.getOrDefault",
             "kotlin.collections.firstNotNullOfOrNull",
             "kotlin.collections.copyInto",
             "kotlin.sequences.shuffled",

--- a/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
@@ -40,7 +40,7 @@ class CityPopulationManager : IsPartOfGameInfoSerialization {
         return toReturn
     }
 
-    @Readonly fun getNumberOfSpecialists() = getNewSpecialists().values.sum()
+    @Readonly fun getNumberOfSpecialists() = getNewSpecialists().sumValues()
 
     @Readonly
     fun getFreePopulation(): Int {

--- a/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
@@ -173,7 +173,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
         if (city.population.population <= 0) return
 
         val remainders = HashMap<String, Float>()
-        val pressurePerFollower = pressures.values.sum() / city.population.population
+        val pressurePerFollower = pressures.sumValues() / city.population.population
 
         // First give each religion an approximate share based on pressure
         for ((religion, pressure) in pressures) {
@@ -182,7 +182,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
             remainders[religion] = pressure.toFloat() - followersOfThisReligion * pressurePerFollower
         }
 
-        var unallocatedPopulation = city.population.population - followers.values.sum()
+        var unallocatedPopulation = city.population.population - followers.sumValues()
 
         // Divide up the remaining population
         while (unallocatedPopulation > 0) {

--- a/core/src/com/unciv/models/Counter.kt
+++ b/core/src/com/unciv/models/Counter.kt
@@ -14,6 +14,7 @@ import yairm210.purity.annotations.Readonly
  *  - The Json.Serializable implementation ensures compact format, it does not solve the non-string-key map problem.
  *  - Therefore, Deserialization works properly ***only*** with [K] === String.
  *    (ignoring this will return a deserialized map, but the keys will violate the compile-time type and BE strings)
+ *  - Deserialization will still ensure all values are actually Int's.
  */
 @InternalState
 open class Counter<K>(
@@ -25,12 +26,7 @@ open class Counter<K>(
                 super.put(key, value)
     }
 
-    override operator fun get(key: K): Int { // don't return null if empty
-        return if (containsKey(key))
-        // .toInt(), because GDX deserializes Counter values as *floats* for some reason
-            super.get(key)!!.toInt()
-        else 0
-    }
+    override operator fun get(key: K): Int = getOrDefault(key, 0)
 
     override fun put(key: K, value: Int): Int? {
         if (value == 0) return remove(key) // No objects of this sort left, no need to count
@@ -38,7 +34,8 @@ open class Counter<K>(
     }
 
     fun add(key: K, value: Int) {
-        put(key, get(key) + value)
+        // Using Java lib directly, so it's only one hash access. Uses compute's ability to remove entries.
+        compute(key) { _, old -> ((old ?: 0) + value).takeIf { it != 0 } }
     }
 
     fun add(other: Counter<K>) {
@@ -59,7 +56,7 @@ open class Counter<K>(
         return newCounter
     }
 
-    @Readonly 
+    @Readonly
     operator fun plus(other: Counter<K>): Counter<K> {
         @LocalState val clone = clone()
         clone.add(other)

--- a/core/src/com/unciv/utils/CollectionExtensions.kt
+++ b/core/src/com/unciv/utils/CollectionExtensions.kt
@@ -175,3 +175,14 @@ inline fun <T> GdxLongArray.fold(initial: T, op: (T, Long) -> T): T {
     }
     return r
 }
+
+@Suppress("unused") // If we ever compile to non-JVM, this will be used. On JVM, it'll be optimized away.
+private inline fun <K, V> MutableMap<K, V>.compute(key: K, crossinline mapping: (K, V?) -> V?) {
+    val oldValue = this[key]
+    val newValue = mapping(key, oldValue)
+    if (newValue == null) {
+        if (oldValue != null) this.remove(key)
+    } else {
+        this[key] = newValue
+    }
+}


### PR DESCRIPTION
I suppose that well-known line should really go into [this file](https://github.com/yairm210/Purity/blob/master/compiler-plugin/src/main/kotlin/yairm210/purity/validation/wellknown/WellKnownReadonlyFunctions.kt) instead, but I'll leave that up to you.

Note - preparing for non-JVM is a bit over the top, we would be miles from that, not only from other direct JDK dependencies... Should I drop the drop-in `compute` replacement?