### PR TITLE
Hide icons when translating spy names

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -121,7 +121,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
 
     private fun addSpyToSelectionTable(spy: Spy) {
         // "Spy" column
-        spySelectionTable.add(spy.name.toLabel())
+        spySelectionTable.add(spy.name.toLabel(hideIcons = true))
         // "Rank" column
         spySelectionTable.add(spy.rank.toLabel())
         // icon column

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/presenter/SpyPresenter.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/presenter/SpyPresenter.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.screens.worldscreen.unit.presenter
 import com.badlogic.gdx.graphics.Color
 import com.unciv.logic.map.HexCoord
 import com.unciv.models.Spy
+import com.unciv.models.translations.tr
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.worldscreen.unit.UnitTable
 
@@ -22,7 +23,7 @@ class SpyPresenter(private val unitTable: UnitTable) : UnitTable.Presenter {
     override fun updateWhenNeeded() = with(unitTable) {
         val spy = selectedSpy!!
         unitNameLabel.clearListeners()
-        unitNameLabel.setText(spy.name)
+        unitNameLabel.setText(spy.name.tr(hideIcons = true))
         descriptionTable.clear()
 
         unitIconHolder.clear()


### PR DESCRIPTION
Fixes #14979

## Summary
- Translate spy names in the espionage overview without rendering ruleset object icons.
- Translate spy names in the spy presenter, where they were previously shown untranslated.
- Keep spy-name generation unchanged.

## Root cause
Spy names are intentionally translatable, but displaying them through the normal translation path can also render ruleset object icons when a spy name matches a ruleset object name.

## Fix
Render spy names with `hideIcons = true` in the relevant UI surfaces.

## Testing
- `./gradlew.bat :core:compileKotlin --console=plain`
- `git diff --check HEAD~1..HEAD`