### PR TITLE
No religious city-states in late era starts (disabling religion)

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -328,11 +328,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     }
 
     @Readonly
-    fun isReligionEnabled(): Boolean {
-        if (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)) return false
-        if (ruleset.modOptions.hasUnique(UniqueType.DisableReligion)) return false
-        return true
-    }
+    fun isReligionEnabled() = ruleset.isReligionEnabled(gameParameters.startingEra)
 
     @Readonly fun isEspionageEnabled(): Boolean = gameParameters.espionageEnabled
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -13,9 +13,11 @@ import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.tile.ResourceSupplyList
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
+import com.unciv.models.stats.Stats
 import com.unciv.ui.screens.victoryscreen.RankingType
 import com.unciv.utils.randomWeighted
 import yairm210.purity.annotations.Readonly
@@ -29,11 +31,13 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     /** Attempts to initialize the city state, returning true if successful. */
     fun initCityState(ruleset: Ruleset, startingEra: String, usedMajorCivs: Sequence<Nation>): Boolean {
+        val cityStateType = ruleset.cityStateTypes[civInfo.nation.cityStateType] ?: return false
+        if (!civInfo.gameInfo.isReligionEnabled() && cityStateType.isReligious()) return false 
+
         val rng = civInfo.state.stateBasedRandom("CityStateFunctions.initCityState")
         val allMercantileResources = ruleset.tileResources.values.filter { it.hasUnique(UniqueType.CityStateOnlyResource) }.map { it.name }
         val uniqueTypes = HashSet<UniqueType>()    // We look through these to determine what kinds of city states we have
 
-        val cityStateType = ruleset.cityStateTypes[civInfo.nation.cityStateType]!!
         uniqueTypes.addAll(cityStateType.friendBonusUniqueMap.getAllUniques().mapNotNull { it.type })
         uniqueTypes.addAll(cityStateType.allyBonusUniqueMap.getAllUniques().mapNotNull { it.type })
 
@@ -67,9 +71,14 @@ class CityStateFunctions(val civInfo: Civilization) {
                 civInfo.cityStateUniqueUnit = possibleUnits.random(rng).name
         }
 
-        // TODO: Return false if attempting to put a religious city-state in a game without religion
-
         return true
+    }
+
+    private fun CityStateType.isReligious(): Boolean {
+        fun UniqueMap.isReligious() =
+            getMatchingUniques(UniqueType.Stats, GameContext.IgnoreConditionals)
+                .any { Stats.parse(it.params[0]).faith > 0f }
+        return friendBonusUniqueMap.isReligious() || allyBonusUniqueMap.isReligious()
     }
 
     fun holdElections() {

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -32,7 +32,7 @@ class CityStateFunctions(val civInfo: Civilization) {
     /** Attempts to initialize the city state, returning true if successful. */
     fun initCityState(ruleset: Ruleset, startingEra: String, usedMajorCivs: Sequence<Nation>): Boolean {
         val cityStateType = ruleset.cityStateTypes[civInfo.nation.cityStateType] ?: return false
-        if (!civInfo.gameInfo.isReligionEnabled() && cityStateType.isReligious()) return false 
+        if (!ruleset.isReligionEnabled(startingEra) && cityStateType.isReligious()) return false 
 
         val rng = civInfo.state.stateBasedRandom("CityStateFunctions.initCityState")
         val allMercantileResources = ruleset.tileResources.values.filter { it.hasUnique(UniqueType.CityStateOnlyResource) }.map { it.name }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -586,6 +586,13 @@ class Ruleset {
         globalUniques.uniques.addAll(uniques)
     }
 
+    @Readonly
+    fun isReligionEnabled(startingEra: String): Boolean {
+        if (eras[startingEra]?.hasUnique(UniqueType.DisablesReligion) == true) return false
+        if (modOptions.hasUnique(UniqueType.DisableReligion)) return false
+        return true
+    }
+
     /** Used for displaying a RuleSet's name */
     override fun toString() = when {
         name.isNotEmpty() -> name

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -107,7 +107,8 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     @Readonly
     override fun isUnavailableBySettings(gameInfo: GameInfo) =
         super<INonPerpetualConstruction>.isUnavailableBySettings(gameInfo) ||
-        (!gameInfo.gameParameters.nuclearWeaponsEnabled && isNuclearWeapon())
+        (!gameInfo.gameParameters.nuclearWeaponsEnabled && isNuclearWeapon()) ||
+        (!gameInfo.isReligionEnabled() && hasUnique(UniqueType.ReligiousUnit))
 
     @Readonly
     fun getUpgradeUnits(gameContext: GameContext = GameContext.EmptyState): Sequence<String> {


### PR DESCRIPTION
The `BaseUnit.isUnavailableBySettings` line is honestly unrelated, but seems like an oversight. You would usually not get to the point where the question pops up whether a Missionary is valid because of zero Faith income, but who knows - mad modders? But then `Building.isUnavailableBySettings` wouldn't block Shrines in late era starts either, but should it?

So - I should either remove that change or implement symmetry in Building too?