### PR TITLE
Fix Android on screen keyboard show/hide

### DIFF
--- a/core/src/com/unciv/ui/components/widgets/TextFieldWithFixes.kt
+++ b/core/src/com/unciv/ui/components/widgets/TextFieldWithFixes.kt
@@ -1,9 +1,13 @@
 package com.unciv.ui.components.widgets
 
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.Input.OnscreenKeyboardType
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.graphics.g2d.BitmapFont
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
+import com.badlogic.gdx.scenes.scene2d.utils.FocusListener
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.keyShortcuts
 
@@ -11,6 +15,8 @@ import com.unciv.ui.components.input.keyShortcuts
  * Creates a text field with two deviations from the default Gdx [TextField]:
  * - Turns off Gdx color markup support while drawing, so [] in the text display properly
  * - If this TextField handles the Tab key (see [keyShortcuts]), its [focus navigation feature][TextField.next] is disabled (otherwise it would search for another TextField in the same parent to give focus to, and remove the on-screen keyboard if it finds none).
+ * - Tells Android's on screen keyboard when this TextField is in password mode
+ * - Shows/hides Android's on screen keyboard automatically whith keyboard focus gain/loss
  * - constructors same as standard TextField, plus a cloning constructor.
  */
 open class TextFieldWithFixes private constructor(text: String, style: TextFieldStyle) : TextField(text, style) {
@@ -23,13 +29,26 @@ open class TextFieldWithFixes private constructor(text: String, style: TextField
         selectionStart = textField.selectionStart
         alignment = textField.alignment
         isPasswordMode = textField.isPasswordMode
-        onscreenKeyboard = textField.onscreenKeyboard
+    }
+
+    init {
+        addListener(object : FocusListener() {
+            override fun keyboardFocusChanged(event: FocusEvent, actor: Actor?, focused: Boolean) {
+                if (!focused && event.relatedActor is TextFieldWithFixes) return // Will be reactivated anyway
+                onscreenKeyboard.show(focused)
+            }
+        })
     }
 
     // Without this, the DeveloperConsole can't catch the Tab key for Autocomplete reliably
     override fun next(up: Boolean) {
         if (KeyCharAndCode.TAB in keyShortcuts) return
         super.next(up)
+    }
+
+    override fun setDisabled(disabled: Boolean) {
+        onscreenKeyboard.show(!disabled)
+        super.setDisabled(disabled)
     }
 
     // Note - this way to force TextField to display `[]` characters normally is an incomplete hack.
@@ -43,6 +62,7 @@ open class TextFieldWithFixes private constructor(text: String, style: TextField
         super.layout()
         style.font.data.markupEnabled = oldEnable
     }
+
     override fun drawText(batch: Batch, font: BitmapFont, x: Float, y: Float) {
         val oldEnable = font.data.markupEnabled
         font.data.markupEnabled = false

--- a/core/src/com/unciv/ui/components/widgets/TextFieldWithFixes.kt
+++ b/core/src/com/unciv/ui/components/widgets/TextFieldWithFixes.kt
@@ -17,6 +17,7 @@ import com.unciv.ui.components.input.keyShortcuts
  * - If this TextField handles the Tab key (see [keyShortcuts]), its [focus navigation feature][TextField.next] is disabled (otherwise it would search for another TextField in the same parent to give focus to, and remove the on-screen keyboard if it finds none).
  * - Tells Android's on screen keyboard when this TextField is in password mode
  * - Shows/hides Android's on screen keyboard automatically whith keyboard focus gain/loss
+ * - Fixes Gdx's password char from a cp-1252 Bullet to Unicode 
  * - constructors same as standard TextField, plus a cloning constructor.
  */
 open class TextFieldWithFixes private constructor(text: String, style: TextFieldStyle) : TextField(text, style) {
@@ -32,12 +33,16 @@ open class TextFieldWithFixes private constructor(text: String, style: TextField
     }
 
     init {
+        onscreenKeyboard = OnscreenKeyboard { visible ->
+            Gdx.input.setOnscreenKeyboardVisible(visible, if (isPasswordMode) OnscreenKeyboardType.Password else OnscreenKeyboardType.Default)
+        }
         addListener(object : FocusListener() {
             override fun keyboardFocusChanged(event: FocusEvent, actor: Actor?, focused: Boolean) {
                 if (!focused && event.relatedActor is TextFieldWithFixes) return // Will be reactivated anyway
                 onscreenKeyboard.show(focused)
             }
         })
+        setPasswordCharacter('\u2022') // Gdx bug: They use 149, which is a bullet in cp-1252, but not in a sensible encoding
     }
 
     // Without this, the DeveloperConsole can't catch the Tab key for Autocomplete reliably

--- a/core/src/com/unciv/ui/components/widgets/TextFieldWithFixes.kt
+++ b/core/src/com/unciv/ui/components/widgets/TextFieldWithFixes.kt
@@ -17,7 +17,7 @@ import com.unciv.ui.components.input.keyShortcuts
  * - If this TextField handles the Tab key (see [keyShortcuts]), its [focus navigation feature][TextField.next] is disabled (otherwise it would search for another TextField in the same parent to give focus to, and remove the on-screen keyboard if it finds none).
  * - Tells Android's on screen keyboard when this TextField is in password mode
  * - Shows/hides Android's on screen keyboard automatically whith keyboard focus gain/loss
- * - Fixes Gdx's password char from a cp-1252 Bullet to Unicode 
+ * - Fixes Gdx's password char from a cp-1252 Bullet to Unicode
  * - constructors same as standard TextField, plus a cloning constructor.
  */
 open class TextFieldWithFixes private constructor(text: String, style: TextFieldStyle) : TextField(text, style) {

--- a/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
+++ b/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
@@ -3,7 +3,6 @@ package com.unciv.ui.components.widgets
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
@@ -46,7 +45,6 @@ open class UncivTextField(
     private val onFocusChange: (TextField.(Boolean) -> Unit)? = null
 ) : TextFieldWithFixes(preEnteredText, BaseScreen.skin) {
     private val isAndroid = false // disabled for now since it's not actually working // Gdx.app.type == Application.ApplicationType.Android
-    private val hideKeyboard = { Gdx.input.setOnscreenKeyboardVisible(false) }
 
     init {
         messageText = hint.tr()
@@ -60,10 +58,6 @@ open class UncivTextField(
         override fun keyboardFocusChanged(event: FocusEvent, actor: Actor, focused: Boolean) {
             if (focused) {
                 scrollAscendantToTextField()
-                if (isAndroid) {
-                    addPopupCloseListener()
-                    Gdx.input.setOnscreenKeyboardVisible(true)
-                }
             }
             onFocusChange?.invoke(this@UncivTextField, focused)
         }
@@ -91,17 +85,6 @@ open class UncivTextField(
                     }
                 }
             }
-        }
-        override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
-            addPopupCloseListener()
-            return false
-        }
-    }
-
-    private fun addPopupCloseListener() {
-        val popup = getAscendant<Popup>()
-        if (popup != null && !popup.closeListeners.contains(hideKeyboard)) {
-            popup.closeListeners.add(hideKeyboard)
         }
     }
 

--- a/core/src/com/unciv/ui/popups/AuthPopup.kt
+++ b/core/src/com/unciv/ui/popups/AuthPopup.kt
@@ -13,7 +13,7 @@ class AuthPopup(stage: Stage, private val authSuccessful: ((Boolean) -> Unit)? =
 
     constructor(screen: BaseScreen, authSuccessful: ((Boolean) -> Unit)? = null) : this(screen.stage, authSuccessful)
 
-    private val passwordField: UncivTextField = UncivTextField("Password")
+    private val passwordField: UncivTextField = UncivTextField("Password").apply { isPasswordMode = true }
     private val button: TextButton = "Authenticate".toTextButton()
     private val negativeButtonStyle: TextButton.TextButtonStyle =
         BaseScreen.skin.get("negative", TextButton.TextButtonStyle::class.java)

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -163,8 +163,9 @@ internal class MultiplayerTab(
 
         if (mpServer.getFeatureSet().authVersion > 0) {
             val passwordTextField = UncivTextField(
-                mpSettings.getCurrentServerPassword() ?: "Password"
+                "Password", mpSettings.getCurrentServerPassword().orEmpty()
             )
+            passwordTextField.isPasswordMode = true
             val setPasswordButton = "Set password".toTextButton()
 
             serverIpTable.add("Set password".toLabel()).padTop(16f).colspan(2).row()


### PR DESCRIPTION
Currently, OSK in Android isn't good. One often needs to tap a field to get it, and swipe up the back button and use it to get rid of it. Especially obvious with the dev console. With this, it feels just right - except of course one notices the disabled code when the activated OSK covers up the text field that triggered it. But I didn't want to touch that wasp nest.

Also contains a workaround for https://github.com/libgdx/libgdx/issues/7809 (has screenshots), and then **actually uses password-mode** TextFields (including telling the onscreen kdb it's pwd mode) **for multiplayer passwords**.

Two curios of note:
* The `TextFieldWithFixes` cloning another `TextFieldWithFixes` copied `onscreenKeyboard` like if it were an actual property, but in fact it's (before this PR) always the same `DefaultOnscreenKeyboard` static implementation of the OnscreenKeyboard helper interface. With this, it's no longer static but needs to look into its parent's isPassword property, so copying it over on clone is still bogus.
* All the removed dead code in `UncivTextField`... Yup, that's right. The previous ways to show/hide the OSK didn't match each other, and were _replaced_ by a focus listener on the superclass ([^1]). That cascaded down to all those removed lines.
* OK maybe three - this is still Gdx 1.14.0, I haven't checked what 1.14.1 can do yet. I'm pretty sure one can do an OSK that e.g. doesn't turn off swipe with it. Allowing 'roid's standard autocomplete was explicitly mentioned...

[^1]: Merging the two is still off the table because I didn't want to dig deep enough to see whether that "I can't scroll that thing into view so I'll pop up another TextField Popup on top instead" is really dead or can still be triggered.