### PR TITLE
China: earn Great Admiral +50% faster in G&K

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -97,7 +97,7 @@
 
 		"favoredReligion": "Taoism",
 		"uniqueName": "Art of War",
-		"uniques": ["Great General provides double combat bonus", "[Great General] is earned [50]% faster"],
+		"uniques": ["Great General provides double combat bonus", "[Great General] is earned [50]% faster", "[Great Admiral] is earned [+50]% faster"],
 		"cities": ["Beijing","Shanghai","Guangzhou","Nanjing","Xian","Chengdu","Hangzhou","Tianjin","Macau","Shandong",
 			"Kaifeng","Ningbo","Baoding","Yangzhou","Harbin","Chongqing","Luoyang","Kunming","Taipei","Shenyang",
 			"Taiyuan","Tainan","Dalian","Lijiang","Wuxi","Suzhou","Maoming","Shaoguan","Yangjiang","Heyuan","Huangshi",


### PR DESCRIPTION
Probably an oversight by firaxis as it got removed in BNW, but the double combat bonus from Great Admirals applies in both G&K and BNW: https://discord.com/channels/586194543280390151/586194543716859916/1511367894485700650 (we need to adjust the unique so Great Admirals and Great Generals can be affected independently)