### PR TITLE
Approve values of 0 for certain mod constants in validator

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -192,7 +192,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         return toReturn
     }
 
-    @Readonly fun canBombard() = !attackedThisTurn && !isInResistance()
+    @Readonly fun canBombard() = getBombardRange() > 0 && !attackedThisTurn && !isInResistance()
     @Readonly fun getCenterTile(): Tile = centerTile
     @Readonly fun getCenterTileOrNull(): Tile? = if (::centerTile.isInitialized) centerTile else null
     @Readonly fun getTiles(): Sequence<Tile> = tiles.asSequence().map { tileMap[it] }

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -37,6 +37,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.images.Portrait
 import com.unciv.ui.images.PortraitPromotion
 import com.unciv.utils.isRunFromJar
+import kotlin.reflect.KProperty0
 
 /**
  *  Class mananging ruleset validation.
@@ -278,22 +279,29 @@ open class RulesetValidator protected constructor(
         // Using reportRulesetSpecificErrors=true as ModOptions never should use Uniques depending on objects from a base ruleset anyway.
         uniqueValidator.checkUniques(ruleset.modOptions, lines, reportRulesetSpecificErrors = true, tryFixUnknownUniques)
 
-        fun modConstantError(constantName: String, criteria: String): String {
-            return "ModConstant '$constantName' does not meet criteria '$criteria'."
+        // TODO: Create overload method for floating point constants. Settle on using either floats or doubles in ModConstants.kt
+        /**
+         * @param propertyName If the [property] has an accessor (getter), then you should manually enter the name of the constant here.
+         */
+        fun checkConstant(property: KProperty0<Int>, range: IntRange, propertyName: String? = null) {
+            if (property.get() in range) return
+            fun IntRange.describe() = when {
+                this.first == Int.MIN_VALUE -> "Maximum $last"
+                this.last == Int.MAX_VALUE -> "Minimum $first"
+                else -> "Minimum $first, Maximum $last"
+            }
+            lines.add("ModConstant '${propertyName ?: property.name}}' does not meet criteria '${range.describe()}'.")
         }
         
         //TODO: More thorough checks. Here I picked just those where bad values might endanger stability.
         val constants = ruleset.modOptions.constants
