### PR TITLE
Fix Educated Elite policy not gifting Great People from allied City-States

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -36,8 +36,8 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
     val isTimedTriggerable = hasModifier(UniqueType.ConditionalTimedUnique)
 
     val isTriggerable = type != null && (
-        type.targetTypes.contains(UniqueTarget.Triggerable)
-            || type.targetTypes.contains(UniqueTarget.UnitTriggerable)
+        type.targetTypes.any { it.canAcceptUniqueTarget(UniqueTarget.Triggerable) }
+            || type.targetTypes.any { it.canAcceptUniqueTarget(UniqueTarget.UnitTriggerable) }
             || isTimedTriggerable
         )
 


### PR DESCRIPTION
## Summary

The Educated Elite policy in the Patronage branch ("Allied City-States will occasionally gift Great People") stopped working in 4.17.8. Adopting the policy no longer sets up the
 periodic timer that triggers great person gifts from allied city-states.

## Root Cause

Commit 479dd558f ("Enable the 'triggers global alert' unique for most uniques", #13560) added an isTriggerable check to PolicyManager.adopt(). Before this change, the adopt
function triggered all policy uniques that had no trigger conditionals. After the change, it filters them through Unique.isTriggerable, which uses an exact HashSet.contains()
match:

// Unique.kt — the problematic check
type.targetTypes.contains(UniqueTarget.Triggerable)

The CityStateCanGiftGreatPeople unique type is declared with UniqueTarget.Global as its target. Global inherits from Triggerable via the inheritsFrom chain (Global ->
Triggerable), which correctly means "Global is a Triggerable" for every other purpose in the codebase. However, HashSet.contains() does an exact equality check and ignores the
inheritance hierarchy entirely — so {Global}.contains(Triggerable) returns false.

As a result, isTriggerable evaluates to false for this unique, the adopt() loop skips it, the CityStateGreatPersonGift flag is never added to flagsCountdown, and the
turn-processing logic that delivers the great person gifts never runs.

## Fix

Changed isTriggerable in Unique.kt to use canAcceptUniqueTarget() instead of contains():

// Before (exact match, ignores inheritance):
type.targetTypes.contains(UniqueTarget.Triggerable)

// After (inheritance-aware):
type.targetTypes.any { it.canAcceptUniqueTarget(UniqueTarget.Triggerable) }

canAcceptUniqueTarget() on UniqueTarget walks the inheritsFrom chain, so Global.canAcceptUniqueTarget(Triggerable) correctly returns true.

The same fix is applied to the UnitTriggerable check for consistency.

## Affected Version

4.17.8 and later (up to current master).