### PR TITLE
Mechanics for City expansion: Start bookkeeping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,8 @@ allprojects {
             "java.util.stream.StreamSupport.longStream",
             "java.util.stream.LongStream.parallel",
 
+            "kotlin.IntArray.get",
+            "kotlin.IntArray.iterator",
             "kotlin.LongArray.get",
             "kotlin.LongArray.iterator",
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -178,6 +178,12 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     @Transient
     var spaceResources = HashSet<String>()
 
+    @delegate:Transient
+    /** Used by all [CityExpansionManager][com.unciv.logic.city.managers.CityExpansionManager] instances to decide on cost formula */
+    val useSeparateTileAcquisitionCosts by lazy {
+        ruleset.modOptions.hasUnique(UniqueType.EnableSeparateTileAcquisitionCosts)
+    }
+
     //endregion
     //region Pure functions
 

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -375,7 +375,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
         newCity.cityConstructions.builtBuildings.add(building)
         newCity.cityConstructions.setTransients()
         newCity.cityStats.update(updateCivStats = false, calculateGrowthModifiers = false)
-        city.expansion.setTransients() // Revert owned tiles to original city
+        city.expansion.setTransients(city) // Revert owned tiles to original city
         return newCity.cityStats.currentCityStats - oldStats
     }
 

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.automation.civilization
 
 import com.unciv.logic.automation.unit.UnitAutomation
 import com.unciv.logic.city.City
+import com.unciv.logic.city.managers.OwnershipSource
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.BFS
 import com.unciv.logic.map.tile.Tile