-        if (constants.cityExpandRange !in 1..100)
-            lines.add(modConstantError("cityExpandRange", "Minimum 1, maximum 100"))
-        if (constants.cityWorkRange !in 1..100)
-            lines.add(modConstantError("cityWorkRange", "Minimum 1, maximum 100"))
-        if (constants.minimalCityDistance < 0) // 0 is ok because it is the number of tiles between cities
-            lines.add(modConstantError("minimalCityDistance", "Minimum 0"))
-        if (constants.minimalCityDistanceOnDifferentContinents < 0)
-            lines.add(modConstantError("minimalCityDistanceOnDifferentContinents", "Minimum 0"))
-        if (constants.baseCityBombardRange < 0) // 0 essentially disables bombardment
-            lines.add(modConstantError("baseCityBombardRange", "Minimum 0"))
+        checkConstant(constants::cityExpandRange, 1..100)
+        checkConstant(constants::cityWorkRange, 1..100)
+        // Crashed with 10 as of writing
+        checkConstant(constants::minimalCityDistance, 0..9)
+        checkConstant(constants::minimalCityDistanceOnDifferentContinents, 0..9)
+        // Game hangs with very high values
+        checkConstant(constants::baseCityBombardRange, 0..1000)
 
         if (ruleset.name.isBlank()) return // The rest of these tests don't make sense for combined rulesets
 

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -278,18 +278,22 @@ open class RulesetValidator protected constructor(
         // Using reportRulesetSpecificErrors=true as ModOptions never should use Uniques depending on objects from a base ruleset anyway.
         uniqueValidator.checkUniques(ruleset.modOptions, lines, reportRulesetSpecificErrors = true, tryFixUnknownUniques)
 
+        fun modConstantError(constantName: String, criteria: String): String {
+            return "ModConstant '$constantName' does not meet criteria '$criteria'."
+        }
+        
         //TODO: More thorough checks. Here I picked just those where bad values might endanger stability.
         val constants = ruleset.modOptions.constants
         if (constants.cityExpandRange !in 1..100)
-            lines.add("Invalid ModConstant 'cityExpandRange'.", sourceObject = null)
+            lines.add(modConstantError("cityExpandRange", "Minimum 1, maximum 100"))
         if (constants.cityWorkRange !in 1..100)
-            lines.add("Invalid ModConstant 'cityWorkRange'.", sourceObject = null)
+            lines.add(modConstantError("cityWorkRange", "Minimum 1, maximum 100"))
         if (constants.minimalCityDistance < 0) // 0 is ok because it is the number of tiles between cities
-            lines.add("Invalid ModConstant 'minimalCityDistance'.", sourceObject = null)
+            lines.add(modConstantError("minimalCityDistance", "Minimum 0"))
         if (constants.minimalCityDistanceOnDifferentContinents < 0)
-            lines.add("Invalid ModConstant 'minimalCityDistanceOnDifferentContinents'.", sourceObject = null)
+            lines.add(modConstantError("minimalCityDistanceOnDifferentContinents", "Minimum 0"))
         if (constants.baseCityBombardRange < 0) // 0 essentially disables bombardment
-            lines.add("Invalid ModConstant 'baseCityBombardRange'.", sourceObject = null)
+            lines.add(modConstantError("baseCityBombardRange", "Minimum 0"))
 
         if (ruleset.name.isBlank()) return // The rest of these tests don't make sense for combined rulesets
 

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -281,7 +281,7 @@ open class RulesetValidator protected constructor(
 
         // TODO: Create overload method for floating point constants. Settle on using either floats or doubles in ModConstants.kt
         /**
-         * @param propertyName If the constant has a getter, then you should manually enter the name of the constant here.
+         * @param propertyName If the constant has a getter, then you should manually enter its name here.
          */
         fun checkConstant(property: KProperty0<Int>, range: IntRange, propertyName: String? = null) {
             if (property.get() in range) return

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -288,7 +288,7 @@ open class RulesetValidator protected constructor(
             lines.add("Invalid ModConstant 'minimalCityDistance'.", sourceObject = null)
         if (constants.minimalCityDistanceOnDifferentContinents < 0)
             lines.add("Invalid ModConstant 'minimalCityDistanceOnDifferentContinents'.", sourceObject = null)
-        if (constants.baseCityBombardRange < 0) // 0 is equivalent to disabling bombardment
+        if (constants.baseCityBombardRange < 0) // 0 essentially disables bombardment
             lines.add("Invalid ModConstant 'baseCityBombardRange'.", sourceObject = null)
 
         if (ruleset.name.isBlank()) return // The rest of these tests don't make sense for combined rulesets

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -281,7 +281,7 @@ open class RulesetValidator protected constructor(
 
         // TODO: Create overload method for floating point constants. Settle on using either floats or doubles in ModConstants.kt
         /**
-         * @param propertyName If the [property] has an accessor (getter), then you should manually enter the name of the constant here.
+         * @param propertyName If the constant has a getter, then you should manually enter the name of the constant here.
          */
         fun checkConstant(property: KProperty0<Int>, range: IntRange, propertyName: String? = null) {
             if (property.get() in range) return

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -284,11 +284,11 @@ open class RulesetValidator protected constructor(
             lines.add("Invalid ModConstant 'cityExpandRange'.", sourceObject = null)
         if (constants.cityWorkRange !in 1..100)
             lines.add("Invalid ModConstant 'cityWorkRange'.", sourceObject = null)
-        if (constants.minimalCityDistance < 1)
+        if (constants.minimalCityDistance < 0) // 0 is ok because it is the number of tiles between cities
             lines.add("Invalid ModConstant 'minimalCityDistance'.", sourceObject = null)
-        if (constants.minimalCityDistanceOnDifferentContinents < 1)
+        if (constants.minimalCityDistanceOnDifferentContinents < 0)
             lines.add("Invalid ModConstant 'minimalCityDistanceOnDifferentContinents'.", sourceObject = null)
-        if (constants.baseCityBombardRange < 1)
+        if (constants.baseCityBombardRange < 0) // 0 is equivalent to disabling bombardment
             lines.add("Invalid ModConstant 'baseCityBombardRange'.", sourceObject = null)
 
         if (ruleset.name.isBlank()) return // The rest of these tests don't make sense for combined rulesets

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -253,9 +253,9 @@ Legend:
     defensiveBuildingStrength
     where %techs is the percentage of techs in the tech tree that are complete
     If no techs exist in this ruleset, %techs = 0.5 (=50%)
-- [^S]: The distance that cities can attack
-- [^T]: The tiles in distance that population in cities can work on. Note: Higher values may lead to performace issues and may cause bugs. cityWorkRange may be greater than cityExpandRange.
-- [^U]: The distance that cities can expand their borders to. Note: Higher values may lead to performace issues and may cause bugs.
+- [^S]: The distance that cities can attack. Minimum 0.
+- [^T]: The tiles in distance that population in cities can work on. Note: Higher values may lead to performace issues and may cause bugs. cityWorkRange may be greater than cityExpandRange. Minimum 1, maximum 100.
+- [^U]: The distance that cities can expand their borders to. Note: Higher values may lead to performace issues and may cause bugs. Minimum 1, maximum 100.
 - [^C]: Formula for Unit Supply:
     Supply = unitSupplyBase (difficulties.json)
     unitSupplyPerCity \* amountOfCities + (difficulties.json)
@@ -266,6 +266,7 @@ Legend:
     The number is the amount of tiles between two cities, not counting the tiles the cities are on.
     e.g. "C__C", where "C" is a tile with a city and "_" is a tile without a city, has a distance of 2.
     First constant is for cities on the same landmass, the second is for cities on different continents.
+    Minimum 0.
 - [^E]: NaturalWonderGenerator uses these to determine the number of Natural Wonders to spawn for a given map size. The number scales linearly with map radius: #wonders = radius * naturalWonderCountMultiplier + naturalWonderCountAddedConstant. The defaults effectively mean Tiny - 1, Small - 2, Medium - 3, Large - 4, Huge - 5, Custom radius >=109 - all G&K wonders.
 - [^F]: MapGenerator.spreadAncientRuins: number of ruins = suitable tile count * this
 - [^G]: MapGenerator.spawnIce: spawn Ice where T < this, with T calculated from temperatureExtremeness, latitude and perlin noise.


### PR DESCRIPTION
After requests on Discord.
No issues from briefly testing.

Bombardment range of 0 should in practice be equivalent to disabling bombardment.
Minimal city distance of 0 causes [this mod](https://github.com/hachchch/Closer-Cities-Distance-of-0) to work again.