### PR TITLE
chore: Fix TileMap.forEachTileInDistance + general cleanup of that file

### DIFF
--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -23,7 +23,6 @@ import yairm210.purity.annotations.Readonly
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
 import kotlin.math.max
-import kotlin.random.Random
 
 /** An Unciv map with all properties as produced by the [map editor][com.unciv.ui.screens.mapeditorscreen.MapEditorScreen]
  * or [MapGenerator][com.unciv.logic.map.mapgenerator.MapGenerator]; or as part of a running [game][GameInfo].
@@ -86,7 +85,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             val EMPTY = TerrainListData(UniqueMap.EMPTY, emptySet())
         }
     }
-    
+
     @Transient
     var tileUniqueMapCache = ConcurrentHashMap<List<String>, TerrainListData>()
 
@@ -130,7 +129,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
      * creates a hexagonal map of given radius (filled with grassland)
      *
      * To help you visualize how Unciv hexagonal coordinate system works, here's a small example:
-     * 
+     *
      * ```
      *          _____         _____         _____
      *         /     \       /     \       /     \
@@ -235,7 +234,8 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     @Deprecated(message = "forEachTileInDistance is faster. If not viable, then this can still be used",
         replaceWith = ReplaceWith("forEachTileInDistance"))
     fun getTilesInDistance(origin: HexCoord, distance: Int): Sequence<Tile> =
-            getTilesInDistanceRange(origin, 0..distance)
+        @Suppress("DEPRECATION")
+        getTilesInDistanceRange(origin, 0..distance)
 
     /** @return All tiles in a hexagonal ring around [origin] with the distances in [range]. Excludes the [origin] tile unless [range] starts at 0.
      *  Respects map edges and world wrap. */
@@ -243,7 +243,8 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     @Deprecated(message = "forEachTileInDistanceRange is faster. If not viable, then this can still be used",
         replaceWith = ReplaceWith("forEachTileInDistanceRange"))
     fun getTilesInDistanceRange(origin: HexCoord, range: IntRange): Sequence<Tile> =
-            range.asSequence().flatMap { getTilesAtDistance(origin, it) }
+        @Suppress("DEPRECATION")
+        range.asSequence().flatMap { getTilesAtDistance(origin, it) }
 
     /** @return All tiles in a hexagonal ring 1 tile wide around [origin] with the [distance]. Contains the [origin] if and only if [distance] is <= 0.
      *  Respects map edges and world wrap. */
@@ -262,7 +263,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
                     var currentX = centerX - distance
                     var currentY = centerY - distance
 
-                    for (i in 0 until distance) { // From 6 to 8
+                    repeat (distance) { // From 6 to 8
                         yield(getIfTileExistsOrNull(currentX, currentY))
                         // We want to get the tile on the other side of the clock,
                         // so if we're at current = origin-delta we want to get to origin+delta.
@@ -270,13 +271,13 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
                         yield(getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY))
                         currentX += 1 // we're going upwards to the left, towards 8 o'clock
                     }
-                    for (i in 0 until distance) { // 8 to 10
+                    repeat (distance) { // 8 to 10
                         yield(getIfTileExistsOrNull(currentX, currentY))
                         yield(getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY))
                         currentX += 1
                         currentY += 1 // we're going up the left side of the hexagon so we're going "up" - +1,+1
                     }
