### PR TITLE
Fix translation generation for Comment nesting typed uniques

### DIFF
--- a/core/src/com/unciv/logic/files/IMediaFinder.kt
+++ b/core/src/com/unciv/logic/files/IMediaFinder.kt
@@ -14,6 +14,7 @@ import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.audio.MusicController
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import com.unciv.ui.images.ImageGetter
+import com.unciv.utils.isRunFromJar
 import kotlin.reflect.full.declaredMemberProperties
 
 /**
@@ -140,8 +141,7 @@ interface IMediaFinder {
         private fun supportedAudioExtensions() = setOf(".mp3", ".ogg", ".wav")   // Per Gdx docs, no aac/m4a
         private fun supportedImageExtensions() = setOf(".png", ".jpg", ".jpeg")
         private fun isRunFromJar(): Boolean =
-            Gdx.app.type == Application.ApplicationType.Desktop &&
-            this::class.java.`package`.specificationVersion != null
+            Gdx.app.type == Application.ApplicationType.Desktop && isRunFromJar(this)
     }
 
     open class Sounds : IMediaFinder {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -14,6 +14,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.SubStat
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.hasPlaceholderParameters
+import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
 
@@ -742,23 +743,20 @@ enum class UniqueParameterType(
 
     companion object {
         @Readonly
-        private fun scanExistingValues(type: UniqueParameterType): Set<String> {
-            return BaseRuleset.entries
+        private fun scanExistingValues(type: UniqueParameterType) =
+            BaseRuleset.entries.asSequence()
                 .mapNotNull { RulesetCache[it.fullName] }
-                .map { scanExistingValues(type, it) }
-                .fold(setOf()) { a, b -> a + b }
-        }
+                .flatMap { scanExistingValues(type, it) }
+                .toSet()
         @Readonly
-        private fun scanExistingValues(type: UniqueParameterType, ruleset: Ruleset): Set<String> {
-            val result = mutableSetOf<String>()
+        private fun scanExistingValues(type: UniqueParameterType, ruleset: Ruleset) = sequence {
             for (unique in ruleset.allUniques()) {
                 val parameterMap = unique.type?.parameterTypeMap ?: continue
                 for ((index, param) in unique.params.withIndex()) {
                     if (type !in parameterMap[index]) continue
-                    result += param
+                    yield(param)
                 }
             }
-            return result
         }
 
         /** Emulate legacy behaviour as exactly as possible */

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -14,7 +14,6 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.SubStat
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.hasPlaceholderParameters
-import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
 

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -36,6 +36,7 @@ import com.unciv.ui.images.AtlasPreview
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.images.Portrait
 import com.unciv.ui.images.PortraitPromotion
