### PR TITLE
Warn about translatable ruleset name collisions

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -42,34 +42,54 @@ import kotlin.collections.set
 enum class RulesetFile(
     val filename: String,
     @Readonly val getRulesetObjects: Ruleset.() -> Sequence<IRulesetObject> = { emptySequence() },
-    @Readonly val getUniques: Ruleset.() -> Sequence<Unique> = { getRulesetObjects().flatMap { it.uniqueObjects } }
+    @Readonly val getUniques: Ruleset.() -> Sequence<Unique> = { getRulesetObjects().flatMap { it.uniqueObjects } },
+    @Readonly val getNames: Ruleset.() -> Sequence<RulesetName> = { getRulesetObjects().map { it.toRulesetName(this) } }
 ) {
     Beliefs("Beliefs.json", { beliefs.values.asSequence() }),
     Buildings("Buildings.json", { buildings.values.asSequence() }),
     Eras("Eras.json", { eras.values.asSequence() }),
-    Religions("Religions.json"),
-    Nations("Nations.json", { nations.values.asSequence() }),
+    Religions("Religions.json", getNames = { religions.asSequence().map { rulesetName(it, "Religion") } }),
+    Nations("Nations.json", { nations.values.asSequence() }, getNames = {
+        val ruleset = this
+        nations.values.asSequence().flatMap { nation ->
+            sequence {
+                yield(nation.toRulesetName(ruleset))
+                yield(ruleset.rulesetName(nation.leaderName, "Nation.leaderName", nation.originRuleset.ifEmpty { ruleset.name }))
+                yieldAll(nation.cities.map { ruleset.rulesetName(it, "Nation.cities", nation.originRuleset.ifEmpty { ruleset.name }) })
+                yieldAll(nation.spyNames.map { ruleset.rulesetName(it, "Nation.spyNames", nation.originRuleset.ifEmpty { ruleset.name }) })
+            }
+        }
+    }),
     Policies("Policies.json", { policies.values.asSequence() }),
     Techs("Techs.json", { technologies.values.asSequence() }),
     Terrains("Terrains.json", { terrains.values.asSequence() }),
     Tutorials("Tutorials.json", { tutorials.values.asSequence() }),
     TileImprovements("TileImprovements.json", { tileImprovements.values.asSequence() }),
     TileResources("TileResources.json", { tileResources.values.asSequence() }),
-    Specialists("Specialists.json"),
+    Specialists("Specialists.json", getNames = { specialists.values.asSequence().map { rulesetName(it.name, "Specialist") } }),
     Units("Units.json", { units.values.asSequence() }),
     UnitPromotions("UnitPromotions.json", { unitPromotions.values.asSequence() }),
-    UnitNameGroup("UnitNameGroups.json", { unitNameGroups.values.asSequence() }),
+    UnitNameGroup("UnitNameGroups.json", { unitNameGroups.values.asSequence() }, getNames = {
+        val ruleset = this
+        unitNameGroups.values.asSequence().flatMap { group ->
+            sequence {
+                yield(group.toRulesetName(ruleset))
+                yieldAll(group.unitNames.map { ruleset.rulesetName(it, "UnitNameGroup.unitNames", group.originRuleset.ifEmpty { ruleset.name }) })
+            }
+        }
+    }),
     UnitTypes("UnitTypes.json", { unitTypes.values.asSequence() }),
-    VictoryTypes("VictoryTypes.json"),
+    VictoryTypes("VictoryTypes.json", getNames = { victories.values.asSequence().map { rulesetName(it.name, "Victory") } }),
     CityStateTypes("CityStateTypes.json", getUniques =
-        { cityStateTypes.values.asSequence().flatMap { it.allyBonusUniqueMap.getAllUniques() + it.friendBonusUniqueMap.getAllUniques() } }),
+        { cityStateTypes.values.asSequence().flatMap { it.allyBonusUniqueMap.getAllUniques() + it.friendBonusUniqueMap.getAllUniques() } },
+        getNames = { cityStateTypes.values.asSequence().map { rulesetName(it.name, "CityStateType") } }),
     Personalities("Personalities.json", { personalities.values.asSequence() }),
     Events("Events.json", { events.values.asSequence() + events.values.flatMap { it.choices } }),
     GlobalUniques("GlobalUniques.json", { sequenceOf(globalUniques) }),
     ModOptions("ModOptions.json", getUniques = { modOptions.uniqueObjects.asSequence() }),
     Speeds("Speeds.json", { speeds.values.asSequence() }),
