### PR TITLE
Fix missing newline in advanced game settings

### DIFF
--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -239,7 +239,7 @@ class GameOptionsTable(
             popup.open()
             popup.update()
         }
-        add(button)
+        add(button).row()
     }
 
     private fun numberOfMajorCivs() = ruleset.nations.values.count {


### PR DESCRIPTION
Before:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9c9c7c59-33f8-4820-b8ae-554aab87a666" />

After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/44d31c9f-4f82-42d3-8850-91adcc5c1fe2" />
