### PR TITLE
Respect alternative promotion prerequisites in validation

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -301,26 +301,40 @@ internal class BaseRulesetValidator(
     }
 
     private fun checkPromotionCircularReferences(lines: RulesetErrorList) {
-        fun recursiveCheck(history: HashSet<Promotion>, promotion: Promotion, level: Int) {
-            if (promotion in history) {
-                lines.add("Circular Reference in Promotions: ${history.joinToString("→") { it.name }}→${promotion.name}",
-                    RulesetErrorSeverity.Warning, promotion)
-                return
-            }
-            if (level > 99) return
+        fun hasAcyclicPathToRoot(promotion: Promotion, history: HashSet<Promotion>, level: Int): Boolean {
+            if (promotion.prerequisites.isEmpty()) return true
+            if (promotion in history) return false
+            if (level > 99) return false
+
             history.add(promotion)
             for (prerequisiteName in promotion.prerequisites) {
                 val prerequisite = ruleset.unitPromotions[prerequisiteName] ?: continue
-                // Performance - if there's only one prerequisite, we can send this linked set as-is, since no one else will be using it
-                val linkedSetToPass =
-                    if (promotion.prerequisites.size == 1) history
-                    else history.toCollection(hashSetOf())
-                recursiveCheck(linkedSetToPass, prerequisite, level + 1)
+                if (hasAcyclicPathToRoot(prerequisite, history.toCollection(hashSetOf()), level + 1))
+                    return true
             }
+            return false
         }
+
+        fun findCircularReference(history: List<Promotion>, promotion: Promotion, level: Int): List<Promotion>? {
+            val existingIndex = history.indexOf(promotion)
+            if (existingIndex >= 0) return history.drop(existingIndex) + promotion
+            if (level > 99) return null
+
+            val newHistory = history + promotion
+            for (prerequisiteName in promotion.prerequisites) {
+                val prerequisite = ruleset.unitPromotions[prerequisiteName] ?: continue
+                return findCircularReference(newHistory, prerequisite, level + 1) ?: continue
+            }
+            return null
+        }
+
         for (promotion in ruleset.unitPromotions.values) {
             if (promotion.prerequisites.isEmpty()) continue
-            recursiveCheck(hashSetOf(), promotion, 0)
+            if (hasAcyclicPathToRoot(promotion, hashSetOf(), 0)) continue
+
+            val circularReference = findCircularReference(emptyList(), promotion, 0) ?: continue
+            lines.add("Circular Reference in Promotions: ${circularReference.joinToString("→") { it.name }}",
+                RulesetErrorSeverity.Warning, promotion)
         }
     }
 

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -301,38 +301,53 @@ internal class BaseRulesetValidator(
     }
 
     private fun checkPromotionCircularReferences(lines: RulesetErrorList) {
-        fun hasAcyclicPathToRoot(promotion: Promotion, history: HashSet<Promotion>, level: Int): Boolean {
-            if (promotion.prerequisites.isEmpty()) return true
-            if (promotion in history) return false
-            if (level > 99) return false
-
-            history.add(promotion)
-            for (prerequisiteName in promotion.prerequisites) {
-                val prerequisite = ruleset.unitPromotions[prerequisiteName] ?: continue
-                if (hasAcyclicPathToRoot(prerequisite, history.toCollection(hashSetOf()), level + 1))
-                    return true
-            }
-            return false
+        val promotionsUnlockedByPrerequisite = HashMap<String, MutableList<Promotion>>()
+        for (promotion in ruleset.unitPromotions.values) {
+            for (prerequisiteName in promotion.prerequisites)
+                promotionsUnlockedByPrerequisite.getOrPut(prerequisiteName) { ArrayList() }.add(promotion)
         }
 
-        fun findCircularReference(history: List<Promotion>, promotion: Promotion, level: Int): List<Promotion>? {
+        val promotionsWithAcyclicPathToRoot = HashSet<Promotion>()
+        val promotionsToCheck = ArrayDeque<Promotion>()
+        for (promotion in ruleset.unitPromotions.values) {
+            if (promotion.prerequisites.isNotEmpty()) continue
+            promotionsWithAcyclicPathToRoot.add(promotion)
+            promotionsToCheck.add(promotion)
+        }
+
+        while (promotionsToCheck.isNotEmpty()) {
+            val promotion = promotionsToCheck.removeFirst()
+            for (unlockedPromotion in promotionsUnlockedByPrerequisite[promotion.name].orEmpty()) {
+                if (!promotionsWithAcyclicPathToRoot.add(unlockedPromotion)) continue
+                promotionsToCheck.add(unlockedPromotion)
+            }
+        }
+
+        val promotionsInAlreadyReportedCycles = HashSet<Promotion>()
+        val promotionsAlreadyChecked = HashSet<Promotion>()
+        fun findCircularReference(history: List<Promotion>, promotion: Promotion): List<Promotion>? {
             val existingIndex = history.indexOf(promotion)
             if (existingIndex >= 0) return history.drop(existingIndex) + promotion
-            if (level > 99) return null
+            if (promotion in promotionsAlreadyChecked) return null
+            if (promotion in promotionsWithAcyclicPathToRoot) return null
 
             val newHistory = history + promotion
             for (prerequisiteName in promotion.prerequisites) {
                 val prerequisite = ruleset.unitPromotions[prerequisiteName] ?: continue
-                return findCircularReference(newHistory, prerequisite, level + 1) ?: continue
+                val circularReference = findCircularReference(newHistory, prerequisite)
+                if (circularReference != null) return circularReference
             }
+
+            promotionsAlreadyChecked.add(promotion)
             return null
         }
 
         for (promotion in ruleset.unitPromotions.values) {
-            if (promotion.prerequisites.isEmpty()) continue
-            if (hasAcyclicPathToRoot(promotion, hashSetOf(), 0)) continue
+            if (promotion in promotionsWithAcyclicPathToRoot) continue
+            if (promotion in promotionsInAlreadyReportedCycles) continue
 
-            val circularReference = findCircularReference(emptyList(), promotion, 0) ?: continue
+            val circularReference = findCircularReference(emptyList(), promotion) ?: continue
+            promotionsInAlreadyReportedCycles.addAll(circularReference)
             lines.add("Circular Reference in Promotions: ${circularReference.joinToString("→") { it.name }}",
                 RulesetErrorSeverity.Warning, promotion)
         }

--- a/docs/Modders/schemas/UnitPromotions.schema.json
+++ b/docs/Modders/schemas/UnitPromotions.schema.json
@@ -21,7 +21,7 @@
       },
       "prerequisites": {
         "title": "Prerequisites",
-        "description": "Prerequisite promotions that are required prior to being able to get the active one.",
+        "description": "Alternative prerequisite promotions. At least one listed promotion is required prior to being able to get the active one.",
         "type": "array",
         "items": {
           "type": "string",

--- a/tests/src/com/unciv/uniques/UniqueErrorTests.kt
+++ b/tests/src/com/unciv/uniques/UniqueErrorTests.kt
@@ -48,6 +48,38 @@ class UniqueErrorTests {
         assert(errors.isNotOK())
     }
 
+
+    @Test
+    fun testPromotionCircularReferenceWithAcyclicAlternativeIsAllowed() {
+        val game = TestGame()
+        val root = game.createUnitPromotion()
+        val firstBranch = game.createUnitPromotion()
+        val secondBranch = game.createUnitPromotion()
+        listOf(root, firstBranch, secondBranch).forEach { it.unitTypes = listOf("Scout") }
+
+        firstBranch.prerequisites = listOf(secondBranch.name, root.name)
+        secondBranch.prerequisites = listOf(firstBranch.name)
+        game.ruleset.modOptions.isBaseRuleset = true
+
+        val errors = game.ruleset.getErrorList(false)
+        Assert.assertTrue(errors.none { it.text.startsWith("Circular Reference in Promotions") })
+    }
+
+    @Test
+    fun testPromotionCircularReferenceWithoutAcyclicAlternativeIsWarned() {
+        val game = TestGame()
+        val firstBranch = game.createUnitPromotion()
+        val secondBranch = game.createUnitPromotion()
+        listOf(firstBranch, secondBranch).forEach { it.unitTypes = listOf("Scout") }
+
+        firstBranch.prerequisites = listOf(secondBranch.name)
+        secondBranch.prerequisites = listOf(firstBranch.name)
+        game.ruleset.modOptions.isBaseRuleset = true
+
+        val errors = game.ruleset.getErrorList(false)
+        Assert.assertTrue(errors.any { it.text.startsWith("Circular Reference in Promotions") })
+    }
+
     @Test
     fun testTimedGlobalUniqueAcceptsTriggerConditionsWhenOnUnit(){
         RulesetCache.loadRulesets(noMods = true)

--- a/tests/src/com/unciv/uniques/UniqueErrorTests.kt
+++ b/tests/src/com/unciv/uniques/UniqueErrorTests.kt
@@ -77,7 +77,11 @@ class UniqueErrorTests {
         game.ruleset.modOptions.isBaseRuleset = true
 
         val errors = game.ruleset.getErrorList(false)
-        Assert.assertTrue(errors.any { it.text.startsWith("Circular Reference in Promotions") })
+        Assert.assertEquals(1, errors.size)
+        Assert.assertEquals(
+            "Circular Reference in Promotions: ${firstBranch.name}→${secondBranch.name}→${firstBranch.name}",
+            errors.single().text
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

This updates promotion circular-reference validation so it matches the existing runtime behavior of unit promotion prerequisites.

Currently, promotion availability treats entries in `prerequisites` as alternatives: a unit can take the promotion if it has at least one listed prerequisite. This PR updates the circular-reference validator to evaluate those prerequisite paths the same way.

## Changes

* Updates promotion circular-reference validation to check whether a promotion has at least one valid acyclic path back to a root promotion.
* Suppresses circular-reference warnings when one prerequisite branch loops but another branch remains valid.
* Continues reporting true closed loops where no valid root path exists.
* Clarifies the `UnitPromotions.schema.json` description for `prerequisites`.
* Adds test coverage for:

  * a promotion with a circular branch and a valid alternative prerequisite path
  * a true closed circular dependency

## Compatibility

This is intended to be backward-compatible.

It does not change the `UnitPromotions.json` format, does not add any new fields, and does not change promotion availability behavior. It only updates validation so it is consistent with the existing interpretation of promotion prerequisites.

## Testing

- Ran targeted validation tests:
  - `./gradlew tests:test --tests "com.unciv.uniques.UniqueErrorTests"`
  - Result: `BUILD SUCCESSFUL`

- Ran broader test task:
  - `./gradlew tests:test`
  - Result: `BUILD SUCCESSFUL`