-                    for (i in 0 until distance) { // 10 to 12
+                    repeat (distance) { // 10 to 12
                         yield(getIfTileExistsOrNull(currentX, currentY))
                         yield(getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY))
                         currentY += 1 // we're going up the top left side of the hexagon so we're heading "up and to the right"
@@ -317,7 +318,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             if (filter(tile)) op(tile)
         } else if (distance == 1) {
             for (tile in get(origin).neighbors) {
-                if (filter(tile)) 
+                if (filter(tile))
                     op(tile)
             }
         } else {
@@ -328,8 +329,8 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             var currentX = centerX - distance
             var currentY = centerY - distance
 
-            var tile: Tile? = null
-            for (i in 0 until distance) { // From 6 to 8
+            var tile: Tile?
+            repeat (distance) { // From 6 to 8
                 tile = getIfTileExistsOrNull(currentX, currentY)
                 if (tile != null && filter(tile)) op(tile)
                 // We want to get the tile on the other side of the clock,
@@ -339,7 +340,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
                 if (tile != null && filter(tile)) op(tile)
                 currentX += 1 // we're going upwards to the left, towards 8 o'clock
             }
-            for (i in 0 until distance) { // 8 to 10
+            repeat (distance) { // 8 to 10
                 tile = getIfTileExistsOrNull(currentX, currentY)
                 if (tile != null && filter(tile)) op(tile)
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
@@ -347,7 +348,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
                 currentX += 1
                 currentY += 1 // we're going up the left side of the hexagon so we're going "up" - +1,+1
             }
-            for (i in 0 until distance) { // 10 to 12
+            repeat (distance) { // 10 to 12
                 tile = getIfTileExistsOrNull(currentX, currentY)
                 if (tile != null && filter(tile)) op(tile)
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
@@ -465,12 +466,12 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
 
         val vectorUnwrappedLeft = HexCoord.of(position.x + radius, position.y - radius)
         val vectorUnwrappedRight = HexCoord.of(position.x - radius, position.y + radius)
-        
+
         fun squareSum(hexCoord: HexCoord): Int {
             val x = hexCoord.x
             val y = hexCoord.y
             return x * x + y * y
-        }  
+        }
 
         return if (squareSum(vectorUnwrappedRight) < squareSum(vectorUnwrappedLeft))
             vectorUnwrappedRight
@@ -562,7 +563,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         val players = gameInfo.gameParameters.players.size
         return bigIslands >= players
     }
-    
+
     fun usingArchipelagoRegions(): Boolean {
         val totalLand = continentSizes.values.sum().toFloat()
         val largestContinent = continentSizes.values.maxOf { it }.toFloat()
@@ -582,10 +583,10 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         check(tileList.isNotEmpty()) { "No tiles were found in the save?!" }
 
         if (tileMatrix.isEmpty()) {
-            val topY = tileList.asSequence().map { it.position.y }.max()
-            bottomY = tileList.asSequence().map { it.position.y }.min()
-            val rightX = tileList.asSequence().map { it.position.x }.max()
-            leftX = tileList.asSequence().map { it.position.x }.min()
+            val topY = tileList.maxOf { it.position.y }
+            bottomY = tileList.minOf { it.position.y }
+            val rightX = tileList.maxOf { it.position.x }
+            leftX = tileList.minOf { it.position.x }
 
             // Initialize arrays with enough capacity to avoid re-allocations (+Arrays.copyOf).
             // We have just calculated the dimensions above, so we know the final size.
@@ -618,9 +619,9 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             tileInfo.setTerrainTransients()
             tileInfo.setUnitTransients(setUnitCivTransients)
         }
-        
-        val minColumn = tileList.asSequence().map { HexMath.getColumn(it.position) }.min()
-        val maxColumn = tileList.asSequence().map { HexMath.getColumn(it.position) }.max()
+
+        val minColumn = tileList.minOf { HexMath.getColumn(it.position) }
+        val maxColumn = tileList.maxOf { HexMath.getColumn(it.position) }
         width = maxColumn - minColumn + 1
     }
 
@@ -741,6 +742,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
      *
      * @param player units of this player will be removed
      */
+    @Suppress("unused")
     fun stripPlayer(player: Player) {
         tileList.forEach {
             for (unit in it.getUnits()) if (unit.owner == player.chosenCiv) unit.removeFromTile()
@@ -757,6 +759,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
      * @param player player whose all units will be changed
      * @param newNation new nation to be set up
      */
+    @Suppress("unused")
     fun switchPlayersNation(player: Player, newNation: Nation) {
         val newCiv = Civilization(newNation)
         tileList.forEach {

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -592,8 +592,9 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             // We have just calculated the dimensions above, so we know the final size.
             tileMatrix.ensureCapacity(rightX - leftX + 1)
             repeat (rightX - leftX + 1) {
-                val row = MutableList<Tile?>(topY - bottomY + 1) { null }
-                tileMatrix.add(row as ArrayList<Tile?>)
+                val row = ArrayList<Tile?>(topY - bottomY + 1)
+                repeat(topY - bottomY + 1) { row.add(null) }
+                tileMatrix.add(row)
             }
         } else {
             // Yes the map generator calls this repeatedly, and we don't want to end up with an oversized tileMatrix

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -497,12 +497,12 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             // that is to say, the "viewableTiles.contains(it) check will return false for neighbors from the same distance
             val tilesToAddInDistanceI = ArrayList<ViewableTile>()
 
-            for (cTile in getTilesAtDistance(position, i)) { // for each tile in that layer,
+            forEachTileAtDistance(position, i) { cTile -> // for each tile in that layer,
                 val cTileHeight = cTile.tileHeight
 
                 // For the sightdistance+1 layer - that's "one out of sight" - it's only visible if it's higher than the current tile
-                if (i == sightDistance+1 && (cTileHeight <= aUnitHeight || forAttack))
-                    continue
+                if (i == sightDistance + 1 && (cTileHeight <= aUnitHeight || forAttack))
+                    return@forEachTileAtDistance
 
                 /*
             Okay so, if we're looking at a tile from height a to one with height c with a MAXIMUM HEIGHT of b in the middle,
@@ -719,10 +719,9 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         for (promotion in unit.baseUnit.promotions)
             unit.promotions.addPromotion(promotion, true)
 
-        for (unique in civInfo.getMatchingUniques(UniqueType.UnitsGainPromotion)) {
-            if (unit.matchesFilter(unique.params[0])) {
+        civInfo.forEachMatchingUnique(UniqueType.UnitsGainPromotion) { unique ->
+            if (unit.matchesFilter(unique.params[0]))
                 unit.promotions.addPromotion(unique.params[1], true)
-            }
         }
 
         // And update civ stats, since the new unit changes both unit upkeep and resource consumption

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -673,8 +673,8 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     ): MapUnit? {
         val unit = baseUnit.newMapUnit(civInfo, unitId)
 
-        fun getPassableNeighbours(tile: Tile): Set<Tile> =
-                tile.neighbors.filter { unit.movement.canPassThrough(it) }.toSet()
+        fun getPassableNeighbours(tile: Tile) =
+                tile.neighbors.filter { unit.movement.canPassThrough(it) }
 
         // both the civ name and actual civ need to be in here in order to calculate the canMoveTo...Darn
         unit.assignOwner(civInfo, false)
@@ -690,17 +690,27 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
 
         // if it's not suitable, try to find another tile nearby
         if (unitToPlaceTile == null) {
+            class TileCandidates(
+                val land: MutableList<Tile> = mutableListOf(),
+                val water: MutableList<Tile> = mutableListOf()
+            ) {
+                constructor(isRestrictedLandUnit: Boolean, tiles: Sequence<Tile>) : this() {
+                    for (tile in tiles)
+                        if (!isRestrictedLandUnit || tile.isLand) land += tile
+                        else water += tile
+                }
+                val allTiles get() = land.asSequence() + water
+            }
+
+            val isRestrictedLandUnit = unit.baseUnit.isLandUnit && !unit.cache.canMoveOnWater
             var tryCount = 0
-            var potentialCandidates = getPassableNeighbours(currentTile)
+            var potentialCandidates = TileCandidates(isRestrictedLandUnit, getPassableNeighbours(currentTile))
             while (unitToPlaceTile == null && tryCount++ < 10) {
-                unitToPlaceTile = potentialCandidates
-                        .sortedByDescending { if (unit.baseUnit.isLandUnit && !unit.cache.canMoveOnWater) it.isLand else true } // Land units should prefer to go into land tiles
-                        .firstOrNull { unit.movement.canMoveTo(it) }
+                unitToPlaceTile = potentialCandidates.land.firstOrNull { unit.movement.canMoveTo(it) } // Land units should prefer to go into land tiles
+                    ?: potentialCandidates.water.firstOrNull { unit.movement.canMoveTo(it) }
                 if (unitToPlaceTile != null) continue
                 // if it's not found yet, let's check their neighbours
-                val newPotentialCandidates = mutableSetOf<Tile>()
-                potentialCandidates.forEach { newPotentialCandidates.addAll(getPassableNeighbours(it)) }
-                potentialCandidates = newPotentialCandidates
+                potentialCandidates = TileCandidates(isRestrictedLandUnit, potentialCandidates.allTiles.flatMap { getPassableNeighbours(it) })
             }
         }
 

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -291,7 +291,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         = forEachTileInDistance(origin, distance, {true}, op)
     @Readonly
     fun forEachTileInDistance(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) {
-        for (i in 0 until distance)
+        for (i in 0..distance)
             forEachTileAtDistance(origin, i, filter, op)
     }
 

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -591,10 +591,9 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             // Initialize arrays with enough capacity to avoid re-allocations (+Arrays.copyOf).
             // We have just calculated the dimensions above, so we know the final size.
             tileMatrix.ensureCapacity(rightX - leftX + 1)
-            for (x in leftX..rightX) {
-                val row = ArrayList<Tile?>(topY - bottomY + 1)
-                for (y in bottomY..topY) row.add(null)
-                tileMatrix.add(row)
+            repeat (rightX - leftX + 1) {
+                val row = MutableList<Tile?>(topY - bottomY + 1) { null }
+                tileMatrix.add(row as ArrayList<Tile?>)
             }
         } else {
             // Yes the map generator calls this repeatedly, and we don't want to end up with an oversized tileMatrix


### PR DESCRIPTION
Closes #14921
See commits individually.
Marked chore because as of now, the buggy function is not used anywhere, but I would like to in the follow-up to #14923.

Last commit is the most risky, but should speak for itself. Thing is, the performance benefits would be significant - _if_ the unit to place would very often not fit into the destination tile or its neighbors, which is unlikely. I still like the readability. Two interesting points: The helper class is local, thus automatically `inner`, so it could inherit the isRestrictedLandUnit via closure, but I chose not to. Also, one entire level of indentation and a few lines could be saved by starting with a single-tile TileCandidates containing only the position passed to placeUnitNearTile, then iterating from there - but since that's no perf improv I skipped that.