### PR TITLE
Prevent automation from orphaning CreatesOneImprovement markers

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/RoadBetweenCitiesAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadBetweenCitiesAutomation.kt
@@ -312,8 +312,7 @@ class RoadBetweenCitiesAutomation(val civInfo: Civilization, private val cachedF
         for (toConnectCity in candidateCities.sortedByDescending { it.getCenterTile().aerialDistanceTo(unitStartingTile) }) {
             val tilesByPriority = getRoadsToBuildFromCity(toConnectCity).flatMap { roadPlan -> roadPlan.tiles.map { tile ->  Pair(tile, roadPlan.priority) } }
             val tilesSorted = tilesByPriority
-                    .filter { !it.first.isMarkedForCreatesOneImprovement() }
-                    .filter { it.first.getUnpillagedRoad() < bestRoadAvailable }
+                    .filter { !it.first.isMarkedForCreatesOneImprovement() && it.first.getUnpillagedRoad() < bestRoadAvailable }
                     .sortedBy { it.first.aerialDistanceTo(unitStartingTile) + (it.second / 10f) }
             val bestTile = tilesSorted.firstOrNull {
                 unitStartingTile == it.first || (unit.movement.canMoveTo(it.first) && unit.movement.canReach(it.first))

--- a/core/src/com/unciv/logic/automation/unit/RoadBetweenCitiesAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadBetweenCitiesAutomation.kt
@@ -311,7 +311,9 @@ class RoadBetweenCitiesAutomation(val civInfo: Civilization, private val cachedF
         // Search through ALL candidate cities for the closest tile to build a road on
         for (toConnectCity in candidateCities.sortedByDescending { it.getCenterTile().aerialDistanceTo(unitStartingTile) }) {
             val tilesByPriority = getRoadsToBuildFromCity(toConnectCity).flatMap { roadPlan -> roadPlan.tiles.map { tile ->  Pair(tile, roadPlan.priority) } }
-            val tilesSorted = tilesByPriority.filter { it.first.getUnpillagedRoad() < bestRoadAvailable }
+            val tilesSorted = tilesByPriority
+                    .filter { !it.first.isMarkedForCreatesOneImprovement() }
+                    .filter { it.first.getUnpillagedRoad() < bestRoadAvailable }
                     .sortedBy { it.first.aerialDistanceTo(unitStartingTile) + (it.second / 10f) }
             val bestTile = tilesSorted.firstOrNull {
                 unitStartingTile == it.first || (unit.movement.canMoveTo(it.first) && unit.movement.canReach(it.first))

--- a/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
@@ -139,8 +139,7 @@ class RoadToAutomation(val civInfo: Civilization) {
         unit.action = null
         unit.automatedRoadConnectionDestination = null
         unit.automatedRoadConnectionPath = null
-        if (!unit.currentTile.isMarkedForCreatesOneImprovement())
-            unit.currentTile.stopWorkingOnImprovement()
+        unit.currentTile.stopWorkingOnImprovement()
     }
 
 

--- a/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
@@ -139,13 +139,15 @@ class RoadToAutomation(val civInfo: Civilization) {
         unit.action = null
         unit.automatedRoadConnectionDestination = null
         unit.automatedRoadConnectionPath = null
-        unit.currentTile.stopWorkingOnImprovement()
+        if (!unit.currentTile.isMarkedForCreatesOneImprovement())
+            unit.currentTile.stopWorkingOnImprovement()
     }
 
 
     /** Conditions for whether it is acceptable to build a road on this tile */
     @Readonly
     fun shouldBuildRoadOnTile(tile: Tile): Boolean {
+        if (tile.isMarkedForCreatesOneImprovement()) return false
         if (tile.roadIsPillaged) return true
         return !tile.isCityCenter() // Can't build road on city tiles
             // Special case for civs that treat forest/jungles as roads (inside their territory). We shouldn't build if railroads aren't unlocked.

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -77,10 +77,12 @@ class WorkerAutomation(
      */
     fun automateWorkerAction(unit: MapUnit, dangerousTiles: HashSet<Tile>) = timeThis<Unit>("automateWorkerAction") {
         val currentTile = unit.getTile()
+        val currentTileIsCreatesOneImprovementMarker = currentTile.isMarkedForCreatesOneImprovement()
         // Must be called before any getPriority checks to guarantee the local road cache is processed
         val citiesToConnect = roadBetweenCitiesAutomation.getNearbyCitiesToConnect(unit)
         // Shortcut, we are working a suitable tile, and we're better off minimizing worker-turns by finishing everything on this tile
-        if (currentTile.improvementInProgress != null && !dangerousTiles.contains(currentTile)
+        if (!currentTileIsCreatesOneImprovementMarker
+            && currentTile.improvementInProgress != null && !dangerousTiles.contains(currentTile)
             && getFullPriority(unit.getTile(), unit) >= 2) {
             return
         }
@@ -91,7 +93,7 @@ class WorkerAutomation(
             return
         }
 
-        if (currentTile.improvementInProgress != null) return // we're working!
+        if (!currentTileIsCreatesOneImprovementMarker && currentTile.improvementInProgress != null) return // we're working!
 
         if (tileToWork == currentTile && tileHasWorkToDo(currentTile, unit)) 
             return startWorkOnCurrentTile(unit)
@@ -264,6 +266,7 @@ class WorkerAutomation(
         unit: MapUnit
     ): Boolean {
         if (tile in tilesToAvoid) return false
+        if (tile.isMarkedForCreatesOneImprovement()) return false
         if (!(tile == currentTile
                     || (unit.isCivilian() && (tile.civilianUnit == null || !tile.civilianUnit!!.cache.hasUniqueToBuildImprovements))
                     || (unit.isMilitary() && (tile.militaryUnit == null || !tile.militaryUnit!!.cache.hasUniqueToBuildImprovements))))
@@ -381,6 +384,7 @@ class WorkerAutomation(
           tile: Tile, 
           ignoreImprovements: Sequence<TileImprovement> = NO_IGNORED_IMPROVEMENTS
     ): TileImprovement? = timeThis("chooseImprovement") {
+        if (tile.isMarkedForCreatesOneImprovement()) return null
         // You can keep working on half-built improvements, even if they're unique to another civ
         if (tile.improvementInProgress != null) return ruleSet.tileImprovements[tile.improvementInProgress]
 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -440,7 +440,9 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             .mapNotNullTo(hashSetOf()) { it.getImprovementToCreate(city.getRuleset(), city.civ)?.name }
 
         for (tile in markedTiles) {
-            val improvementInProgress = tile.improvementInProgress!!
+            val improvementInProgress = checkNotNull(tile.improvementInProgress) {
+                "Tile ${tile.position} is marked for ${UniqueType.CreatesOneImprovement.name} without an improvement in progress"
+            }
             if (improvementInProgress !in improvementsInQueue)
                 tile.improvementFunctions.removeCreatesOneImprovementMarker(removeConstruction = false)
         }

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -413,8 +413,11 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
                 if (stockpileCosts.any { (resourceName, amount) ->
                             civResources[resourceName] == null
-                                    || amount > civResources[resourceName]!! })
+                                    || amount > civResources[resourceName]!! }) {
+                    if (construction is Building)
+                        removeImprovementForBuilding(construction)
                     continue // Removes this construction from the queue
+                }
             }
             if (construction.isBuildable(this))
                 constructionQueue.add(constructionName)
@@ -422,6 +425,22 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                 removeImprovementForBuilding(construction)
         }
         chooseNextConstruction()
+        validateCreatesOneImprovementMarkers()
+    }
+
+    /** Remove orphaned [UniqueType.CreatesOneImprovement] markers whose queue entry was removed elsewhere. */
+    private fun validateCreatesOneImprovementMarkers() {
+        val improvementsInQueue = constructionQueue.asSequence()
+            .map { getConstruction(it) as? Building }
+            .mapNotNull { it?.getImprovementToCreate(city.getRuleset(), city.civ)?.name }
+            .toHashSet()
+
+        for (tile in city.getTiles()) {
+            if (!tile.isMarkedForCreatesOneImprovement()) continue
+            val improvementInProgress = tile.improvementInProgress ?: continue
+            if (improvementInProgress !in improvementsInQueue)
+                tile.stopWorkingOnImprovement()
+        }
     }
 
     fun validateInProgressConstructions() {

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -430,16 +430,19 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     /** Remove orphaned [UniqueType.CreatesOneImprovement] markers whose queue entry was removed elsewhere. */
     private fun validateCreatesOneImprovementMarkers() {
-        val improvementsInQueue = constructionQueue.asSequence()
-            .map { getConstruction(it) as? Building }
-            .mapNotNull { it?.getImprovementToCreate(city.getRuleset(), city.civ)?.name }
-            .toHashSet()
+        val markedTiles = city.getTiles()
+            .filter { it.isMarkedForCreatesOneImprovement() }
+            .toList()
+        if (markedTiles.isEmpty()) return
 
-        for (tile in city.getTiles()) {
-            if (!tile.isMarkedForCreatesOneImprovement()) continue
-            val improvementInProgress = tile.improvementInProgress ?: continue
+        val improvementsInQueue = constructionQueue.asSequence()
+            .mapNotNull { getConstruction(it) as? Building }
+            .mapNotNullTo(hashSetOf()) { it.getImprovementToCreate(city.getRuleset(), city.civ)?.name }
+
+        for (tile in markedTiles) {
+            val improvementInProgress = tile.improvementInProgress!!
             if (improvementInProgress !in improvementsInQueue)
-                tile.stopWorkingOnImprovement()
+                tile.improvementFunctions.removeCreatesOneImprovementMarker(removeConstruction = false)
         }
     }
 
@@ -488,7 +491,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
     private fun removeImprovementForBuilding(building: Building){
         val improvementToCreate = building.getImprovementToCreate(city.getRuleset(), city.civ) ?: return
         val tile = city.getTiles().firstOrNull { it.isMarkedForCreatesOneImprovement(improvementToCreate.name) }
-        tile?.improvementFunctions?.removeCreatesOneImprovementMarker()
+        tile?.improvementFunctions?.removeCreatesOneImprovementMarker(removeConstruction = false)
     }
 
     private fun constructionBegun(construction: IConstruction) {
@@ -873,10 +876,13 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     /** Add [construction] to the end or top (controlled by [addToTop]) of the queue with all checks (does nothing if not possible)
      *
+     *  @param tile Supports [UniqueType.CreatesOneImprovement] the tile to place the improvement from that unique on.
+     *      Required when adding such a building without an existing marker.
      *  Note: Overload with string parameter `constructionName` exists as well.
      */
-    fun addToQueue(construction: IConstruction, addToTop: Boolean = false) {
+    fun addToQueue(construction: IConstruction, addToTop: Boolean = false, tile: Tile? = null) {
         if (!canAddToQueue(construction)) return
+        markTileForCreatesOneImprovement(construction, tile)
         val constructionName = construction.name
         when {
             isQueueEmptyOrIdle() ->
@@ -899,11 +905,25 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         currentConstructionIsUserSet = true
     }
 
+    private fun markTileForCreatesOneImprovement(construction: IConstruction, tile: Tile?) {
+        val improvementToCreate = (construction as? Building)?.getImprovementToCreate(city.getRuleset(), city.civ)
+            ?: return
+        if (getTileForImprovement(improvementToCreate.name) != null) return
+
+        val tileForImprovement = requireNotNull(tile) {
+            "Cannot queue ${construction.name} without a target tile for ${UniqueType.CreatesOneImprovement.name}"
+        }
+        require(tileForImprovement.improvementFunctions.canBuildImprovement(improvementToCreate, city.state)) {
+            "Cannot queue ${construction.name}: ${improvementToCreate.name} cannot be built on ${tileForImprovement.position}"
+        }
+        tileForImprovement.improvementFunctions.markForCreatesOneImprovement(improvementToCreate.name)
+    }
+
     /** Add a construction named [constructionName] to the end of the queue with all checks
      *
      *  Note: Delegates to overload with `construction` parameter.
      */
-    fun addToQueue(constructionName: String) = addToQueue(getConstruction(constructionName))
+    fun addToQueue(constructionName: String, tile: Tile? = null) = addToQueue(getConstruction(constructionName), tile = tile)
 
     /** Remove one entry from the queue by index.
      *  @param automatic  If this was done automatically, we should automatically try to choose a new construction and treat it as such
@@ -916,7 +936,9 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         if (construction is Building) {
             val improvement = construction.getImprovementToCreate(city.getRuleset(), city.civ)
             if (improvement != null) {
-                getTileForImprovement(improvement.name)?.stopWorkingOnImprovement()
+                getTileForImprovement(improvement.name)
+                    ?.improvementFunctions
+                    ?.removeCreatesOneImprovementMarker(removeConstruction = false)
             }
         }
 
@@ -1005,7 +1027,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         val improvement = building.getImprovementToCreate(city.getRuleset(), city.civ)
             ?: return
         val tileForImprovement = getTileForImprovement(improvement.name) ?: return
-        tileForImprovement.stopWorkingOnImprovement()  // clears mark
+        tileForImprovement.improvementFunctions.removeCreatesOneImprovementMarker(removeConstruction = false)
         if (removeOnly) return
         tileForImprovement.setImprovement(improvement, city.civ)
         // If bought the worldscreen will not have been marked to update, and the new improvement won't show until later...

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -1083,6 +1083,7 @@ class Tile : IsPartOfGameInfoSerialization {
 
     /** Clears [improvementQueue] */
     fun stopWorkingOnImprovement() {
+        if (isMarkedForCreatesOneImprovement()) return
         improvementQueue.clear()
     }
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -1076,6 +1076,7 @@ class Tile : IsPartOfGameInfoSerialization {
     }
 
     fun startWorkingOnImprovement(improvement: TileImprovement, civInfo: Civilization, unit: MapUnit) {
+        if (isMarkedForCreatesOneImprovement()) return
         improvementQueue.clear()
         queueImprovement(improvement, civInfo, unit)
     }

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -329,15 +329,17 @@ class TileImprovementFunctions(val tile: Tile) {
 
     /** Marks tile as target tile for a building with a [UniqueType.CreatesOneImprovement] unique */
     fun markForCreatesOneImprovement(improvement: String) {
-        tile.stopWorkingOnImprovement()
+        tile.improvementQueue.clear()
         tile.queueImprovement(improvement, -1)
     }
 
-    /** Un-Marks a tile as target tile for a building with a [UniqueType.CreatesOneImprovement] unique,
-     *  and ensures that matching queued buildings are removed. */
-    fun removeCreatesOneImprovementMarker() {
+    /** Un-Marks a tile as target tile for a building with a [UniqueType.CreatesOneImprovement] unique.
+     *  @param removeConstruction whether to also remove the matching queued building. */
+    fun removeCreatesOneImprovementMarker(removeConstruction: Boolean = true) {
         if (!tile.isMarkedForCreatesOneImprovement()) return
-        tile.owningCity?.cityConstructions?.removeCreateOneImprovementConstruction(tile.improvementInProgress!!)
-        tile.stopWorkingOnImprovement()
+        val improvementInProgress = tile.improvementInProgress!!
+        tile.improvementQueue.clear()
+        if (removeConstruction)
+            tile.owningCity?.cityConstructions?.removeCreateOneImprovementConstruction(improvementInProgress)
     }
 }

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -337,7 +337,9 @@ class TileImprovementFunctions(val tile: Tile) {
      *  @param removeConstruction whether to also remove the matching queued building. */
     fun removeCreatesOneImprovementMarker(removeConstruction: Boolean = true) {
         if (!tile.isMarkedForCreatesOneImprovement()) return
-        val improvementInProgress = tile.improvementInProgress!!
+        val improvementInProgress = checkNotNull(tile.improvementInProgress) {
+            "Cannot remove ${UniqueType.CreatesOneImprovement.name} marker from ${tile.position} without an improvement in progress"
+        }
         tile.improvementQueue.clear()
         if (removeConstruction)
             tile.owningCity?.cityConstructions?.removeCreateOneImprovementConstruction(improvementInProgress)

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -487,8 +487,10 @@ class CityScreen(
                     // might get a bit fragile if several buildings constructing the same improvement type
                     // were to be allowed in the queue - or a little nontransparent to the user why they
                     // won't reorder - maybe one day redesign to have the target tiles attached to queue entries.
-                    tileInfo.improvementFunctions.markForCreatesOneImprovement(improvement.name)
-                    city.cityConstructions.addToQueue(pickTileData.building.name)
+                    if (city.cityConstructions.canAddToQueue(pickTileData.building)) {
+                        city.cityConstructions.addToQueue(pickTileData.building.name)
+                        tileInfo.improvementFunctions.markForCreatesOneImprovement(improvement.name)
+                    }
                 }
             }
             update()

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -483,14 +483,7 @@ class CityScreen(
                 if (pickTileData.isBuying) {
                     BuyButtonFactory(this).askToBuyConstruction(pickTileData.building, pickTileData.buyStat, tileInfo)
                 } else {
-                    // This way to store where the improvement a CreatesOneImprovement Building will create goes
-                    // might get a bit fragile if several buildings constructing the same improvement type
-                    // were to be allowed in the queue - or a little nontransparent to the user why they
-                    // won't reorder - maybe one day redesign to have the target tiles attached to queue entries.
-                    if (city.cityConstructions.canAddToQueue(pickTileData.building)) {
-                        city.cityConstructions.addToQueue(pickTileData.building.name)
-                        tileInfo.improvementFunctions.markForCreatesOneImprovement(improvement.name)
-                    }
+                    city.cityConstructions.addToQueue(pickTileData.building, tile = tileInfo)
                 }
             }
             update()

--- a/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
+++ b/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
@@ -11,6 +11,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -358,6 +359,55 @@ internal class WorkerAutomationTest {
             "Repair", currentTile.improvementInProgress
         )
         assertTrue(currentTile.turnsToImprovement > 0)
+    }
+
+
+    @Test
+    fun `automated workers should not target CreatesOneImprovement markers`() {
+        civInfo.tech.techsResearched.add(testGame.ruleset.tileImprovements["Farm"]!!.techRequired!!)
+        val city = testGame.addCity(civInfo, testGame.tileMap[0,0])
+
+        val workerTile = city.getCenterTile()
+        val markedTile = testGame.tileMap[1,1]
+        markedTile.baseTerrain = Constants.grassland
+        markedTile.improvementFunctions.markForCreatesOneImprovement("Farm")
+
+        val worker = testGame.addUnit("Worker", civInfo, workerTile)
+        worker.currentMovement = 2f
+
+        workerAutomation.automateWorkerAction(worker, hashSetOf())
+
+        assertNotEquals(
+            "Automated worker should not move onto a CreatesOneImprovement marker",
+            markedTile,
+            worker.getTile()
+            )
+        assertTrue(
+            "CreatesOneImprovement marker should remain on the district tile",
+            markedTile.isMarkedForCreatesOneImprovement()
+            )
+        assertEquals("Automated worker should leave CreatesOneImprovement marker unchanged",
+            "Farm", markedTile.improvementInProgress)
+        assertEquals("Automated worker should not convert CreatesOneImprovement marker into normal worker progress",
+            -1, markedTile.turnsToImprovement)
+    }
+
+    @Test
+    fun `worker orders should not overwrite CreatesOneImprovement markers`() {
+        civInfo.tech.techsResearched.add(testGame.ruleset.tileImprovements["Farm"]!!.techRequired!!)
+        testGame.addCity(civInfo, testGame.tileMap[0,0])
+
+        val markedTile = testGame.tileMap[1,1]
+        markedTile.baseTerrain = Constants.grassland
+        markedTile.improvementFunctions.markForCreatesOneImprovement("Farm")
+
+        val worker = testGame.addUnit("Worker", civInfo, markedTile)
+        val farm = testGame.ruleset.tileImprovements["Farm"]!!
+
+        markedTile.startWorkingOnImprovement(farm, civInfo, worker)
+
+        assertEquals("Farm", markedTile.improvementInProgress)
+        assertEquals(-1, markedTile.turnsToImprovement)
     }
 
 

--- a/tests/src/com/unciv/logic/city/CityTest.kt
+++ b/tests/src/com/unciv/logic/city/CityTest.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.city
 
+import com.unciv.Constants
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.HexCoord
 import com.unciv.testing.GdxTestRunner
@@ -94,5 +95,51 @@ class CityTest {
         assertTrue(capitalCity.hasSoldBuildingThisTurn)
     }
 
+    @Test
+    fun `should mark selected tile when queueing CreatesOneImprovement building`() {
+        val farm = testGame.ruleset.tileImprovements["Farm"]!!
+        testCiv.tech.techsResearched.add(farm.techRequired!!)
+        val building = createFarmPlacingBuilding()
+        val targetTile = testGame.getTile(1, 1)
+        targetTile.baseTerrain = Constants.grassland
+
+        capitalCity.cityConstructions.addToQueue(building, tile = targetTile)
+
+        assertTrue(capitalCity.cityConstructions.isBeingConstructedOrEnqueued(building.name))
+        assertTrue(targetTile.isMarkedForCreatesOneImprovement("Farm"))
+    }
+
+    @Test
+    fun `should require selected tile when queueing CreatesOneImprovement building`() {
+        val building = createFarmPlacingBuilding()
+
+        try {
+            capitalCity.cityConstructions.addToQueue(building)
+            fail("Expected queueing a CreatesOneImprovement building without a tile to fail")
+        } catch (ex: IllegalArgumentException) {
+            assertTrue(ex.message!!.contains("target tile"))
+        }
+
+        assertFalse(capitalCity.cityConstructions.isBeingConstructedOrEnqueued(building.name))
+    }
+
+    @Test
+    fun `should clear marker when removing CreatesOneImprovement building from queue`() {
+        val farm = testGame.ruleset.tileImprovements["Farm"]!!
+        testCiv.tech.techsResearched.add(farm.techRequired!!)
+        val building = createFarmPlacingBuilding()
+        val targetTile = testGame.getTile(1, 1)
+        targetTile.baseTerrain = Constants.grassland
+        capitalCity.cityConstructions.addToQueue(building, tile = targetTile)
+
+        capitalCity.cityConstructions.removeFromQueue(0, false)
+
+        assertFalse(targetTile.isMarkedForCreatesOneImprovement())
+        assertFalse(capitalCity.cityConstructions.isBeingConstructedOrEnqueued(building.name))
+    }
+
+    private fun createFarmPlacingBuilding() =
+        testGame.createBuilding("Creates a [Farm] improvement on a specific tile")
+            .apply { ruleset = testGame.ruleset }
 
 }


### PR DESCRIPTION
## Summary

Fixes an issue where automation could orphan `CreatesOneImprovement` construction markers, leaving tiles permanently stuck as “Under construction”.

This was observed in Civ6-mod with districts such as Entertainment Complex, Campus, and Neighbourhood. These districts use `CreatesOneImprovement` to mark a selected tile while the city is constructing the matching district building.

## Problem

Worker automation can treat a `CreatesOneImprovement` marker as a normal in-progress tile improvement.

In testing, pressing **Move automated units** while a district was queued could cause the district to disappear from the city queue while the selected tile remained marked as under construction. The tile then stayed blocked and the district had to be built somewhere else.

The issue was reproducible when an automated worker was close enough to include the district tile in its worker automation search range. A worker one tile farther away did not trigger the bug.

## Cause

`CreatesOneImprovement` district markers are stored on the tile as an improvement in progress, but they are owned by city construction rather than worker automation.

Worker automation currently checks for `improvementInProgress` and can treat that tile as a normal half-built worker improvement. This can desynchronize the tile marker from the city construction queue.

## Changes

This PR adds protections around `CreatesOneImprovement` markers:

* Worker automation ignores tiles marked for `CreatesOneImprovement`.
* Road automation avoids using `CreatesOneImprovement` marker tiles as worker road targets.
* Worker-style improvement starts are prevented from overwriting `CreatesOneImprovement` markers.
* City construction validation clears orphaned `CreatesOneImprovement` markers when no matching queued construction remains.
* City screen placement avoids marking a tile if the matching construction can no longer be queued.
* Adds test coverage for automated workers not targeting `CreatesOneImprovement` markers.

## Testing

Validated with automated and in-game testing.

Automated tests:

```bash
./gradlew compileKotlin
./gradlew test
```

Both pass.

In-game verification:

* Loaded a Civ6-mod save where the issue was reproducible.
* Queued `Entertainment Complex District`.
* Selected the district tile.
* Placed automated Worker 2 inside the previous trigger range.
* Pressed **Move automated units**.
* Confirmed the district no longer disappeared from the city queue.
* Confirmed the tile no longer became orphaned as `Entertainment Complex (Under construction)`.
* Continued testing and confirmed the district completed normally.

Before this patch, the same scenario caused the tile to become stuck under construction while the city stopped building the district.
