### PR TITLE
Do not display (Unknown) after Civ name in MP metadata preview

### DIFF
--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
@@ -49,14 +49,11 @@ object MultiplayerHelpers {
         if (preview?.currentPlayer != null) {
             val currentTurnStartTime = Instant.ofEpochMilli(preview.currentTurnStartTime)
             val currentPlayer = preview.getCurrentPlayerCiv()
+            val mpSettings = UncivGame.Current.settings.multiplayer
             // "You", name of friend, or null
             val playerDescriptor: String? = 
-                if (currentPlayer.playerId == UncivGame.Current.settings.multiplayer.getUserId()) 
-                    "You" 
-                else UncivGame.Current.settings.multiplayer.friendList
-                    .filter{ it.playerID == currentPlayer.playerId }
-                    .map{ it.name }
-                    .firstOrNull()
+                if (currentPlayer.playerId == mpSettings.getUserId()) "You" 
+                else mpSettings.friendList.firstOrNull { it.playerID == currentPlayer.playerId }?.name
             
             var playerText = "{${preview.currentPlayer}}"
             if (playerDescriptor != null)

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
@@ -49,14 +49,18 @@ object MultiplayerHelpers {
         if (preview?.currentPlayer != null) {
             val currentTurnStartTime = Instant.ofEpochMilli(preview.currentTurnStartTime)
             val currentPlayer = preview.getCurrentPlayerCiv()
-            val playerDescriptor = if (currentPlayer.playerId == UncivGame.Current.settings.multiplayer.getUserId()) {
-                "You"
-            } else {
-                val friend = UncivGame.Current.settings.multiplayer.friendList
-                    .firstOrNull{ it.playerID == currentPlayer.playerId }
-                friend?.name ?: "Unknown"
-            }
-            val playerText = "{${preview.currentPlayer}}{ }({$playerDescriptor})"
+            // null if not 
+            val playerDescriptor: String? = 
+                if (currentPlayer.playerId == UncivGame.Current.settings.multiplayer.getUserId()) 
+                    "You" 
+                else UncivGame.Current.settings.multiplayer.friendList
+                    .filter{ it.playerID == currentPlayer.playerId }
+                    .map{ it.name }
+                    .firstOrNull()
+            
+            var playerText = "{${preview.currentPlayer}}"
+            if (playerDescriptor != null)
+                playerText += "{ }({$playerDescriptor})"
 
             descriptionText.appendLine("Current Turn: [$playerText] since [${Duration.between(currentTurnStartTime, Instant.now()).formatShort()}] ago".tr())
             descriptionText.appendLine("Time to play the turn: [${Duration.ofMinutes(currentPlayer.playerMinutesBeforeForceResign.toLong()).formatShort()}]".tr())

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
@@ -49,7 +49,7 @@ object MultiplayerHelpers {
         if (preview?.currentPlayer != null) {
             val currentTurnStartTime = Instant.ofEpochMilli(preview.currentTurnStartTime)
             val currentPlayer = preview.getCurrentPlayerCiv()
-            // null if not 
+            // "You", name of friend, or null
             val playerDescriptor: String? = 
                 if (currentPlayer.playerId == UncivGame.Current.settings.multiplayer.getUserId()) 
                     "You" 


### PR DESCRIPTION
Space is scarce, especially on small screens.
The "Unknown" descriptor for players not in your friend list is in my opinion redundant, and can push other useful information out of view.

Before:
<img width="1357" height="819" alt="image" src="https://github.com/user-attachments/assets/a12b49fb-ed46-46f1-8378-0d97863b68b6" />

After:
<img width="1357" height="819" alt="image" src="https://github.com/user-attachments/assets/7cc590df-eb4e-404a-b8f0-4f397efd2e75" />

If the person is in your friend list, the behavior is unchanged:
<img width="1357" height="819" alt="image" src="https://github.com/user-attachments/assets/fedc5ad3-247d-4d91-bc78-75b230d8cfce" />