+import com.unciv.utils.isRunFromJar
 
 /**
  *  Class mananging ruleset validation.
@@ -676,7 +677,7 @@ open class RulesetValidator protected constructor(
     private fun checkTilesetSanity(lines: RulesetErrorList) {
         // If running from a jar *and* checking a builtin ruleset, skip this check.
         // - We can't list() the jsons, and the unit test before release is sufficient, the tileset config can't have changed since then.
-        if (ruleset.folderLocation == null && this::class.java.`package`?.specificationVersion != null)
+        if (ruleset.folderLocation == null && isRunFromJar(this))
             return
 
         val tilesetConfigFolder = (ruleset.folderLocation ?: Gdx.files.internal("")).child("jsons/TileSets")

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -442,15 +442,8 @@ object TranslationFileWriter {
             }
 
             // Do simpler parameter numbering when typed, as the code below is susceptible to problems with nested brackets - UniqueTypes don't have them (yet)!
-            if (unique.type != null) {
-                for ((index, typeList) in unique.type.parameterTypeMap.withIndex()) {
-                    if (typeList.none { it in translatableUniqueParameterTypes }) continue
-                    // Unknown/Comment parameter contents better be offered to translators too
-                    resultStrings.add("${unique.params[index]} = ")
-                }
-                resultStrings.add("${unique.type.getTranslatable()} = ")
-                return
-            }
+            if (unique.type != null)
+                return submitTypedUnique(unique)
 
             if (unique.deprecatedType != null) {
                 resultStrings.add("${unique.deprecatedType.getTranslatable()} = ")
@@ -465,6 +458,23 @@ object TranslationFileWriter {
                 resultStrings.add("$parameter = ")
             }
             resultStrings.add("${stringToTranslate.fillPlaceholders(*parameterNames.toTypedArray())} = ")
+        }
+
+        fun submitTypedUnique(unique: Unique) {
+            require(unique.type != null)
+            if (unique.type == UniqueType.Comment && unique.params[0] == "[+10]% growth [in all cities]")
+                Unit
+            for ((index, typeList) in unique.type.parameterTypeMap.withIndex()) {
+                if (typeList.none { it in translatableUniqueParameterTypes }) continue
+                // Unknown/Comment parameter contents better be offered to translators too
+                if (unique.type == UniqueType.Comment) {
+                    val subUnique = Unique(unique.params[index])
+                    if (subUnique.type != null)
+                        return submitTypedUnique(subUnique)
+                }
+                resultStrings.add("${unique.params[index]} = ")
+            }
+            resultStrings.add("${unique.type.getTranslatable()} = ")
         }
 
         // Example: PolicyBranch inherits from Policy inherits from RulesetObject.

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -44,6 +44,7 @@ import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.utils.Log
 import com.unciv.utils.debug
+import com.unciv.utils.isRunFromJar
 import java.io.File
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
@@ -71,7 +72,7 @@ object TranslationFileWriter {
             var fastlaneOutput = ""
             // check to make sure we're not running from a jar since these users shouldn't need to
             // regenerate base game translation and fastlane files
-            if (TranslationFileWriter.javaClass.`package`.specificationVersion == null) {
+            if (!isRunFromJar(this)) {
                 val percentages = generateTranslationFiles(translations)
                 writeLanguagePercentages(percentages)
                 fastlaneOutput = "\n" + writeTranslatedFastlaneFiles(translations)

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -70,25 +70,35 @@ object TranslationFileWriter {
     private fun defaultFileFilter(file: File) = file.name.endsWith(".json", true)
 
     //region Update translation files
-    fun writeNewTranslationFiles(): String {
+    fun writeNewTranslationFiles(modSelection: String): String {
+        val allSelected = modSelection == "All mods"
+        val baseSelected = allSelected || BaseRuleset.entries.any { it.fullName == modSelection }
+
         try {
             val translations = Translations()
             translations.readAllLanguagesTranslation()
+            val modSelected = !baseSelected && modSelection in translations.modsWithTranslations
 
             var fastlaneOutput = ""
             // check to make sure we're not running from a jar since these users shouldn't need to
             // regenerate base game translation and fastlane files
-            if (!isRunFromJar(this)) {
+            if (baseSelected && !isRunFromJar(this)) {
                 val percentages = generateTranslationFiles(translations)
                 writeLanguagePercentages(percentages)
                 fastlaneOutput = "\n" + writeTranslatedFastlaneFiles(translations)
             }
 
-            // See #5168 for some background on this
-            for ((modName, modTranslations) in translations.modsWithTranslations) {
+            fun processMod(modName: String, modTranslations: Translations) {
                 val modFolder = UncivGame.Current.files.getModFolder(modName)
                 val modPercentages = generateTranslationFiles(modTranslations, modFolder, translations)
                 writeLanguagePercentages(modPercentages, modFolder)  // unused by the game but maybe helpful for the mod developer
+            }
+            if (allSelected) {
+                // See #5168 for some background on this
+                for ((modName, modTranslations) in translations.modsWithTranslations)
+                    processMod(modName, modTranslations)
+            } else if (modSelected) {
+                processMod(modSelection, translations.modsWithTranslations[modSelection]!!)
             }
 
             return "Translation files are generated successfully.".tr() + fastlaneOutput

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -17,6 +17,7 @@ import com.unciv.models.ruleset.GlobalUniques
 import com.unciv.models.ruleset.PolicyBranch
 import com.unciv.models.ruleset.Quest
 import com.unciv.models.ruleset.RuinReward
+import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.Specialist
 import com.unciv.models.ruleset.Speed
@@ -62,6 +63,11 @@ object TranslationFileWriter {
     private const val fullDescriptionFile = "full_description.txt"
     // Current dir on desktop should be assets, so use two '..' get us to project root
     private const val fastlanePath = "../../fastlane/metadata/android/"
+    private fun BaseRuleset.jsonFolderName() = "jsons/$fullName"
+    private fun BaseRuleset.jsonFolder() = if (UncivGame.isCurrentInitialized())
+            UncivGame.Current.files.getLocalFile(jsonFolderName())
+        else Gdx.app.files.local(jsonFolderName())
+    private fun defaultFileFilter(file: File) = file.name.endsWith(".json", true)
 
     //region Update translation files
     fun writeNewTranslationFiles(): String {
@@ -162,8 +168,7 @@ object TranslationFileWriter {
                 linesToTranslate += "$bindingLabel = "
 
             for (baseRuleset in BaseRuleset.entries) {
-                val generatedStringsFromBaseRuleset =
-                        GenerateStringsFromJSONs(UncivGame.Current.files.getLocalFile("jsons/${baseRuleset.fullName}"))
+                val generatedStringsFromBaseRuleset = GenerateStringsFromJSONs(baseRuleset)
                 for (entry in generatedStringsFromBaseRuleset)
                     fileNameToGeneratedStrings[entry.key + " from " + baseRuleset.fullName] = entry.value
             }
@@ -333,24 +338,40 @@ object TranslationFileWriter {
      *  All work is done right on instantiation.
       */
     private class GenerateStringsFromJSONs(
+        /** Used only to call UniqueParameterType.guessTypeForTranslationWriter */
+        private val ruleset: Ruleset,
         jsonsFolder: FileHandle,
-        fileFilter: (File) -> Boolean = { file -> file.name.endsWith(".json", true) }
+        fileFilter: (File) -> Boolean
     ): LinkedHashMap<String, MutableSet<String>>() {
         // Using LinkedHashMap (instead of HashMap) is important to maintain the order of sections in the translation file
 
-        val ruleset = RulesetCache.getVanillaRuleset()
-        val startMillis = System.currentTimeMillis()
-
-        var uniqueIndexOfNewLine = 0
-        val listOfJSONFiles = jsonsFolder
-            .list(fileFilter)
-            .sortedBy { it.name() }       // generatedStrings maintains order, so let's feed it a predictable one
+        constructor(baseRuleset: BaseRuleset) : this(
+            RulesetCache[baseRuleset.fullName]!!,
+            baseRuleset.jsonFolder(),
+            ::defaultFileFilter
+        )
+        constructor(jsonsFolder: FileHandle, fileFilter: (File) -> Boolean = ::defaultFileFilter) : this(
+            RulesetCache[jsonsFolder.parent().name()]?.takeIf { it.modOptions.isBaseRuleset } ?: RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!,
+            jsonsFolder, fileFilter
+        )
 
         // One set per json file, secondary loop var. Could be nicer to isolate all per-file
         // processing into another class, but then we'd have to pass uniqueIndexOfNewLine around.
         lateinit var resultStrings: MutableSet<String>
 
         init {
+            val startMillis = System.currentTimeMillis()
+
+            var uniqueIndexOfNewLine = 0
+            fun addNewLine() {
+                // This is a small hack to insert multiple /n into the set, which can't contain identical lines
+                resultStrings.add("$specialNewLineCode ${uniqueIndexOfNewLine++}")
+            }
+
+            val listOfJSONFiles = jsonsFolder
+                .list(fileFilter)
+                .sortedBy { it.name() }       // generatedStrings maintains order, so let's feed it a predictable one
+
             for (jsonFile in listOfJSONFiles) {
                 val filename = jsonFile.nameWithoutExtension()
 
@@ -366,12 +387,11 @@ object TranslationFileWriter {
                 if (data is kotlin.Array<*>) {
                     for (element in data) {
                         serializeElement(element!!) // let's serialize the strings recursively
-                        // This is a small hack to insert multiple /n into the set, which can't contain identical lines
-                        resultStrings.add("$specialNewLineCode ${uniqueIndexOfNewLine++}")
+                        addNewLine()
                     }
                 } else {
                     serializeElement(data)
-                    resultStrings.add("$specialNewLineCode ${uniqueIndexOfNewLine++}")
+                    addNewLine()
                 }
             }
             val displayName = if (jsonsFolder.name() != "jsons") jsonsFolder.name()

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -13,14 +13,17 @@ import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.logic.map.HexCoord
+import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.GameSettings.ScreenSize
 import com.unciv.models.metadata.ModCategories
+import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.disable
+import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.extensions.setFontColor
 import com.unciv.ui.components.extensions.toLabel
@@ -31,11 +34,14 @@ import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.TranslatedSelectBox
 import com.unciv.ui.components.widgets.UncivTextField
+import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.popups.Popup
 import com.unciv.utils.Concurrency
 import com.unciv.utils.Display
+import com.unciv.utils.isRunFromJar
 import com.unciv.utils.isUUID
 import com.unciv.utils.launchOnGLThread
 import com.unciv.utils.withoutItem
@@ -217,21 +223,35 @@ internal class AdvancedTab(
 
         val generateTranslationsButton = "Generate translation files".toTextButton()
 
-        generateTranslationsButton.onActivation {
-            generateTranslationsButton.setText(Constants.working.tr())
-            Concurrency.run("WriteTranslations") {
-                val result = TranslationFileWriter.writeNewTranslationFiles()
-                launchOnGLThread {
-                    // notify about completion
-                    generateTranslationsButton.setText(result.tr())
-                    generateTranslationsButton.disable()
-                }
-            }
-        }
+        // Can't use UncivGame.Current.translations.modsWithTranslations here, it's selective to the chosen language
+        val entries = listOf("All mods") +
+            (if (isRunFromJar(this)) emptyList() else listOf(BaseRuleset.Civ_V_GnK.fullName)) +
+            RulesetCache.keys.filter { mod -> BaseRuleset.entries.none { it.fullName == mod } }.sorted()
+        val modSelect = TranslatedSelectBox(entries, "All mods")
 
         generateTranslationsButton.keyShortcuts.add(Input.Keys.F12)
         generateTranslationsButton.addTooltip("F12", 18f)
-        add(generateTranslationsButton).colspan(2).row()
+
+        add(generateTranslationsButton)
+        add(modSelect).maxWidth(stage.width / 2).row()
+        val resultCell = add().colspan(2)
+        row()
+
+        generateTranslationsButton.onActivation {
+            resultCell.setActor(null)
+            generateTranslationsButton.setText(Constants.working.tr())
+            generateTranslationsButton.disable()
+            Concurrency.run("WriteTranslations") {
+                val result = TranslationFileWriter.writeNewTranslationFiles(modSelect.selected.value)
+                launchOnGLThread {
+                    // notify about completion
+                    val resultLabel = WrappableLabel(result, stage.width / 2, Color.GOLD).apply { wrap = true }
+                    resultCell.minHeight(resultLabel.height + 10f).setActor(resultLabel)
+                    generateTranslationsButton.setText("Generate translation files".tr())
+                    generateTranslationsButton.enable()
+                }
+            }
+        }
     }
 
     private fun addUpdateModCategories() {

--- a/core/src/com/unciv/utils/StringExtensions.kt
+++ b/core/src/com/unciv/utils/StringExtensions.kt
@@ -19,3 +19,7 @@ fun String.toUUIDOrNull(): UUID? = try {
  */
 @Pure
 fun String.isUUID(): Boolean = toUUIDOrNull() != null
+
+/** Determines if we're running from a jar, given an instance of any Unciv-specific class.
+ *  (Not a String extension, but as long as we don't have a 'generic' extension file...) */
+fun isRunFromJar(obj: Any): Boolean = obj::class.java.`package`.specificationVersion != null

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -22,6 +22,7 @@ import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Display
 import com.unciv.utils.Log
+import com.unciv.utils.isRunFromJar
 import org.lwjgl.system.Configuration
 import java.awt.GraphicsEnvironment
 import java.awt.Image
@@ -106,7 +107,7 @@ internal object DesktopLauncher {
 
         val dataDirectory = customDataDir ?: "."
 
-        val isRunFromJAR = DesktopLauncher.javaClass.`package`.specificationVersion != null
+        val isRunFromJAR = isRunFromJar(this)
         ImagePacker.packImages(isRunFromJAR, dataDirectory)
 
         val config = Lwjgl3ApplicationConfiguration()


### PR DESCRIPTION
Fixes #14925
Contains a lot of unrelated stuff, sorry. The crux is in the last commit (https://github.com/yairm210/Unciv/commit/dada5dc6248d59d5c10b6e759c353222864a08c3). Do tell me if you want it split.

Confirmed that it has no effect on Alpha Frontier, and base ruleset stuff only gets moved.

#### Questions:
- How is TFW run again in a release cycle? It might be advantageous to change the select default to base rulesets. (The G&K entry of the select _does_ process both)
- Is that lazy simplification to use the G&K name to represent processing both Unciv base rulesets OK?
- Would you want a "for" label queezed between the button and select?

<details><summary>UI change: Advanced Tab</summary>

<img width="845" height="499" alt="image" src="https://github.com/user-attachments/assets/943295eb-78b9-455b-abb5-333643724176" />

</details>