@@ -107,7 +108,7 @@ object UseGoldAutomation {
             }
             if (ranOutOfMoney) {
                 for (tileThatNeedsBuying in tilesThatNeedBuying) {
-                    cityWithLeastCostToBuy.expansion.relinquishOwnership(tileThatNeedsBuying)
+                    cityWithLeastCostToBuy.expansion.relinquishOwnership(tileThatNeedsBuying, OwnershipSource.Bought)
                 }
                 civInfo.addGold(goldSpent)
             }

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -15,7 +15,6 @@ import java.util.*
 
 object UseGoldAutomation {
 
-
     /** allow AI to spend money to purchase city-state friendship, buildings & unit */
     fun useGold(civ: Civilization) {
         for (unit in civ.units.getCivUnits())

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -391,8 +391,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         state = GameContext(this)
         tilesInRange = getCenterTile().getTilesInDistance(getWorkRange()).toHashSet()
         population.city = this
-        expansion.city = this
-        expansion.setTransients()
+        expansion.setTransients(this)
         cityConstructions.city = this
         religion.setTransients(this)
         cityConstructions.setTransients()

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -59,7 +59,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     @Transient
     lateinit var tilesInRange: HashSet<Tile>
-    
+
     @Transient var state = GameContext.EmptyState
 
     @Transient
@@ -85,7 +85,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     @Transient  // CityStats has no serializable fields
     var cityStats = CityStats(this)
-    
+
     var resourceStockpiles = Counter<String>()
 
     /** All tiles that this city controls */
@@ -102,14 +102,14 @@ class City : IsPartOfGameInfoSerialization, INamed {
     var hasSoldBuildingThisTurn = false
     var isPuppet = false
     var shouldReassignPopulation = false  // flag so that on startTurn() we reassign population
-    
+
     var unitShouldUseSavedPromotion = HashMap<String, Boolean>()
-    
+
     var unitToPromotions = HashMap<String, UnitPromotions>()
 
     /** Neighboring explored cities, in radius of 12 tiles */
     @delegate:Transient
-    val neighboringCities: List<City> by lazy { 
+    val neighboringCities: List<City> by lazy {
         civ.gameInfo.getCities().filter { it != this && it.getCenterTile().isExplored(civ) && it.getCenterTile().aerialDistanceTo(getCenterTile()) <= 12 }.toList()
     }
 
@@ -119,7 +119,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     /**
      * Civ object for the original founder of this city
-     * 
+     *
      * Setting this also sets its backing serialization string ``foundingCiv``
      * */
     @Transient
@@ -133,7 +133,6 @@ class City : IsPartOfGameInfoSerialization, INamed {
             field = value
             foundingCiv = value?.civID ?: ""
         }
-
 
 
     var avoidGrowth: Boolean = false
@@ -152,7 +151,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     @Transient @Cache private val landAttackPathing = ConcurrentHashMap<Civilization, PathingMap>()
     @Transient @Cache private val amphibiousAttackPathing = ConcurrentHashMap<Civilization, PathingMap>()
     @Transient @Cache private lateinit var potentialRoadPathing: PathingMap
-    
+
 
     /** Persisted connected-to-capital (by any medium) to allow "disconnected" notifications after loading */
     var connectedToCapitalStatus = false
@@ -203,7 +202,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     @Readonly fun isCapital(): Boolean = cityConstructions.builtBuildingUniqueMap.hasUnique(UniqueType.IndicatesCapital, state)
     @Readonly fun isCoastal(): Boolean = centerTile.isAdjacentToCoast()
     @Readonly fun isNaval(): Boolean = centerTile.isWater || isCoastal()
-    
+
     @Readonly fun getBombardRange(): Int = civ.gameInfo.ruleset.modOptions.constants.baseCityBombardRange
     @Readonly fun getWorkRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityWorkRange
     @Readonly fun getExpandRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityExpandRange
@@ -217,7 +216,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         val mediumTypes = civ.cache.citiesConnectedToCapitalToMediums[this] ?: return false
         return connectionTypePredicate(mediumTypes)
     }
-    
+
     @Readonly
     fun getLandAttackPath(destination: City, maxTurns: Int = PathingMap.MAX_VALID_TURNS): List<Tile>? {
         @LocalState val pathingCache = landAttackPathing.getOrPut(destination.civ, {PathingMap.createLandAttackPathingMap(civ, centerTile, destination.civ)})
@@ -316,7 +315,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         Stat.Food -> population.foodStored += amount
         else -> civ.addStat(stat, amount)
     }
-    
+
     @Readonly
     fun getGameResource(gameResource: GameResource): Int = when (gameResource){
         is TileResource -> getAvailableResourceAmount(gameResource)
@@ -337,7 +336,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
             else -> civ.addGameResource(stat, amount)
         }
     }
-    
+
     @Readonly
     fun getStatReserve(stat: Stat): Int = when (stat) {
         Stat.Production -> cityConstructions.getWorkDone(cityConstructions.getCurrentConstruction().name)
@@ -401,7 +400,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     }
 
     fun setFlag(flag: CityFlags, amount: Int, adjustWithGameSpeed: Boolean = false) {
-        flagsCountdown[flag.name] = 
+        flagsCountdown[flag.name] =
             if (adjustWithGameSpeed) (amount * civ.gameInfo.speed.modifier).roundToInt()
             else amount
     }
@@ -468,9 +467,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
         // The relinquish ownership MUST come before removing the city,
         // because it updates the city stats which assumes there is a capital, so if you remove the capital it crashes
-        for (tile in getTiles()) {
-            expansion.relinquishOwnership(tile)
-        }
+        expansion.clear()
 
         // Move the capital if destroyed (by a nuke or by razing)
         // Must be before removing existing capital because we may be annexing a puppet which means city stats update - see #8337
@@ -538,7 +535,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         population.autoAssignPopulation() // also updates city stats
         civ.cache.updateCivResources() // this building could be a resource-requiring one
     }
-    
+
     @Readonly
     fun canPlaceNewUnit(construction: BaseUnit): Boolean {
         val tile = getCenterTile()
@@ -689,7 +686,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         forEachLocalMatchingUnique(uniqueType, gameContext, op)
         civ.forEachMatchingUnique(uniqueType, gameContext, op)
     }
-    
+
     fun clearCaches() {
         landAttackPathing.clear()
         amphibiousAttackPathing.clear()
@@ -764,7 +761,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     }
 
     //endregion
-    
+
     companion object {
         const val NO_ID = "00000000-0000-0000-0000-000000000000"
         fun pseudoRandomId(civ: Civilization) = pseudoRandomUuid(GameContext(civ).stateBasedRandom("City.Id", civ.cities.size)).toString()

--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -54,7 +54,9 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
      *  * Re-evaluated per turn, since CityExpansionManager gets cloned. Should enable dynamic base size modding.
      */
     internal val foundingTileFilter: (Tile)->Boolean by lazy {
-        if (foundingUnique == null || foundingUnique!!.params[0] in Constants.all) fun(tile: Tile) = true
+        if (foundingUnique == null || foundingUnique!!.params[0] in Constants.all)
+            @Suppress("FunctionOnlyReturningConstant") // detekt false positive
+            fun(tile: Tile) = true
         else fun(tile: Tile) = tile.matchesFilter(foundingUnique!!.params[0], city.civ)
     }
 

--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -80,7 +80,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
     // -- Note (added later) that this last link is specific to civ VI and not civ V
     @Readonly
     fun getCultureToNextTile(): Int {
-        var cultureToNextTile = 6 * (max(0, tilesClaimed(OwnershipSource.Expansion)) + 1.4813).pow(1.3)
+        var cultureToNextTile = getLegacyCultureToNextTile() // TODO This is meant to allow using an optional Countables-based moddable formula instead
 
         cultureToNextTile *= city.civ.gameInfo.speed.cultureCostModifier
 
@@ -92,6 +92,13 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
                 cultureToNextTile *= unique.params[0].toPercent()
 
         return cultureToNextTile.roundToInt()
+    }
+
+    @Readonly
+    fun getLegacyCultureToNextTile(): Double {
+        val tileCount = if (city.civ.gameInfo.useSeparateTileAcquisitionCosts) tilesClaimed(OwnershipSource.Expansion)
+        else tilesClaimed(OwnershipSource.All) - tilesClaimed(OwnershipSource.Base)
+        return 6 * (max(0, tileCount) + 1.4813).pow(1.3)
     }
 
     @Readonly
@@ -125,9 +132,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun getGoldCostOfTile(tile: Tile): Int {
-        val baseCost = 50
-        val distanceFromCenter = tile.aerialDistanceTo(city.getCenterTile())
-        var cost = baseCost * (distanceFromCenter - 1) + tilesClaimed(OwnershipSource.Bought) * 5.0
+        var cost = getLegacyGoldCostOfTile(tile) // TODO This is meant to allow using an optional Countables-based moddable formula instead
 
         cost *= city.civ.gameInfo.speed.goldCostModifier
 
@@ -137,6 +142,15 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         }
 
         return cost.roundToInt()
+    }
+
+    @Readonly
+    private fun getLegacyGoldCostOfTile(tile: Tile): Double {
+        val baseCost = 50
+        val distanceFromCenter = tile.aerialDistanceTo(city.getCenterTile())
+        val tileCount = if (city.civ.gameInfo.useSeparateTileAcquisitionCosts) tilesClaimed(OwnershipSource.Bought)
+            else tilesClaimed(OwnershipSource.All) - tilesClaimed(OwnershipSource.Base)
+        return baseCost * (distanceFromCenter - 1) + tileCount * 5.0
     }
 
     @Readonly

--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -14,6 +14,7 @@ import com.unciv.ui.components.extensions.toPercent
 import com.unciv.utils.withItem
 import com.unciv.utils.withoutItem
 import org.jetbrains.annotations.VisibleForTesting
+import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.Readonly
 import kotlin.math.max
 import kotlin.math.pow
@@ -27,17 +28,48 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
     /** Amount of culture this city has accumulated, serialized */
     var cultureStored: Int = 0
 
+    /** Number of tiles acquired per source, _partially_ serialized - see class doc */
+    @Cache
+    private val tileCounts = CityExpansionTileCounter()
+
+    @delegate:Transient
+    private val foundingUnique by lazy {
+        @Suppress("DEPRECATION") // forEachMatchingUnique doesn't allow chaining
+        city.civ.getMatchingUniques(UniqueType.OneTimeTakeOverTilesInRadius)
+            .firstOrNull { it.hasModifier(UniqueType.TriggerUponFoundingCity) }
+    }
+    @delegate:Transient
+    /** Radius for tiles a city gets assigned when being founded.
+     *  * Usually 1, unless the civ has OneTimeTakeOverTilesInRadius with TriggerUponFoundingCity.
+     *  * Determines which tiles are considered "base free" and not counting against expansion costs.
+     *  * Re-evaluated per turn, since CityExpansionManager gets cloned. Should enable dynamic base size modding.
+     */
+    internal val foundingRadius by lazy {
+        foundingUnique?.let { it.params[1].toInt() } ?: 1
+    }
+    @delegate:Transient
+    /** Filter function for tiles a city gets assigned when being founded.
+     *  * Usually returning true, unless the civ has OneTimeTakeOverTilesInRadius with TriggerUponFoundingCity.
+     *  * Determines which tiles are considered "base free" and not counting against expansion costs.
+     *  * Re-evaluated per turn, since CityExpansionManager gets cloned. Should enable dynamic base size modding.
+     */
+    internal val foundingTileFilter: (Tile)->Boolean by lazy {
+        if (foundingUnique == null || foundingUnique!!.params[0] in Constants.all) fun(tile: Tile) = true
+        else fun(tile: Tile) = tile.matchesFilter(foundingUnique!!.params[0], city.civ)
+    }
+
     fun clone(): CityExpansionManager {
         val toReturn = CityExpansionManager()
         toReturn.cultureStored = cultureStored
+        toReturn.tileCounts.cloneFrom(tileCounts)
         return toReturn
     }
 
     @Readonly
-    fun tilesClaimed(): Int {
-        val tilesAroundCity = city.getCenterTile().neighbors
-                .map { it.position }
-        return city.tiles.count { it != city.location && it !in tilesAroundCity}
+    /** Return tiles claimed, per source */
+    fun tilesClaimed(source: OwnershipSource = OwnershipSource.Expansion): Int {
+        tileCounts.normalize()
+        return tileCounts[source]
     }
 
     // This one has conflicting sources -
@@ -48,7 +80,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
     // -- Note (added later) that this last link is specific to civ VI and not civ V
     @Readonly
     fun getCultureToNextTile(): Int {
-        var cultureToNextTile = 6 * (max(0, tilesClaimed()) + 1.4813).pow(1.3)
+        var cultureToNextTile = 6 * (max(0, tilesClaimed(OwnershipSource.Expansion)) + 1.4813).pow(1.3)
 
         cultureToNextTile *= city.civ.gameInfo.speed.cultureCostModifier
 
@@ -85,7 +117,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
             throw NotEnoughGoldToBuyTileException("$city tried to buy $tile, but lacks gold (cost $goldCost, has ${city.civ.gold})")
 
         city.civ.addGold(-goldCost)
-        takeOwnership(tile)
+        takeOwnership(tile, OwnershipSource.Bought)
 
         // Reapply worked tiles optimization (aka CityFocus) - doing it here means AI profits too
         city.reassignPopulationDeferred()
@@ -95,7 +127,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
     fun getGoldCostOfTile(tile: Tile): Int {
         val baseCost = 50
         val distanceFromCenter = tile.aerialDistanceTo(city.getCenterTile())
-        var cost = baseCost * (distanceFromCenter - 1) + tilesClaimed() * 5.0
+        var cost = baseCost * (distanceFromCenter - 1) + tilesClaimed(OwnershipSource.Bought) * 5.0
 
         cost *= city.civ.gameInfo.speed.goldCostModifier
 
@@ -124,7 +156,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
     }
 
     //region state-changing functions
-    /** Relinquishes all tiles.
+    /** Relinquishes all tiles and resets tile acquisition source counts.
      *  @see reset */
     fun clear() {
         for (tile in city.getTiles())
@@ -132,7 +164,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         tileCounts.reset()
     }
 
-    /** Relinquishes all tiles, and re-acquires the base initial tiles
+    /** Relinquishes all tiles and resets tile acquisition source counts, and re-acquires the base initial tiles
      *  @see clear */
     fun reset() {
         clear()
@@ -140,18 +172,19 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         // The only way to create a city inside an owned tile is if it's in your territory
         // In this case, if you don't assign control of the central tile to the city,
         // It becomes an invisible city and weird shit starts happening
-        takeOwnership(city.getCenterTile())
+        takeOwnership(city.getCenterTile(), OwnershipSource.Base)
 
-        for (tile in city.getCenterTile().getTilesInDistance(1)
-                .filter { it.getCity() == null }) // can't take ownership of owned tiles (by other cities)
-            takeOwnership(tile)
+        val tilesToTake = city.getCenterTile().getTilesInDistance(foundingRadius)
+            .filter { it.getCity() == null && foundingTileFilter(it) } // can't take ownership of owned tiles (by other cities)
+        for (tile in tilesToTake)
+            takeOwnership(tile, OwnershipSource.Base)
     }
 
     private fun addNewTileWithCulture(): HexCoord? {
         val chosenTile = chooseNewTileToOwn()
         if (chosenTile != null) {
             cultureStored -= getCultureToNextTile()
-            takeOwnership(chosenTile)
+            takeOwnership(chosenTile, OwnershipSource.Expansion)
             return chosenTile.position
         }
         return null
@@ -162,9 +195,12 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
      * things like worked tiles, locked tiles, and stats.
      * @param tile The tile to relinquish
      */
-    fun relinquishOwnership(tile: Tile) {
+    fun relinquishOwnership(tile: Tile, source: OwnershipSource? = null) {
         if (tile.owningCity != city) return // UseGoldAutomation will relinquish tiles that is hasn't actually bought
+        tileCounts.normalize()
         city.tiles = city.tiles.withoutItem(tile.position)
+        tileCounts.relinquishOne(source)
+
         for (city in city.civ.cities) {
             if (city.isWorked(tile)) {
                 city.population.stopWorkingTile(tile.position)
@@ -189,8 +225,9 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
      * that are no longer allowed on that tile.
      *
      * @param tile The tile to take over
+     * @param source How the tile was acquired, for accounting
      */
-    fun takeOwnership(tile: Tile) {
+    fun takeOwnership(tile: Tile, source: OwnershipSource) {
         check(!tile.isCityCenter()) { "Trying to found a city in a tile that already has one" }
         if (tile.getCity() != null)
             tile.getCity()!!.expansion.relinquishOwnership(tile)
@@ -198,8 +235,10 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         if (tile.improvement == Constants.barbarianEncampment)
             tile.setImprovementBasic(null)
 
+        tileCounts.normalize()
         city.tiles = city.tiles.withItem(tile.position)
         tile.setOwningCity(city)
+        tileCounts[source]++
         city.population.autoAssignPopulation()
         city.civ.cache.updateOurTiles()
         city.cityStats.update()
@@ -219,6 +258,10 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         tile.history.recordTakeOwnership(tile)
     }
 
+    @VisibleForTesting
+    /** Only unit tests are allowed to call [takeOwnership] without a source, and they will count as free */
+    fun takeOwnership(tile: Tile) = takeOwnership(tile, OwnershipSource.Free)
+
     fun nextTurn(culture: Float) {
         cultureStored += culture.toInt()
         if (cultureStored >= getCultureToNextTile()) {
@@ -231,7 +274,9 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         }
     }
 
-    fun setTransients() {
+    fun setTransients(city: City) {
+        this.city = city
+        tileCounts.setTransients(city)
         val tiles = city.getTiles()
         for (tile in tiles)
             tile.setOwningCity(city)

--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -1,6 +1,5 @@
 package com.unciv.logic.city.managers
 
-import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.automation.Automation
@@ -8,12 +7,13 @@ import com.unciv.logic.city.City
 import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
+import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.tile.Tile
-import com.unciv.logic.map.toHexCoord
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.utils.withItem
 import com.unciv.utils.withoutItem
+import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Readonly
 import kotlin.math.max
 import kotlin.math.pow
@@ -21,7 +21,10 @@ import kotlin.math.roundToInt
 
 class CityExpansionManager : IsPartOfGameInfoSerialization {
     @Transient
-    lateinit var city: City
+    private lateinit var city: City
+
+    @VisibleForTesting
+    /** Amount of culture this city has accumulated, serialized */
     var cultureStored: Int = 0
 
     fun clone(): CityExpansionManager {
@@ -121,9 +124,18 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
     }
 
     //region state-changing functions
-    fun reset() {
+    /** Relinquishes all tiles.
+     *  @see reset */
+    fun clear() {
         for (tile in city.getTiles())
             relinquishOwnership(tile)
+        tileCounts.reset()
+    }
+
+    /** Relinquishes all tiles, and re-acquires the base initial tiles
+     *  @see clear */
+    fun reset() {
+        clear()
 
         // The only way to create a city inside an owned tile is if it's in your territory
         // In this case, if you don't assign control of the central tile to the city,
@@ -135,12 +147,12 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
             takeOwnership(tile)
     }
 
-    private fun addNewTileWithCulture(): Vector2? {
+    private fun addNewTileWithCulture(): HexCoord? {
         val chosenTile = chooseNewTileToOwn()
         if (chosenTile != null) {
             cultureStored -= getCultureToNextTile()
             takeOwnership(chosenTile)
-            return chosenTile.position.toVector2()
+            return chosenTile.position
         }
         return null
     }
@@ -151,6 +163,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
      * @param tile The tile to relinquish
      */
     fun relinquishOwnership(tile: Tile) {
+        if (tile.owningCity != city) return // UseGoldAutomation will relinquish tiles that is hasn't actually bought
         city.tiles = city.tiles.withoutItem(tile.position)
         for (city in city.civ.cities) {
             if (city.isWorked(tile)) {
@@ -184,7 +197,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
 
         if (tile.improvement == Constants.barbarianEncampment)
             tile.setImprovementBasic(null)
-            
+
         city.tiles = city.tiles.withItem(tile.position)
         tile.setOwningCity(city)
         city.population.autoAssignPopulation()
@@ -196,7 +209,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
                 unit.movement.teleportToClosestMoveableTile()
             else if (unit.civ == city.civ && unit.isSleeping()) {
                 // If the unit is sleeping and is a worker, it might want to build on this tile
-                // So lets try to wake it up for the player to notice it
+                // So let's try to wake it up for the player to notice it
                 if (unit.cache.hasUniqueToBuildImprovements || unit.cache.hasUniqueToCreateWaterImprovements) {
                     unit.due = true
                     unit.action = null
@@ -211,7 +224,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         if (cultureStored >= getCultureToNextTile()) {
             val location = addNewTileWithCulture()
             if (location != null) {
-                val locations = LocationAction(location.toHexCoord(), city.location.toHexCoord())
+                val locations = LocationAction(location, city.location.toHexCoord())
                 city.civ.addNotification("[${city.name}] has expanded its borders!", locations,
                     NotificationCategory.Cities, NotificationIcon.Culture)
             }

--- a/core/src/com/unciv/logic/city/managers/CityExpansionTileCounter.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionTileCounter.kt
@@ -1,0 +1,171 @@
+package com.unciv.logic.city.managers
+
+import com.badlogic.gdx.utils.Json
+import com.badlogic.gdx.utils.JsonValue
+import com.unciv.logic.IsPartOfGameInfoSerialization
+import com.unciv.logic.city.City
+import com.unciv.logic.map.tile.Tile
+import yairm210.purity.annotations.Readonly
+
+/** This is just a Python-like NOP for silencing IDE complaints about empty blocks. Also a good target for breakpoints. */
+private inline val pass: Unit get() = Unit
+
+/**
+ *  Counts tiles acquired per [source][OwnershipSource].
+ *
+ *  Previously, all costs were based on a count of owned tiles.
+ *  But it's clear [(see issue #6394)](https://github.com/yairm210/Unciv/issues/6394) that:
+ *  *   There's free Tiles: Shohone and Citadel should not increase price
+ *  *   Culture prograssion is not altered by buying for gold
+ *  *   Gold progression is not altered by culture expansion
+ */
+@Suppress("NOTHING_TO_INLINE") // Readability
+class CityExpansionTileCounter : IsPartOfGameInfoSerialization, Json.Serializable {
+    private enum class State { Migrating, Deserialized, Operational }
+
+    private var state = State.Migrating
+    private val tileCounts = IntArray(OwnershipSource.entries.size)
+
+    @Transient
+    private lateinit var city: City
+
+    internal fun setTransients(city: City) {
+        this.city = city
+    }
+
+    @Readonly
+    private inline fun getUnchecked(source: OwnershipSource) = tileCounts[source.ordinal]
+    @Readonly
+    private inline fun getAll() = getUnchecked(OwnershipSource.All)
+    private inline fun setUnchecked(source: OwnershipSource, value: Int) { tileCounts[source.ordinal] = value }
+    private inline fun setAll(value: Int) = setUnchecked(OwnershipSource.All, value)
+
+    @Readonly
+    internal operator fun get(source: OwnershipSource): Int {
+        require(state == State.Operational)
+        return getUnchecked(source)
+    }
+
+    internal operator fun set(source: OwnershipSource, value: Int) {
+        require(source != OwnershipSource.All && state == State.Operational)
+        setUnchecked(source, value)
+        setAll(tileCounts.sum() - getAll())
+    }
+
+    /** For use only by [CityExpansionManager.clone] */
+    internal fun cloneFrom(other: CityExpansionTileCounter) {
+        other.tileCounts.copyInto(tileCounts)
+        state = other.state
+    }
+
+    /** Use only after clearing `[city].tiles` */
+    internal fun reset() {
+        tileCounts.fill(0)
+        state = State.Operational
+    }
+
+    /** Reduces tile count, fixing [OwnershipSource.All].
+     *  * Only necessary because we don't store source per-tile
+     *  @param source If `null`, choose a source to deduct from, in favour of the player
+     *  @throws IllegalStateException when state not [State.Operational] or count would become negative
+     */
+    internal fun relinquishOne(source: OwnershipSource?) {
+        val source = when {
+            // Where to deduct is passed by caller
+            source != null -> source
+            // since we don't store source per-tile (whether it was acquired free, or bought, or expanded) we deduct in favour of the player
+            getUnchecked(OwnershipSource.Bought) > 0 -> OwnershipSource.Bought
+            getUnchecked(OwnershipSource.Expansion) > 0 -> OwnershipSource.Expansion
+            getUnchecked(OwnershipSource.Free) > 0 -> OwnershipSource.Free
+            else -> OwnershipSource.Base
+        }
+        check(getUnchecked(source) > 0)
+        set(source, getUnchecked(source))
+    }
+
+    /** Do necessary corrections to get to [State.Operational].
+     *  This means deriving the values that are not serialized:
+     *  * [OwnershipSource.Base] is derived from ruleset and tiles around [city]
+     *  * [OwnershipSource.All] is set from `[city].tiles.size`
+     *  * [OwnershipSource.Expansion] is set to make up the difference
+     */
+    internal fun normalize() {
+        if (state == State.Operational) return
+        if (state == State.Migrating) {
+            // TODO - check all owned tiles for Citadel(equivalent)s?
+            // But for now, let's compromise and assume none were bought and none were from Citadels
+            pass
+        }
+        val all = city.tiles.size
+        val base = countOwnedBaseTiles()
+        val expansion = all - getUnchecked(OwnershipSource.Bought) - getUnchecked(OwnershipSource.Free) - base
+        check(expansion >= 0)
+        setUnchecked(OwnershipSource.Base, base)
+        setUnchecked(OwnershipSource.Expansion, expansion)
+        setAll(all)
+        state = State.Operational
+    }
+
+    private fun verify() {
+        if (!::city.isInitialized)
+            return
+        check(tileCounts.sum() == getAll() * 2) {
+            "Tiles owned by ${city.name} have a discrepancy between sum of sources (${tileCounts.sum() - getAll()}) and source All (${getAll()})"
+        }
+        check(getAll() == city.tiles.size) {
+            "Tiles owned by ${city.name} have a discrepancy between tiles.size (${city.tiles.size}) and expansion.tileCounts (${getAll()})"
+        }
+    }
+
+    private fun countOwnedBaseTiles(): Int {
+        val foundingRadius = city.expansion.foundingRadius
+        fun foundingTileFilter(tile: Tile) = tile.owningCity == city && city.expansion.foundingTileFilter(tile)
+        return if (foundingRadius == 1)
+            1 + city.getCenterTile().neighbors.count(::foundingTileFilter)
+        else
+            @Suppress("DEPRECATION") // forEachTileInDistance doesn't allow chaining
+            city.getCenterTile().getTilesInDistance(foundingRadius).count(::foundingTileFilter)
+    }
+
+    //region Overrides
+    override fun write(json: Json) {
+        normalize()
+        verify()
+        fun save(key: OwnershipSource) {
+            if (getUnchecked(key) > 0)
+                json.writeValue(key.name, getUnchecked(key))
+        }
+        // Don't serialize All, Expansion or Base: They can be derived.
+        save(OwnershipSource.Bought)
+        save(OwnershipSource.Free)
+    }
+
+    override fun read(json: Json, jsonData: JsonValue) {
+        fun load(key: OwnershipSource) {
+            val entry = jsonData.get(key.name) ?: return
+            setUnchecked(key, entry.asInt())
+        }
+        load(OwnershipSource.Bought)
+        load(OwnershipSource.Free)
+        state = State.Deserialized
+    }
+
+    /** Debug-only visualization */
+    override fun toString() =
+        (if (::city.isInitialized) city.name + ": " else "") +
+        "$state [${OwnershipSource.entries.joinToString { "$it=${getUnchecked(it)}" } }]"
+
+    /** Having an equality contract saves space in serialized games */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CityExpansionTileCounter) return false
+        if (equivalent(other) || other.equivalent(this)) return true
+        return state == other.state && tileCounts.contentEquals(other.tileCounts)
+    }
+    private fun equivalent(other: CityExpansionTileCounter) =
+        state == State.Operational && other.state == State.Migrating &&
+            getUnchecked(OwnershipSource.Bought) == 0 && getUnchecked(OwnershipSource.Free) == 0
+    override fun hashCode() = 31 * state.hashCode() + tileCounts.contentHashCode()
+
+    //endregion
+}

--- a/core/src/com/unciv/logic/city/managers/OwnershipSource.kt
+++ b/core/src/com/unciv/logic/city/managers/OwnershipSource.kt
@@ -1,0 +1,28 @@
+package com.unciv.logic.city.managers
+
+import com.unciv.logic.city.City
+import com.unciv.models.ruleset.unique.UniqueType.OneTimeTakeOverTilesInCity
+import com.unciv.models.ruleset.unique.UniqueType.OneTimeTakeOverTilesInRadius
+
+/**
+ *  Source of tile ownership
+ *  * Used to index into [CityExpansionTileCounter]
+ *  @property All virtual value, readonly, represents sum of all sources, should always equal [City.tiles].size
+ *  @property Expansion Tile was acquired via normal expansion via Culture
+ *  @property Bought Tile was acquired by buying it with Gold
+ *  @property Free Tile was acquired via "take over" triggers [OneTimeTakeOverTilesInCity]/[OneTimeTakeOverTilesInRadius] or dev console
+ *  @property Base Tile was initially acquired during city founding
+ */
+enum class OwnershipSource {
+    All,
+    Expansion,
+    Bought,
+    Free,
+    Base;
+
+    companion object {
+        /** Case-insensitive version of [valueOf] for the console */
+        fun parse(text: String): OwnershipSource? =
+            entries.firstOrNull { it.name.equals(text, true) }
+    }
+}

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -882,6 +882,7 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
 
+    /** Do not call from outside [CityExpansionManager][com.unciv.logic.city.managers.CityExpansionManager], or the tile counters will de-synchronize */
     fun setOwningCity(city: City?) {
         if (roadOwner != "" && roadOwnerObject == null)
             roadOwnerObject = tileMap.gameInfo.getCivilization(roadOwner)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -4,6 +4,7 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.city.City
+import com.unciv.logic.city.managers.OwnershipSource
 import com.unciv.logic.civilization.*
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
@@ -1073,7 +1074,7 @@ object UniqueTriggerActivation {
                     for (applicableCity in applicableCities) {
                         for (i in 1..positiveAmount) {
                             val tileToOwn = applicableCity.expansion.chooseNewTileToOwn() ?: break
-                            applicableCity.expansion.takeOwnership(tileToOwn)
+                            applicableCity.expansion.takeOwnership(tileToOwn, OwnershipSource.Free)
                         }
                     }
                     if (notification != null)
@@ -1365,7 +1366,7 @@ object UniqueTriggerActivation {
                                 diplomacyCityState.setFlag(DiplomacyFlags.TilesStolen, 1)
                             }
                         }
-                        cityToAddTo.expansion.takeOwnership(tileToTakeOver)
+                        cityToAddTo.expansion.takeOwnership(tileToTakeOver, OwnershipSource.Free)
                     }
 
                     for (otherCiv in civsToNotify)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -1338,8 +1338,7 @@ object UniqueTriggerActivation {
 
                 val citiesWithAdjacentTiles = tilesToTakeOver.asSequence()
                     .flatMap { it.neighbors + it }
-                    .map { it.owningCity }
-                    .filterNotNull()
+                    .mapNotNull { it.owningCity }
                     .filter { it.civ == civInfo }
                     .toSet()
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -12,8 +12,8 @@ import yairm210.purity.annotations.Readonly
 // I didn't put this in a companion object because APPARENTLY doing that means you can't use it in the init function.
 private val numberRegex = Regex("\\d+$") // Any number of trailing digits
 
-const val ADDITIVE_BONUS_EXPLANATION = "Multiple bonuses stack additively: +50% + +50% = +100%"
-const val MULTIPLICATIVE_BONUS_EXPLANATION = "Multiple bonuses stack multiplicatively: +50% + +50% = x1.5 * x1.5 = +125%"
+private const val ADDITIVE_BONUS_EXPLANATION = "Multiple bonuses stack additively: +50% + +50% = +100%"
+private const val MULTIPLICATIVE_BONUS_EXPLANATION = "Multiple bonuses stack multiplicatively: +50% + +50% = x1.5 * x1.5 = +125%"
 
 enum class UniqueType(
     val text: String,
@@ -72,7 +72,7 @@ enum class UniqueType(
     PercentProductionBuildingsInCapital("[relativeAmount]% Production towards any buildings that already exist in the Capital", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentYieldFromPillaging("[relativeAmount]% Yield from pillaging tiles", UniqueTarget.Global, UniqueTarget.Unit),
     PercentHealthFromPillaging("[relativeAmount]% Health from pillaging tiles", UniqueTarget.Global, UniqueTarget.Unit),
-    
+
     // endregion Stat providing uniques
 
     // region City-State related uniques
@@ -85,8 +85,8 @@ enum class UniqueType(
     CityStateMoreGiftedUnits("Militaristic City-States grant units [positiveAmount] times as fast when you are at war with a common nation", UniqueTarget.Global),
 
     CityStateGoldGiftsProvideMoreInfluence("Gifts of Gold to City-States generate [relativeAmount]% more Influence", UniqueTarget.Global),
-    
-    
+
+
     CityStateCanBeBoughtForGold("Can spend Gold to annex or puppet a City-State that has been your Ally for [nonNegativeAmount] turns", UniqueTarget.Global),
     CityStateTerritoryAlwaysFriendly("City-State territory always counts as friendly territory", UniqueTarget.Global),
 
@@ -127,7 +127,7 @@ enum class UniqueType(
 
     /// Buying units/buildings
     // There is potential to merge these
-    
+
     BuyUnitsIncreasingCost("May buy [baseUnitFilter] units for [nonNegativeAmount] [stat] [cityFilter] at an increasing price ([amount])", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     BuyBuildingsIncreasingCost("May buy [buildingFilter] buildings for [nonNegativeAmount] [stat] [cityFilter] at an increasing price ([amount])", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     BuyUnitsForAmountStat("May buy [baseUnitFilter] units for [nonNegativeAmount] [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
@@ -213,7 +213,7 @@ enum class UniqueType(
     UnitStartingPromotions("All newly-trained [baseUnitFilter] units [cityFilter] receive the [promotion] promotion", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     // Todo: Lowercase the 'U' of 'Units' in this unique
     CityHealingUnits("[mapUnitFilter] Units adjacent to this city heal [amount] HP per turn when healing", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    
+
     // change the XP cost for a relative amount %
     XPForPromotionModifier("[relativeAmount]% XP required for promotions",UniqueTarget.Global,
         docDescription = MULTIPLICATIVE_BONUS_EXPLANATION),
@@ -314,7 +314,7 @@ enum class UniqueType(
     CanBePurchasedWithStat("Can be purchased with [stat] [cityFilter]", UniqueTarget.Building, UniqueTarget.Unit),
     CanBePurchasedForAmountStat("Can be purchased for [amount] [stat] [cityFilter]", UniqueTarget.Building, UniqueTarget.Unit),
     MaxNumberBuildable("Limited to [amount] per Civilization", UniqueTarget.Building, UniqueTarget.Unit),
-    
+
     /** A special unique, as it only activates [RejectionReasonType] when it has conditionals that *do not* apply.
      * Meant to be used together with conditionals, like `"Only available <after adopting [Piety]> <while the empire is happy>"`.
      * Restricts Upgrade/Transform pathways.
@@ -379,7 +379,7 @@ enum class UniqueType(
 
     CreatesOneImprovement("Creates a [improvementName] improvement on a specific tile", UniqueTarget.Building,
         docDescription = "When choosing to construct this building, the player must select a tile where the improvement can be built." +
-                " Upon building completion, the tile will gain this improvement." + 
+                " Upon building completion, the tile will gain this improvement." +
                 " Limited to one per building.",
         flags = UniqueFlag.setOfNoConditionals
         ),
@@ -464,7 +464,7 @@ enum class UniqueType(
     WithdrawsBeforeMeleeCombat("Withdraws before melee combat", UniqueTarget.Unit),
     CannotCaptureCities("Unable to capture cities", UniqueTarget.Unit, UniqueTarget.Global),
     CannotPillage("Unable to pillage tiles", UniqueTarget.Unit, UniqueTarget.Global),
-    
+
     // allow any unit to destory cities instead of capturing them, also allows non melee units to destroy cities
     CanDestroyCities("Destroys [cityFilter] cities instead of capturing", UniqueTarget.Unit,
         docDescription = "The unit will destroy [cityFilter] cities instead of capturing them, also allows non-melee units to destroy cities." + "Capital cities (including city states) are immune to this effect."),
@@ -688,7 +688,7 @@ enum class UniqueType(
     NoFeatureRemovalNeeded("Does not need removal of [terrainFeature]", UniqueTarget.Improvement),
     RemovesFeaturesIfBuilt("Removes removable features when built", UniqueTarget.Improvement),
 
-    DefensiveBonus("Gives a defensive bonus of [relativeAmount]%", UniqueTarget.Improvement, 
+    DefensiveBonus("Gives a defensive bonus of [relativeAmount]%", UniqueTarget.Improvement,
         docDescription = "Does not accept unit-based conditionals"),
     ImprovementMaintenance("Costs [amount] [stat] per turn when in your territory", UniqueTarget.Improvement), // Roads
     ImprovementAllMaintenance("Costs [amount] [stat] per turn", UniqueTarget.Improvement), // Roads
@@ -748,7 +748,7 @@ enum class UniqueType(
     ConditionalWLTKD("during We Love The King Day", UniqueTarget.Conditional),
 
     ConditionalHappy("while the empire is happy", UniqueTarget.Conditional),
-    
+
     ConditionalDuringEra("during the [era]", UniqueTarget.Conditional),
     ConditionalBeforeEra("before the [era]", UniqueTarget.Conditional),
     ConditionalStartingFromEra("starting from the [era]", UniqueTarget.Conditional),
@@ -934,7 +934,7 @@ enum class UniqueType(
     GetLeaderTitle("Get the leader title of [leaderTitle]", UniqueTarget.Triggerable, flags = UniqueFlag.setOfHiddenToUsers),
 
     //endregion
-    
+
     ///////////////////////////////////////// region 09 UNIT TRIGGERABLES /////////////////////////////////////////
 
     OneTimeUnitHeal("[unitTriggerTarget] heals [positiveAmount] HP", UniqueTarget.UnitTriggerable),
@@ -1024,7 +1024,7 @@ enum class UniqueType(
         UniqueTarget.Promotion,
         UniqueTarget.Tech,
         flags = UniqueFlag.setOfHiddenToUsers),
-    
+
     UnitActionPriority("with [amount] priority",
         UniqueTarget.UnitActionModifier,
         UniqueTarget.MetaModifier, // Can also be applied to UniqueTarget.Triggerable
@@ -1038,14 +1038,14 @@ enum class UniqueType(
     ShowsWhenUnbuilable("Shown while unbuilable", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
     ModifierHiddenFromUsers("hidden from users", UniqueTarget.MetaModifier),
     WillNotBeChosenForNewGames("Will not be chosen for new games", UniqueTarget.Nation),
-    
+
     ForEveryCountable("for every [countable]", UniqueTarget.MetaModifier,
         docDescription = "Works for positive numbers only"),
     ForEveryAdjacentTile("for every adjacent [tileFilter]", UniqueTarget.MetaModifier,
         docDescription = "Works for positive numbers only"),
     ForEveryAmountCountable("for every [positiveAmount] [countable]", UniqueTarget.MetaModifier,
         docDescription = "Works for positive numbers only"),
-    
+
     ModifiedByGameSpeed("(modified by game speed)", UniqueTarget.MetaModifier,
         docDescription = "Can only be applied to certain uniques, see details of each unique for specifics"),
     ModifiedByGameProgress("(modified by game progress up to [relativeAmount]%)", UniqueTarget.MetaModifier,

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -14,6 +14,11 @@ private val numberRegex = Regex("\\d+$") // Any number of trailing digits
 
 private const val ADDITIVE_BONUS_EXPLANATION = "Multiple bonuses stack additively: +50% + +50% = +100%"
 private const val MULTIPLICATIVE_BONUS_EXPLANATION = "Multiple bonuses stack multiplicatively: +50% + +50% = x1.5 * x1.5 = +125%"
+private const val TILE_ACQUISITION_EXPLANATION =
+    "Without this, Unciv determines costs of both tile acquisition from Culture and buying with Gold from the same source:" +
+    " total tiles acquired outside the initial founding ring, independent of how the tile was acquired." +
+    " This unique changes that, so only normal expansion affects culture cost, and only buying affects purchase price," +
+    " while free sources like a Citadel won't affect costs at all."
 
 enum class UniqueType(
     val text: String,
@@ -1065,6 +1070,7 @@ enum class UniqueType(
         docDescription = "In this case, 'starting era' means the first defined Era in the entire ruleset."),
     AllowRazeCapital("Allow raze capital", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
     AllowRazeHolyCity("Allow raze holy city", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
+    EnableSeparateTileAcquisitionCosts("Enable separate tile acquisition costs", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals, docDescription = TILE_ACQUISITION_EXPLANATION),
 
     SuppressWarnings("Suppress warning [validationWarning]", *UniqueTarget.CanIncludeSuppression, flags = UniqueFlag.setOfHiddenNoConditionals, docDescription = Suppression.uniqueDocDescription),
 

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleCityCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleCityCommands.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.screens.devconsole
 
+import com.unciv.logic.city.managers.OwnershipSource
 import com.unciv.models.ruleset.Building
 import com.unciv.ui.screens.devconsole.CliInput.Companion.findCliInput
 
@@ -42,16 +43,17 @@ internal class ConsoleCityCommands : ConsoleCommandNode {
             DevConsoleResponse.OK
         },
 
-        "addtile" to ConsoleAction("city addtile <cityName> [radius]") { console, params ->
+        "addtile" to ConsoleAction("city addtile <cityName> [radius] [Free|Expansion|Bought]") { console, params ->
             val selectedTile = console.getSelectedTile()
             val city = console.getCity(params[0])
             if (selectedTile.neighbors.none { it.getCity() == city })
                 throw ConsoleErrorException("Tile is not adjacent to any tile already owned by the city")
             if (selectedTile.isCityCenter()) throw ConsoleErrorException("Cannot transfer city center")
             val radius = params.getOrNull(1)?.toInt() ?: 0
+            val source = params.getOrNull(2)?.let { OwnershipSource.parse(it.content) } ?: OwnershipSource.Free
             for (tile in selectedTile.getTilesInDistance(radius)) {
                 if (tile.getCity() != city && !tile.isCityCenter())
-                    city.expansion.takeOwnership(tile)
+                    city.expansion.takeOwnership(tile, source)
             }
             DevConsoleResponse.OK
         },

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.screens.devconsole
 import com.unciv.Constants
 import com.unciv.logic.city.City
+import com.unciv.logic.city.managers.OwnershipSource
 import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.Notification
 import com.unciv.logic.civilization.NotificationCategory
@@ -106,13 +107,14 @@ internal class ConsoleTileCommands: ConsoleCommandNode {
         "addriver" to ConsoleRiverAction("tile addriver <direction>", true),
         "removeriver" to ConsoleRiverAction("tile removeriver <direction>", false),
 
-        "setowner" to ConsoleAction("tile setowner [civName|cityName]") { console, params ->
+        "setowner" to ConsoleAction("tile setowner [civName|cityName] [Free|Expansion|Bought]") { console, params ->
             val selectedTile = console.getSelectedTile()
+            val source = params.getOrNull(1)?.let { OwnershipSource.parse(it.content) } ?: OwnershipSource.Free
             val oldOwner = selectedTile.getCity()
             val newOwner = getOwnerCity(console, params, selectedTile)
             // for simplicity, treat assign to civ without cities same as un-assign
             oldOwner?.expansion?.relinquishOwnership(selectedTile) // redundant if new owner is not null, but simpler for un-assign
-            newOwner?.expansion?.takeOwnership(selectedTile)
+            newOwner?.expansion?.takeOwnership(selectedTile, source)
             DevConsoleResponse.OK
         },
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -3277,6 +3277,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: ModOptions
 
+??? example  "Enable separate tile acquisition costs"
+	Without this, Unciv determines costs of both tile acquisition from Culture and buying with Gold from the same source: total tiles acquired outside the initial founding ring, independent of how the tile was acquired. This unique changes that, so only normal expansion affects culture cost, and only buying affects purchase price, while free sources like a Citadel won't affect costs at all.
+
+	This unique does not support conditionals.
+
+	Applicable to: ModOptions
+
 ??? example  "Suppress warning [validationWarning]"
 	Allows suppressing specific validation warnings. Errors, deprecation warnings, or warnings about untyped and non-filtering uniques should be heeded, not suppressed, and are therefore not accepted. Note that this can be used in ModOptions, in the uniques a warning is about, or as modifier on the unique triggering a warning - but you still need to be specific. Even in the modifier case you will need to specify a sufficiently selective portion of the warning text as parameter.
 

--- a/tests/src/com/unciv/logic/city/managers/CityExpansionManagerTest.kt
+++ b/tests/src/com/unciv/logic/city/managers/CityExpansionManagerTest.kt
@@ -27,7 +27,7 @@ class CityExpansionManagerTest {
         testGame.makeHexagonalMap(6)
         civ = testGame.addCiv()
         city = testGame.addCity(civ, testGame.getTile(HexCoord.Zero), initialPopulation = 1)
-        cityExpansionManager.city = city
+        cityExpansionManager.setTransients(city)
     }
 
     @Test
@@ -100,7 +100,7 @@ class CityExpansionManagerTest {
         val cityStateCiv = testGame.addCiv(cityStateType = "Militaristic")
         val cityState = testGame.addCity(cityStateCiv, testGame.getTile(4,0))
         val cityStateExpansionManager = CityExpansionManager()
-        cityStateExpansionManager.city = cityState
+        cityStateExpansionManager.setTransients(cityState)
 
         val cultureToNextTileCiv = cityExpansionManager.getCultureToNextTile()
 
@@ -118,7 +118,7 @@ class CityExpansionManagerTest {
         val uniqueCiv = testGame.addCiv("[-25]% Culture cost of natural border growth [in all cities]")
         val uniqueCity = testGame.addCity(uniqueCiv, testGame.getTile(4,0))
         val cityUniqueExpansionManager = CityExpansionManager()
-        cityUniqueExpansionManager.city = uniqueCity
+        cityUniqueExpansionManager.setTransients(uniqueCity)
 
         val cultureToNextTile = cityExpansionManager.getCultureToNextTile()
 
@@ -135,7 +135,7 @@ class CityExpansionManagerTest {
         val uniqueCiv = testGame.addCiv("[-25]% Gold cost of acquiring tiles [in all cities]")
         val uniqueCity = testGame.addCity(uniqueCiv, testGame.getTile(4,0))
         val cityUniqueExpansionManager = CityExpansionManager()
-        cityUniqueExpansionManager.city = uniqueCity
+        cityUniqueExpansionManager.setTransients(uniqueCity)
 
         val goldCost2TileDistance = cityExpansionManager.getGoldCostOfTile(testGame.getTile(2,0))
 

--- a/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
@@ -2,6 +2,7 @@
 package com.unciv.uniques
 
 import com.unciv.Constants
+import com.unciv.logic.city.managers.OwnershipSource
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.models.ruleset.BeliefType
@@ -730,10 +731,12 @@ class GlobalUniquesTests {
         val civInfo = game.addCiv()
         val tile = game.getTile(HexCoord.Zero)
         val city = game.addCity(civInfo, tile, true)
-        Assert.assertEquals(7, city.getTiles().count())
+        fun tileCount() = city.expansion.tilesClaimed(OwnershipSource.All)
+
+        Assert.assertEquals(7, tileCount())
         val building = game.createBuilding("Gain control over [8] tiles [in this city]")
         city.cityConstructions.addBuilding(building)
-        Assert.assertEquals(15, city.getTiles().count())
+        Assert.assertEquals(15, tileCount())
     }
 
     // endregion


### PR DESCRIPTION
DO NOT MERGE AS IS
* For early evaluation
* **Important open question**: Is this architecture the way to go, just because it is closer to how Civ5 did it - or would it be better to store the acquisition source ***on the tile*** instead. At the moment I'm 50/50 conflicted. Input welcome. Only once it's clear this is the best architecture - then OK, it's playtested well. Might want to reduce `check`s for prod, but they already helped catch pre-existing quirks.
* Ideas for a good unit test?
* Note this also prepares a little for Countable-based Uniques to control the formulae.

Closes #6394
Replaces #10254

To "fix" the issue requires an actual change of logic, which with this PR a Mod can enable. There's no way we could gradually introduce a fix, as no matter how the actual formulae turn out, there will be multiplayer games where one player can buy tiles for less than another given the same circumstances, same for cultural expansion.

