### PR TITLE
chore: Unit test for educated elite trigger and GP gifting by CS

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -366,9 +366,9 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     /**
      *  Advance a turn, running automation for AI players, stopping for human players
      *  @param progressBar Optional reference to UI widget either provided by [WorldScreen.nextTurn][com.unciv.ui.screens.worldscreen.WorldScreen.nextTurn] or `null` when simulating
-     *  @param shouldGainTime on a multiplayer game, if true, makes the player who's turn is ended recover time to play before risking to get forced to resign, 'false' by default 
+     *  @param shouldGainTime on a multiplayer game, if true, makes the player whose turn is ended recover time to play before risking getting forced to resign, 'false' by default 
      */
-    fun nextTurn(progressBar: NextTurnProgress? = null, shouldGainTime: Boolean = false):Unit = timeThis("GameInfo.nextTurn") {
+    fun nextTurn(progressBar: NextTurnProgress? = null, shouldGainTime: Boolean = false): Unit = timeThis("GameInfo.nextTurn") {
         var player = currentPlayerCiv
         var playerIndex = civilizations.indexOf(player)
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -428,8 +428,9 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
             val worldScreen = UncivGame.Current.worldScreen
             // Do we need to break if player won?
-            if (simulateUntilWin && player.victoryManager.hasWon()) {
+            if (simulateUntilWin && (player.victoryManager.hasWon() || simulateMaxTurns > 0 && turns >= simulateMaxTurns)) {
                 simulateUntilWin = false
+                simulateMaxTurns = 0
                 worldScreen?.autoPlay?.stopAutoPlay()
                 break
             }

--- a/core/src/com/unciv/logic/simulation/Simulation.kt
+++ b/core/src/com/unciv/logic/simulation/Simulation.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.automation.Timers
 import com.unciv.models.metadata.GameSetupInfo
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlin.math.max
@@ -136,7 +137,7 @@ class Simulation(
             }
         }
 
-        jobs.forEach { it.join() }
+        jobs.joinAll()
         Timers.singleton.endTiming()
     }
 
@@ -314,4 +315,3 @@ class Simulation(
         return if (x >= 0) 1 - tau else tau - 1
     }
 }
-

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -26,7 +26,14 @@ import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.ui.images.ImageGetter
 
 /**
- *  A testing game using a fresh clone of the Civ_V_GnK ruleset so it can be modded in-place
+ *  A testing game using a fresh clone of the Civ_V_GnK ruleset so it can be modded in-place.
+ *  * By default, it will have a map consisting of a single Tile. Use [makeHexagonalMap] or [makeRectangularMap] for more room.
+ *  * Starts with no civilizations, not even barbarians. Use [addCiv], [addBarbarianCiv] as needed. Note addCiv has two overloads, one creating a Nation and one using a G&K Nation.
+ *  * Initially, [GameInfo.currentPlayerCiv] is an uninitialized dummy and not suitable for e.g. a nextTurn.
+ *  * Helpers to modify the ruleset: [createBaseUnit], [createBelief], [createBuilding], [createPolicy], [createPolicyBranch],
+ *    [createResource], [createTileImprovement], [createUnitPromotion], [createUnitType], [createWonder]
+ *  * Helpers to modify game state: [addCity], [addDefaultMeleeUnitWithUniques], [addDefaultRangedUnitWithUniques], [addReligion], [addTileToCity], [addUnit]
+ *
  *  @param addGlobalUniques optional global uniques to add to the ruleset
  *  @param forUITesting default initializes UncivGame.Current and its settings, `true` initializes ImageGetter ruleset instead. Needed for FasterUIDevelopment.
  */

--- a/tests/src/com/unciv/uniques/UniqueErrorTests.kt
+++ b/tests/src/com/unciv/uniques/UniqueErrorTests.kt
@@ -1,12 +1,17 @@
 package com.unciv.uniques
 
+import com.unciv.UncivGame
+import com.unciv.logic.civilization.CivFlags
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.validation.RulesetErrorSeverity
 import com.unciv.models.ruleset.validation.UniqueValidator
