### PR TITLE
Fix leak for a LoadingPopup in "Resume"

### DIFF
--- a/core/src/com/unciv/ui/screens/LoadingScreen.kt
+++ b/core/src/com/unciv/ui/screens/LoadingScreen.kt
@@ -15,6 +15,8 @@ class LoadingScreen(
     previousScreen: BaseScreen? = null
 ) : BaseScreen() {
     private val screenshot: Texture
+    private var loadingPopup: LoadingPopup? = null
+
     init {
         screenshot = takeScreenshot(previousScreen)
         val image = ImageWithCustomSize(
@@ -32,7 +34,7 @@ class LoadingScreen(
         stage.addAction(Actions.sequence(
             Actions.delay(1000f),
             Actions.run {
-                LoadingPopup(this)
+                loadingPopup = LoadingPopup(this)
             }
         ))
     }
@@ -55,6 +57,8 @@ class LoadingScreen(
 
     override fun dispose() {
         screenshot.dispose()
+        stage.root.clearActions() // super.dispose does that too, but prevent race condition
+        loadingPopup?.close() // Prevent leak due to EventReceiver reference
         super.dispose()
     }
 }

--- a/core/src/com/unciv/ui/screens/savescreens/QuickSave.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/QuickSave.kt
@@ -109,6 +109,7 @@ object QuickSave {
             } else {
                 try {
                     screen.game.loadGame(savedGame)
+                    loadingPopup.close() // It's no longer on stage, but having an event receiver would keep it alive
                 } catch (_: OutOfMemoryError) {
                     outOfMemory()
                 } catch (ex: Exception) {


### PR DESCRIPTION
To reproduce:
* Debug on Android
* Resume a game
* Select a unit
* Set a breakpoint in [Popup.kt:208](https://github.com/yairm210/Unciv/blob/47109094958bc9b329d240ffecd954ffa47bee91/core/src/com/unciv/ui/popups/Popup.kt#L208)
* Tap the unit name bottom left so the rename Popup shows
* Activate on-screen keyboard
* Watch which classes of popup hit the breakpoint: You'll also find a `LoadingPopup`, not only a `AskTextPopup`.

This is actually a design flaw in `EventBus`, which _does_ use weak references properly in `EventBus.listeners`, but NOT in `EventReceiver.eventHandlers`. The `Any` it stores way down there is in this case a lambda reference to that lambda I had you set a breakpoint in, which keeps its containing instance alive (it must, it does use `this`). But that containing instance in turn contains a reference to the `EventReceiver` storing the lambda...

I was actually after the buggy `fitContentIntoVisibleArea` itself (pushes in the wrong direction, Timo probably confused top-down Y and bottom-up Y)... See Gdx 1.14.1 tracker issue

Edit: By the way, that LoadingPopup and the one in LoadingScreen are different in the described code path, and in that code path actually having a LoadingScreen is counter-productive: It **removes** the first LoadingPopup between the Json load and the Ruleset to WorldScreen loading, thus before the hard work is done. :sigh:. If the remaining hard work takes longer than a second, OK, then another appears... Which in turn would have the potential to leak... I guess for cleanliness that one should get a close too.