### PR TITLE
Fix black outlines for Stat symbols in notifications

### DIFF
--- a/core/src/com/unciv/models/stats/Stat.kt
+++ b/core/src/com/unciv/models/stats/Stat.kt
@@ -30,6 +30,7 @@ enum class Stat(
         @Pure fun safeValueOf(name: String) = valuesAsMap[name]
         @Pure fun isStat(name: String) = name in valuesAsMap
         @Pure fun names() = valuesAsMap.keys
+        val fontChars = entries.map { it.character }.toSet()
         val statsWithCivWideField = setOf(Gold, Science, Culture, Faith, Happiness)
     }
 }

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.components.extensions
 
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.Colors
 import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.TextureData
 import com.badlogic.gdx.graphics.glutils.FileTextureData
@@ -29,6 +30,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup
 import com.badlogic.gdx.utils.Align
 import com.badlogic.gdx.utils.Array
 import com.unciv.Constants
+import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.GdxKeyCodeFixes.DEL
 import com.unciv.ui.components.extensions.GdxKeyCodeFixes.toString
@@ -391,6 +393,28 @@ fun Label.setFontSize(size: Int): Label {
     @Suppress("UsePropertyAccessSyntax") setStyle(style)
     setFontScale(size / Fonts.ORIGINAL_FONT_SIZE)
     return this
+}
+
+/** Only if this Label contains [Stat symbols][Stat.fontChars], tweak `fontColor` and `text`
+ *  so that these symbols render normally and not as black outline.
+ *  - **Only makes sense when the font color is very dark**
+ *  - **To be called _after_ translation!**
+ */
+fun Label.removeFontColorFromStatIcons() {
+    if (text.none { it in Stat.fontChars }) return
+    val fontColorMarkup = "[#${style.fontColor.toString().substring(0, 6)}]"
+    val newText = buildString {
+        append(fontColorMarkup)
+        for (char in text) {
+            if (char in Stat.fontChars) {
+                append("[]")
+                append(char)
+                append(fontColorMarkup)
+            } else append(char)
+        }
+    }
+    setFontColor(Color.WHITE)
+    setText(newText)
 }
 
 /** [pack][WidgetGroup.pack] a [WidgetGroup] if its [needsLayout][WidgetGroup.needsLayout] is true.

--- a/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
@@ -19,6 +19,7 @@ import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.MayaCalendar.toMayaNumerals
 import com.unciv.ui.components.extensions.packIfNeeded
+import com.unciv.ui.components.extensions.removeFontColorFromStatIcons
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.onClick
@@ -387,6 +388,7 @@ class NotificationsScroll(
             val maxLabelWidth = maxEntryWidth - (itemIconSize + 5f) * notification.icons.size - 10f
             val label = WrappableLabel(notification.text, maxLabelWidth, ImageGetter.CHARCOAL, labelFontSize, hideIcons = true)
             label.setAlignment(Align.center)
+            label.removeFontColorFromStatIcons()
             if (label.prefWidth > maxLabelWidth * scaleFactor) {  // can't explain why the comparison needs scaleFactor
                 label.wrap = true
                 listItem.add(label).maxWidth(label.optimizePrefWidth()).padRight(10f)


### PR DESCRIPTION
From:
    <img width="562" height="284" alt="image" src="https://github.com/user-attachments/assets/e5d2b487-4604-45fc-8dc9-5d6cb02bdf49" />
To:
    <img width="561" height="288" alt="image" src="https://github.com/user-attachments/assets/418e8607-d4dc-40ed-a373-af10c77edb3d" />

.. a kludge, if I had ever finished the Label replacement that would have been straightforward.