+import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -59,5 +64,63 @@ class UniqueErrorTests {
         val uniqueWithSourceObject = Unique(uniqueText, sourceObjectType = UniqueTarget.Promotion)
         val errorListCorrectUniqueContainer = UniqueValidator(ruleset).checkUnique(uniqueWithSourceObject, false, null)
         assert(errorListCorrectUniqueContainer.getFinalSeverity() == RulesetErrorSeverity.OK)
+    }
+
+    @Test
+    fun testEducatedEliteGreatPersonGifting() {
+        // set up game
+        var failures = 0
+        fun logFailure(msg: String) {
+            failures++
+            println(msg)
+        }
+        val flagName = CivFlags.CityStateGreatPersonGift.name
+        val game = TestGame()
+        game.makeHexagonalMap(2)
+        game.setSpeed("Quick")
+        // prevent files access from completing tutorial tasks
+        UncivGame.Current.settings.tutorialTasksCompleted.addAll(
+            game.gameInfo.ruleset.events.keys
+                .filter { it.startsWith("Tutorial Task: [") }
+                .flatMap { it.getPlaceholderParameters() }
+        )
+
+        // set up civs
+        val civ = game.addCiv()
+        game.addCity(civ, game.getTile(-2, 0))
+        game.gameInfo.currentPlayerCiv = civ
+        val cityState = game.addCiv(cityStateType = "Mercantile")
+        game.addCity(cityState, game.getTile(2, 0))
+
+        // make the city-state allied
+        civ.diplomacyFunctions.makeCivilizationsMeet(cityState)
+        civ.addGold(10000)
+        cityState.cityStateFunctions.receiveGoldGift(civ, 10000)
+        if (cityState.allyCiv != civ)
+            logFailure("The test civ and city-state should be allied after a 10k gift")
+
+        // adopt the GP-gift-enabling policy
+        civ.removeFlag(flagName)
+        val ee = game.ruleset.policies["Educated Elite"]!!
+        civ.policies.freePolicies++
+        civ.policies.adopt(ee)
+        if (!civ.hasFlag(flagName))
+            logFailure("The test civ should have the $flagName flag after adopting Educated Elite")
+
+        // Ensure automation won't use up the GP - a threat won't do as it will be placed in the capital
+        game.ruleset.units.entries.removeIf { it.value.isGreatPerson }
+        game.createBaseUnit("Civilian", "Great Person - [Gold]", "Unbuildable", "Uncapturable")
+
+        // Force the countdown and pass *one* turn, a GP should appear
+        civ.addFlag(flagName, 1)
+        game.gameInfo.simulateUntilWin = true
+        game.gameInfo.simulateMaxTurns = 1
+        game.gameInfo.nextTurn()
+        val unit = civ.units.getCivUnits().firstOrNull { it.isGreatPerson() }
+        if (unit == null)
+            logFailure("No gifted Great Person unit found after setting $flagName to 1 and passing a turn")
+        else
+            println("GP unit gifted: $unit")
+        Assert.assertEquals(0, failures)
     }
 }

--- a/tests/src/com/unciv/uniques/UniqueErrorTests.kt
+++ b/tests/src/com/unciv/uniques/UniqueErrorTests.kt
@@ -77,7 +77,6 @@ class UniqueErrorTests {
         val flagName = CivFlags.CityStateGreatPersonGift.name
         val game = TestGame()
         game.makeHexagonalMap(2)
-        game.setSpeed("Quick")
         // prevent files access from completing tutorial tasks
         UncivGame.Current.settings.tutorialTasksCompleted.addAll(
             game.gameInfo.ruleset.events.keys
@@ -100,7 +99,6 @@ class UniqueErrorTests {
             logFailure("The test civ and city-state should be allied after a 10k gift")
 
         // adopt the GP-gift-enabling policy
-        civ.removeFlag(flagName)
         val ee = game.ruleset.policies["Educated Elite"]!!
         civ.policies.freePolicies++
         civ.policies.adopt(ee)

--- a/tests/src/com/unciv/uniques/UniqueErrorTests.kt
+++ b/tests/src/com/unciv/uniques/UniqueErrorTests.kt
@@ -42,19 +42,19 @@ class UniqueErrorTests {
         val errors = ruleset.getErrorList(false)
         assert(errors.isNotOK())
     }
-    
+
     @Test
     fun testTimedGlobalUniqueAcceptsTriggerConditionsWhenOnUnit(){
         RulesetCache.loadRulesets(noMods = true)
         val ruleset = RulesetCache.getVanillaRuleset()
         // Since the <for [3] turns> turns this unique into a triggerable, the <upon> trigger condition should be ok
         val uniqueText = "[-5]% Strength <for [3] turns> <upon damaging a [Warrior] unit>"
-        
+
         // Without a unit, this is an error
         val uniqueNoSourceObject = Unique(uniqueText)
         val errorListNoSourceObject = UniqueValidator(ruleset).checkUnique(uniqueNoSourceObject, false, null)
         assert(errorListNoSourceObject.getFinalSeverity() == RulesetErrorSeverity.Warning)
-        
+
         // When applied on a unit or promotion etc, this is fine
         val uniqueWithSourceObject = Unique(uniqueText, sourceObjectType = UniqueTarget.Promotion)
         val errorListCorrectUniqueContainer = UniqueValidator(ruleset).checkUnique(uniqueWithSourceObject, false, null)


### PR DESCRIPTION
***expected*** to fail checks before #14909 is merged, and will fail no longer once it is.

This required fixing simulation, because currently with all civs AI nextTurn will never stop no matter which simulation settings are in effect. Doesn't hinder any other unit test, but I couldn't test for unintended side effects as I don't really know how.

Also contains some linting and Kdoc expansion, sorry.