-    Difficulties("Difficulties.json"),
-    Quests("Quests.json"),
+    Difficulties("Difficulties.json", getNames = { difficulties.values.asSequence().map { it.toRulesetName(this) } }),
+    Quests("Quests.json", getNames = { quests.values.asSequence().map { rulesetName(it.name, "Quest") } }),
     Ruins("Ruins.json", { ruinRewards.values.asSequence() });
 }
 
@@ -330,6 +350,9 @@ class Ruleset {
     fun allRulesetObjects(): Sequence<IRulesetObject> = RulesetFile.entries.asSequence().flatMap { it.getRulesetObjects(this) }
     @Readonly
     fun allUniques(): Sequence<Unique> = RulesetFile.entries.asSequence().flatMap { it.getUniques(this) }
+    @Readonly
+    fun allNames(): Sequence<RulesetName> =
+        RulesetFile.entries.asSequence().flatMap { it.getNames(this) }.filter { it.name.isNotEmpty() }
     @Readonly fun allICivilopediaText(): Sequence<ICivilopediaText> = allRulesetObjects() + events.values.flatMap { it.choices }
 
     fun load(folderHandle: FileHandle) {

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -42,14 +42,16 @@ import kotlin.collections.set
 /** Specifies filenames to load for a Ruleset, and how to extract shared views over their contents.
  *
  *  [getRulesetObjects] and [getUniques] are used by ruleset-wide validation and unique parsing.
- *  [getNames] lists names that should be considered translation keys. Override it when a file
- *  contains names outside [IRulesetObject.name], such as nation city names or spy names.
+ *  [getINamed] backs [getNames] for files whose entries have names without being [IRulesetObject]s.
+ *  Override [getNames] directly when a file contains names outside its main objects, such as nation
+ *  city names or spy names.
  */
 enum class RulesetFile(
     val filename: String,
     @Readonly val getRulesetObjects: Ruleset.() -> Sequence<IRulesetObject> = { emptySequence() },
     @Readonly val getUniques: Ruleset.() -> Sequence<Unique> = { getRulesetObjects().flatMap { it.uniqueObjects } },
-    @Readonly val getNames: Ruleset.() -> Sequence<RulesetName> = { getRulesetObjects().map { it.toRulesetName(this) } }
+    @Readonly val getINamed: Ruleset.() -> Sequence<INamed> = { getRulesetObjects() },
+    @Readonly val getNames: Ruleset.() -> Sequence<RulesetName> = { getINamed().map { it.toRulesetName(this) } }
 ) {
     Beliefs("Beliefs.json", { beliefs.values.asSequence() }),
     Buildings("Buildings.json", { buildings.values.asSequence() }),
@@ -72,7 +74,7 @@ enum class RulesetFile(
     Tutorials("Tutorials.json", { tutorials.values.asSequence() }),
     TileImprovements("TileImprovements.json", { tileImprovements.values.asSequence() }),
     TileResources("TileResources.json", { tileResources.values.asSequence() }),
-    Specialists("Specialists.json", getNames = { specialists.values.asSequence().map { rulesetName(it.name, "Specialist") } }),
+    Specialists("Specialists.json", getINamed = { specialists.values.asSequence() }),
     Units("Units.json", { units.values.asSequence() }),
     UnitPromotions("UnitPromotions.json", { unitPromotions.values.asSequence() }),
     UnitNameGroup("UnitNameGroups.json", { unitNameGroups.values.asSequence() }, getNames = {
@@ -85,17 +87,17 @@ enum class RulesetFile(
         }
     }),
     UnitTypes("UnitTypes.json", { unitTypes.values.asSequence() }),
-    VictoryTypes("VictoryTypes.json", getNames = { victories.values.asSequence().map { rulesetName(it.name, "Victory") } }),
+    VictoryTypes("VictoryTypes.json", getINamed = { victories.values.asSequence() }),
     CityStateTypes("CityStateTypes.json", getUniques =
         { cityStateTypes.values.asSequence().flatMap { it.allyBonusUniqueMap.getAllUniques() + it.friendBonusUniqueMap.getAllUniques() } },
-        getNames = { cityStateTypes.values.asSequence().map { rulesetName(it.name, "CityStateType") } }),
+        getINamed = { cityStateTypes.values.asSequence() }),
     Personalities("Personalities.json", { personalities.values.asSequence() }),
     Events("Events.json", { events.values.asSequence() + events.values.flatMap { it.choices } }),
     GlobalUniques("GlobalUniques.json", { sequenceOf(globalUniques) }),
     ModOptions("ModOptions.json", getUniques = { modOptions.uniqueObjects.asSequence() }),
     Speeds("Speeds.json", { speeds.values.asSequence() }),
-    Difficulties("Difficulties.json", getNames = { difficulties.values.asSequence().map { it.toRulesetName(this) } }),
-    Quests("Quests.json", getNames = { quests.values.asSequence().map { rulesetName(it.name, "Quest") } }),
+    Difficulties("Difficulties.json", getINamed = { difficulties.values.asSequence() }),
+    Quests("Quests.json", getINamed = { quests.values.asSequence() }),
     Ruins("Ruins.json", { ruinRewards.values.asSequence() });
 }
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -39,6 +39,12 @@ import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Readonly
 import kotlin.collections.set
 
+/** Specifies filenames to load for a Ruleset, and how to extract shared views over their contents.
+ *
+ *  [getRulesetObjects] and [getUniques] are used by ruleset-wide validation and unique parsing.
+ *  [getNames] lists names that should be considered translation keys. Override it when a file
+ *  contains names outside [IRulesetObject.name], such as nation city names or spy names.
+ */
 enum class RulesetFile(
     val filename: String,
     @Readonly val getRulesetObjects: Ruleset.() -> Sequence<IRulesetObject> = { emptySequence() },
@@ -350,6 +356,7 @@ class Ruleset {
     fun allRulesetObjects(): Sequence<IRulesetObject> = RulesetFile.entries.asSequence().flatMap { it.getRulesetObjects(this) }
     @Readonly
     fun allUniques(): Sequence<Unique> = RulesetFile.entries.asSequence().flatMap { it.getUniques(this) }
+    /** Returns all non-empty ruleset names that can act as translation keys, with their source metadata. */
     @Readonly
     fun allNames(): Sequence<RulesetName> =
         RulesetFile.entries.asSequence().flatMap { it.getNames(this) }.filter { it.name.isNotEmpty() }

--- a/core/src/com/unciv/models/ruleset/RulesetName.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetName.kt
@@ -1,0 +1,21 @@
+package com.unciv.models.ruleset
+
+import yairm210.purity.annotations.Readonly
+
+data class RulesetName(
+    val name: String,
+    val source: String,
+    val originRuleset: String
+)
+
+@Readonly
+internal fun IRulesetObject.toRulesetName(ruleset: Ruleset): RulesetName =
+    RulesetName(
+        name,
+        this::class.simpleName ?: "RulesetObject",
+        originRuleset.ifEmpty { ruleset.name }
+    )
+
+@Readonly
+internal fun Ruleset.rulesetName(name: String, source: String, originRuleset: String = this.name): RulesetName =
+    RulesetName(name, source, originRuleset)

--- a/core/src/com/unciv/models/ruleset/RulesetName.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetName.kt
@@ -1,5 +1,6 @@
 package com.unciv.models.ruleset
 
+import com.unciv.models.stats.INamed
 import yairm210.purity.annotations.Readonly
 
 /** A ruleset name entry for checks that need to reason about translation keys across ruleset sources.
@@ -15,11 +16,11 @@ data class RulesetName(
 )
 
 @Readonly
-internal fun IRulesetObject.toRulesetName(ruleset: Ruleset): RulesetName =
+internal fun INamed.toRulesetName(ruleset: Ruleset): RulesetName =
     RulesetName(
         name,
         this::class.simpleName ?: "RulesetObject",
-        originRuleset.ifEmpty { ruleset.name }
+        (this as? IRulesetObject)?.originRuleset?.ifEmpty { ruleset.name } ?: ruleset.name
     )
 
 @Readonly

--- a/core/src/com/unciv/models/ruleset/RulesetName.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetName.kt
@@ -2,6 +2,12 @@ package com.unciv.models.ruleset
 
 import yairm210.purity.annotations.Readonly
 
+/** A ruleset name entry for checks that need to reason about translation keys across ruleset sources.
+ *
+ *  The same raw [name] can be valid in more than one place, but still share a translation key.
+ *  [source] identifies the object type or field that contributed it, and [originRuleset] helps
+ *  validation distinguish built-in reuse from modded name collisions.
+ */
 data class RulesetName(
     val name: String,
     val source: String,

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -15,6 +15,7 @@ import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.RulesetFile
+import com.unciv.models.ruleset.RulesetName
 import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.nation.getContrastRatio
@@ -533,17 +534,7 @@ open class RulesetValidator protected constructor(
 
         val duplicateNames = translatableNames
             .groupBy { it.name }
-            .filter { (_, names) ->
-                val sourceSet = names.map { it.source }.toSet()
-                val origins = names.map { it.originRuleset }
-                val isKnownBuiltInRulesetCollision = origins.all { it.isNotEmpty() }
-                    && origins.toSet().singleOrNull()?.let { it in builtInRulesetNames } == true
-                val isKnownBuiltInSourceCollision = sourceSet in knownBenignSourceCollisions
-                    && origins.all { it in builtInRulesetNames }
-                sourceSet.size >= 2
-                    && !isKnownBuiltInRulesetCollision
-                    && !isKnownBuiltInSourceCollision
-            }
+            .filter { (_, names) -> shouldReportTranslationNameCollision(names, builtInRulesetNames, knownBenignSourceCollisions) }
             .mapValues { (_, names) -> names.map { it.source }.distinct().sorted() }
             .toSortedMap()
 
@@ -554,6 +545,40 @@ open class RulesetValidator protected constructor(
                 sourceObject = null
             )
         }
+    }
+
+    private fun shouldReportTranslationNameCollision(
+        names: List<RulesetName>,
+        builtInRulesetNames: Set<String>,
+        knownBenignSourceCollisions: Set<Set<String>>
+    ): Boolean {
+        val sourceTypes = names.map { it.source }.toSet()
+        if (sourceTypes.size < 2) return false
+
+        val origins = names.map { it.originRuleset }
+        if (isCollisionWithinSingleBuiltInRuleset(origins, builtInRulesetNames)) return false
+        if (isKnownBenignBuiltInSourceCollision(sourceTypes, origins, builtInRulesetNames, knownBenignSourceCollisions)) return false
+
+        return true
+    }
+
+    private fun isCollisionWithinSingleBuiltInRuleset(
+        origins: List<String>,
+        builtInRulesetNames: Set<String>
+    ): Boolean {
+        if (origins.any { it.isEmpty() }) return false
+        val distinctOrigins = origins.toSet()
+        return distinctOrigins.size == 1 && distinctOrigins.single() in builtInRulesetNames
+    }
+
+    private fun isKnownBenignBuiltInSourceCollision(
+        sourceTypes: Set<String>,
+        origins: List<String>,
+        builtInRulesetNames: Set<String>,
+        knownBenignSourceCollisions: Set<Set<String>>
+    ): Boolean {
+        return sourceTypes in knownBenignSourceCollisions
+            && origins.all { it in builtInRulesetNames }
     }
 
     //endregion

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -516,39 +516,13 @@ open class RulesetValidator protected constructor(
         }
     }
 
-    private data class TranslatableName(val name: String, val source: String, val originRuleset: String)
-
     private fun addTranslationNameCollisionWarnings(lines: RulesetErrorList) {
-        fun originRuleset() = ruleset.name
-        fun IRulesetObject.originRulesetOrRulesetName() = originRuleset.ifEmpty { ruleset.name }
-
-        val translatableNames = sequence {
-            yieldAll(ruleset.allRulesetObjects().map {
-                TranslatableName(it.name, it::class.simpleName ?: "RulesetObject", it.originRulesetOrRulesetName())
-            })
-
-            yieldAll(ruleset.religions.map { TranslatableName(it, "Religion", originRuleset()) })
-            yieldAll(ruleset.specialists.values.map { TranslatableName(it.name, "Specialist", originRuleset()) })
-            yieldAll(ruleset.difficulties.values.map { TranslatableName(it.name, "Difficulty", it.originRulesetOrRulesetName()) })
-            yieldAll(ruleset.victories.values.map { TranslatableName(it.name, "Victory", originRuleset()) })
-            yieldAll(ruleset.cityStateTypes.values.map { TranslatableName(it.name, "CityStateType", originRuleset()) })
-            yieldAll(ruleset.quests.values.map { TranslatableName(it.name, "Quest", originRuleset()) })
-
-            yieldAll(ruleset.nations.values.asSequence().flatMap { nation ->
-                sequence {
-                    yield(TranslatableName(nation.leaderName, "Nation.leaderName", nation.originRulesetOrRulesetName()))
-                    yieldAll(nation.cities.map { TranslatableName(it, "Nation.cities", nation.originRulesetOrRulesetName()) })
-                    yieldAll(nation.spyNames.map { TranslatableName(it, "Nation.spyNames", nation.originRulesetOrRulesetName()) })
-                }
-            })
-            yieldAll(ruleset.unitNameGroups.values.flatMap { group ->
-                group.unitNames.map { TranslatableName(it, "UnitNameGroup.unitNames", group.originRulesetOrRulesetName()) }
-            })
-        }
-            .filter { it.name.isNotEmpty() }
-            .toList()
+        val translatableNames = ruleset.allNames().toList()
 
         val builtInRulesetNames = BaseRuleset.entries.map { it.fullName }.toSet()
+        // Base rulesets intentionally reuse a few display names in different source types:
+        // "Scout" is both a BaseUnit and UnitType, "Settler" is a BaseUnit and Difficulty,
+        // and some great person names appear in both UnitNameGroups and generated unit names.
         val knownBenignSourceCollisions = setOf(
             setOf("BaseUnit", "UnitType"),
             setOf("BaseUnit", "Difficulty"),
@@ -564,9 +538,11 @@ open class RulesetValidator protected constructor(
                 val origins = names.map { it.originRuleset }
                 val isKnownBuiltInRulesetCollision = origins.all { it.isNotEmpty() }
                     && origins.toSet().singleOrNull()?.let { it in builtInRulesetNames } == true
+                val isKnownBuiltInSourceCollision = sourceSet in knownBenignSourceCollisions
+                    && origins.all { it in builtInRulesetNames }
                 sourceSet.size >= 2
-                    && sourceSet !in knownBenignSourceCollisions
                     && !isKnownBuiltInRulesetCollision
+                    && !isKnownBuiltInSourceCollision
             }
             .mapValues { (_, names) -> names.map { it.source }.distinct().sorted() }
             .toSortedMap()

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -8,6 +8,7 @@ import com.unciv.UncivGame
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.logic.map.tile.RoadStatus
+import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.IRulesetObject
@@ -118,6 +119,8 @@ open class RulesetValidator protected constructor(
         addDifficultyErrors(lines)
         addEventErrors(lines)
         addCityStateTypeErrors(lines)
+
+        addTranslationNameCollisionWarnings(lines)
 
         initTextureNamesCache(lines)
 
@@ -510,6 +513,70 @@ open class RulesetValidator protected constructor(
                         "Victory types ${victoryType.name} and ${otherVictory.name} have the same requirements!",
                         RulesetErrorSeverity.Warning, sourceObject = null
                     )
+        }
+    }
+
+    private data class TranslatableName(val name: String, val source: String, val originRuleset: String)
+
+    private fun addTranslationNameCollisionWarnings(lines: RulesetErrorList) {
+        fun originRuleset() = ruleset.name
+        fun IRulesetObject.originRulesetOrRulesetName() = originRuleset.ifEmpty { ruleset.name }
+
+        val translatableNames = sequence {
+            yieldAll(ruleset.allRulesetObjects().map {
+                TranslatableName(it.name, it::class.simpleName ?: "RulesetObject", it.originRulesetOrRulesetName())
+            })
+
+            yieldAll(ruleset.religions.map { TranslatableName(it, "Religion", originRuleset()) })
+            yieldAll(ruleset.specialists.values.map { TranslatableName(it.name, "Specialist", originRuleset()) })
+            yieldAll(ruleset.difficulties.values.map { TranslatableName(it.name, "Difficulty", it.originRulesetOrRulesetName()) })
+            yieldAll(ruleset.victories.values.map { TranslatableName(it.name, "Victory", originRuleset()) })
+            yieldAll(ruleset.cityStateTypes.values.map { TranslatableName(it.name, "CityStateType", originRuleset()) })
+            yieldAll(ruleset.quests.values.map { TranslatableName(it.name, "Quest", originRuleset()) })
+
+            yieldAll(ruleset.nations.values.asSequence().flatMap { nation ->
+                sequence {
+                    yield(TranslatableName(nation.leaderName, "Nation.leaderName", nation.originRulesetOrRulesetName()))
+                    yieldAll(nation.cities.map { TranslatableName(it, "Nation.cities", nation.originRulesetOrRulesetName()) })
+                    yieldAll(nation.spyNames.map { TranslatableName(it, "Nation.spyNames", nation.originRulesetOrRulesetName()) })
+                }
+            })
+            yieldAll(ruleset.unitNameGroups.values.flatMap { group ->
+                group.unitNames.map { TranslatableName(it, "UnitNameGroup.unitNames", group.originRulesetOrRulesetName()) }
+            })
+        }
+            .filter { it.name.isNotEmpty() }
+            .toList()
+
+        val builtInRulesetNames = BaseRuleset.entries.map { it.fullName }.toSet()
+        val knownBenignSourceCollisions = setOf(
+            setOf("BaseUnit", "UnitType"),
+            setOf("BaseUnit", "Difficulty"),
+            setOf("BaseUnit", "UnitNameGroup"),
+            setOf("Personality", "UnitNameGroup.unitNames"),
+            setOf("Specialist", "UnitNameGroup")
+        )
+
+        val duplicateNames = translatableNames
+            .groupBy { it.name }
+            .filter { (_, names) ->
+                val sourceSet = names.map { it.source }.toSet()
+                val origins = names.map { it.originRuleset }
+                val isKnownBuiltInRulesetCollision = origins.all { it.isNotEmpty() }
+                    && origins.toSet().singleOrNull()?.let { it in builtInRulesetNames } == true
+                sourceSet.size >= 2
+                    && sourceSet !in knownBenignSourceCollisions
+                    && !isKnownBuiltInRulesetCollision
+            }
+            .mapValues { (_, names) -> names.map { it.source }.distinct().sorted() }
+            .toSortedMap()
+
+        for ((name, sources) in duplicateNames) {
+            lines.add(
+                "The name \"$name\" is used by several ruleset entries (${sources.joinToString()}) and may cause translation problems.",
+                RulesetErrorSeverity.WarningOptionsOnly,
+                sourceObject = null
+            )
         }
     }
 

--- a/tests/src/com/unciv/uniques/RulesetValidatorTests.kt
+++ b/tests/src/com/unciv/uniques/RulesetValidatorTests.kt
@@ -1,0 +1,116 @@
+package com.unciv.uniques
+
+import com.unciv.models.ruleset.Building
+import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.ruleset.validation.RulesetErrorSeverity
+import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class RulesetValidatorTests {
+
+    @Test
+    fun `ruleset validator warns about spy name collision with ruleset object`() {
+        val game = TestGame()
+        game.ruleset.buildings["Park"] = Building().apply {
+            name = "Park"
+            originRuleset = "Test mod"
+            uniques.add("Unbuildable")
+        }
+        game.ruleset.nations.values.first().spyNames = arrayListOf("Park")
+
+        val errors = game.ruleset.getErrorList()
+
+        assertTrue(errors.any {
+            it.errorSeverityToReport == RulesetErrorSeverity.WarningOptionsOnly
+                && it.text.contains("\"Park\"")
+                && it.text.contains("Building")
+                && it.text.contains("Nation.spyNames")
+        })
+    }
+
+    @Test
+    fun `ruleset validator warns about non ruleset object name collisions`() {
+        val game = TestGame()
+        game.ruleset.name = "Test mod"
+        game.ruleset.buildings["Park"] = Building().apply {
+            name = "Park"
+            originRuleset = "Test mod"
+            uniques.add("Unbuildable")
+        }
+        game.ruleset.religions.add("Park")
+
+        val errors = game.ruleset.getErrorList()
+
+        assertTrue(errors.any {
+            it.errorSeverityToReport == RulesetErrorSeverity.WarningOptionsOnly
+                && it.text.contains("\"Park\"")
+                && it.text.contains("Building")
+                && it.text.contains("Religion")
+        })
+    }
+
+    @Test
+    fun `ruleset validator warns when mod name collision has empty origin`() {
+        val game = TestGame()
+        game.ruleset.name = ""
+        game.ruleset.buildings["Park"] = Building().apply {
+            name = "Park"
+            originRuleset = BaseRuleset.Civ_V_GnK.fullName
+            uniques.add("Unbuildable")
+        }
+        game.ruleset.religions.add("Park")
+
+        val errors = game.ruleset.getErrorList()
+
+        assertTrue(errors.any {
+            it.errorSeverityToReport == RulesetErrorSeverity.WarningOptionsOnly
+                && it.text.contains("\"Park\"")
+                && it.text.contains("Building")
+                && it.text.contains("Religion")
+        })
+    }
+
+    @Test
+    fun `ruleset validator warns about leader name collisions`() {
+        val game = TestGame()
+        game.ruleset.buildings["Park"] = Building().apply {
+            name = "Park"
+            originRuleset = "Test mod"
+            uniques.add("Unbuildable")
+        }
+        game.ruleset.nations.values.first().leaderName = "Park"
+
+        val errors = game.ruleset.getErrorList()
+
+        assertTrue(errors.any {
+            it.errorSeverityToReport == RulesetErrorSeverity.WarningOptionsOnly
+                && it.text.contains("\"Park\"")
+                && it.text.contains("Building")
+                && it.text.contains("Nation.leaderName")
+        })
+    }
+
+    @Test
+    fun `ruleset validator warns about city name collisions`() {
+        val game = TestGame()
+        game.ruleset.buildings["Park"] = Building().apply {
+            name = "Park"
+            originRuleset = "Test mod"
+            uniques.add("Unbuildable")
+        }
+        game.ruleset.nations.values.first().cities = arrayListOf("Park")
+
+        val errors = game.ruleset.getErrorList()
+
+        assertTrue(errors.any {
+            it.errorSeverityToReport == RulesetErrorSeverity.WarningOptionsOnly
+                && it.text.contains("\"Park\"")
+                && it.text.contains("Building")
+                && it.text.contains("Nation.cities")
+        })
+    }
+}


### PR DESCRIPTION
Follow-up to #14979.

## Summary
Adds a mild `WarningOptionsOnly` ruleset validator warning for translatable names reused across different ruleset name sources.

The name collection is exposed through `RulesetFile.getNames` and `Ruleset.allNames()`, following the existing `RulesetFile` traversal pattern used by `getRulesetObjects` and `getUniques`. `RulesetValidator` then consumes that centralized name list and only applies the collision warning policy.

## Motivation
Some names can be valid in multiple contexts but still share the same translation key. This can cause ambiguous translations, such as a spy name colliding with a building name from a mod.

The warning is intended to make these collisions visible to mod authors without changing gameplay behavior or silently hiding configured names.

[EDIT]: When the colliding entries are controlled by the same modder, they can avoid the ambiguity by using distinct abstract translation keys, for example `SPY_PARK = Park` and `BUILDING_PARK = Park`. This warning is meant to make such cases easier to notice.

## Notes
This intentionally does not change the existing `allRulesetObjects`, `allUniques`, or `allICivilopediaText` behavior. The Difficulty/EventChoice questions discussed in review seem like separate historical cleanup items, so this PR keeps the scope limited to name collision warnings.

Known built-in base ruleset name reuse is suppressed so Vanilla/G&K validation stays clean, while mod-origin collisions are still reported.

## Testing
- `./gradlew.bat :tests:test --tests com.unciv.uniques.RulesetValidatorTests --console=plain`
- `./gradlew.bat :tests:test --tests com.unciv.testing.BasicTests.baseRulesetHasNoBugs --console=plain`
- `git diff --check`