### PR TITLE
chore: Public run config for FasterUIDevelopment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,8 @@ android/release/
 
 # Transient Unciv files
 android/assets/GameSettings.json
-/android/assets/ModListCache.json
+android/assets/FasterUIDevSettings.json
+android/assets/ModListCache.json
 android/assets/lasterror.txt
 android/assets/fonts/
 android/assets/maps/

--- a/.run/FasterUIDevelopment.run.xml
+++ b/.run/FasterUIDevelopment.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="FasterUIDevelopment" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.unciv.dev.FasterUIDevelopment" />
+    <module name="Unciv.tests.test" />
+    <option name="VM_PARAMETERS" value="-Xmx2048m -Xms256m -XX:MaxMetaspaceSize=256m" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$/android/assets" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
... and git-exclude the separate settings file it uses.

Not many devs will use it, but recreating it was a bit of a hassle just now, so maybe?