### PR TITLE
Fix expansion clearing barbarian camps leaving obsolete quests

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -182,9 +182,12 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         if (tile.getCity() != null)
             tile.getCity()!!.expansion.relinquishOwnership(tile)
 
-        if (tile.improvement == Constants.barbarianEncampment)
-            tile.setImprovementBasic(null)
-            
+        if (tile.improvement == Constants.barbarianEncampment) {
+            tile.removeImprovement()
+            for (cityState in city.civ.gameInfo.getAliveCityStates())
+                cityState.questManager.handleObsoleteGlobalQuests()
+        }
+
         city.tiles = city.tiles.withItem(tile.position)
         tile.setOwningCity(city)
         city.population.autoAssignPopulation()

--- a/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
@@ -34,6 +34,7 @@ import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.toPercent
+import com.unciv.ui.components.fonts.Fonts
 import com.unciv.utils.randomWeighted
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
@@ -131,6 +132,10 @@ class QuestManager : IsPartOfGameInfoSerialization {
             quest.setTransients(civ.gameInfo)
     }
 
+    /** Debug visualization only */
+    override fun toString() = if (!::civ.isInitialized) "(uninitialized)"
+        else "${civ.civID}:$assignedQuests"
+
     fun endTurn() {
 
         if (civ.isDefeated()) {
@@ -211,9 +216,9 @@ class QuestManager : IsPartOfGameInfoSerialization {
 
     // by turn so the same civ doesn't give the same quests always, and by civID so on the same turn different civs give different quests
     @Readonly private fun getRandom() = civ.state.stateBasedRandom("QuestManager")
-    @Readonly private fun getRandom(challenger: Civilization?) = if (challenger == null) getRandom() 
+    @Readonly private fun getRandom(challenger: Civilization?) = if (challenger == null) getRandom()
         else civ.getDiplomacyManager(challenger)?.state?.stateBasedRandom("QuestManager") ?: getRandom()
-    
+
     private fun tryStartNewGlobalQuest() {
         if (globalQuestCountdown != 0)
             return
@@ -292,6 +297,15 @@ class QuestManager : IsPartOfGameInfoSerialization {
         winnersAndLosers.losers.forEach { notifyExpired(it, winnersAndLosers.winners) }
 
         assignedQuests.removeAll { it.questNameInstance == questName }  // removing winners then losers would leave those with score 0
+    }
+
+    fun handleObsoleteGlobalQuests() {
+        val iterator = assignedQuests.iterator()
+        for (assignedQuest in iterator) {
+            if (!isObsolete(assignedQuest)) continue
+            notifyExpired(assignedQuest)
+            iterator.remove()
+        }
     }
 
     fun handleIndividualQuests() {
@@ -1025,4 +1039,8 @@ class AssignedQuest : IsPartOfGameInfoSerialization {
             else -> Unit
         }
     }
+
+    /** Debug visualization only */
+    override fun toString() = if (!::quest.isInitialized) "(uninitialized)"
+        else "$questName(${quest.type}, assigner=$assigner, assignee=$assignee, d2=$data1, d1=$data2, ${Fonts.turn}$assignedOnTurn)"
 }


### PR DESCRIPTION
Fixes #14965 

### Notes
- I find it a little strange this quest type is global - it has an assignee and afaik no other civ can get the reward? I may be wrong...
- I changed `setImprovementBasic` to `removeImprovement` - with no `civToHandleCompletion` passed to `setImprovement`, the side effects are pretty limited - visibility and lastSeenImprovement. I believe that is better to have than to have not.
- I considered implementing the quest cleanup as part of setImprovement - but then the code in `MapUnit.clearEncampment` would need reorder and become more fragile. May still be the better choice - as yet unseen sources for encampment removal???
- The QuestManager source is too chaotic, it needs some reorg. Not this PR.

<details><summary>screenshots</summary>

<img width="1206" height="543" alt="before" title="Before" src="https://github.com/user-attachments/assets/bb86d6a7-d48d-4544-a8e5-071592f9ca67" />

<img width="1206" height="543" alt="trigger" title="Trigger" src="https://github.com/user-attachments/assets/e6d9a687-8b87-47df-809e-2fc9d114b785" />

<img width="1206" height="543" alt="after" title="After" src="https://github.com/user-attachments/assets/08dac539-85b7-4999-9ea9-c6bc1a876e54" />

</details>
