### PR TITLE
Context menu indicators for existing context menus

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -872,6 +872,7 @@ Reset tutorials =
 Do you want to reset completed tutorials? = 
 Reset = 
 
+Show long-press indicators = 
 Show zoom buttons in world screen = 
 Experimental = 
 Experimental Demographics scoreboard = 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -59,6 +59,15 @@ class GameSettings {
     var tutorialsShown = HashSet<String>()
     var tutorialTasksCompleted = HashSet<String>()
 
+    enum class LongPressIndicatorSetting {
+        Default, Off, Debug; // Debug only offered on Debug page of Options
+        fun toBoolean() = this == Default
+        companion object {
+            fun of(bool: Boolean) = if (bool) Default else Off
+        }
+    }
+    var showLongPressIndicators = LongPressIndicatorSetting.Default
+
     var soundEffectsVolume = 0.5f
     var citySoundsVolume = 0.5f
     var musicVolume = 0.5f

--- a/core/src/com/unciv/ui/components/UncivTooltip.kt
+++ b/core/src/com/unciv/ui/components/UncivTooltip.kt
@@ -22,6 +22,7 @@ import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.KeyboardBindings
 import com.unciv.ui.components.widgets.ColorMarkupLabel
+import com.unciv.ui.popups.AnimatedMenuPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
 
 /**
@@ -311,6 +312,8 @@ class UncivTooltip <T: Actor>(
                 tip.hide(true)
                 removeListener(tip)
             }
+            if (this !is Group) return
+            children.filter { it.name == AnimatedMenuPopup.indicatorAndroid }.forEach { it.remove() }
         }
 
         /**

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -2,7 +2,6 @@ package com.unciv.ui.components.extensions
 
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.graphics.Colors
 import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.TextureData
 import com.badlogic.gdx.graphics.glutils.FileTextureData
@@ -541,7 +540,7 @@ fun TextureData.getReadonlyPixmap(): Pixmap {
     return field.get(this) as Pixmap
 }
 
-fun <T: Actor>Stack.addInTable(actor: T): Cell<T> {
+fun <T: Actor> Stack.addInTable(actor: T): Cell<T> {
     val table = Table()
     add(table)
     return table.add(actor).grow()

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -545,3 +545,11 @@ fun <T: Actor> Stack.addInTable(actor: T): Cell<T> {
     add(table)
     return table.add(actor).grow()
 }
+
+/** Recursively return all children of a Group, depth-first */
+fun Group.allChildren(): Sequence<Actor> = sequence {
+    for (child in children) {
+        if (child is Group) yieldAll(child.allChildren())
+        yield(child)
+    }
+}

--- a/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
+++ b/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
@@ -15,6 +15,8 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.utils.Layout
 import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable
 import com.badlogic.gdx.utils.Align
+import com.unciv.UncivGame
+import com.unciv.models.metadata.GameSettings.LongPressIndicatorSetting
 import com.unciv.ui.components.SmallButtonStyle
 import com.unciv.ui.components.UncivTooltip
 import com.unciv.ui.components.UncivTooltip.Companion.getEdgePoint
@@ -137,10 +139,13 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
 
 
     private object Helpers {
-        fun addIndicator(actor: Group, indicatorMinSizeRelative: Float) =
-            if (Gdx.app.type == Application.ApplicationType.Android)
+        fun addIndicator(actor: Group, indicatorMinSizeRelative: Float) {
+            val setting = UncivGame.Current.settings.showLongPressIndicators
+            if (setting == LongPressIndicatorSetting.Off) return
+            if (setting == LongPressIndicatorSetting.Debug || Gdx.app.type == Application.ApplicationType.Android)
                 addIndicatorAndroid(actor, indicatorMinSizeRelative)
             else addIndicatorDesktop(actor, indicatorMinSizeRelative)
+        }
 
         private fun getIndicatorSize(actor: Group, indicatorMinSizeRelative: Float): Float {
             val actorHeight = (actor as? Layout)?.prefHeight ?: actor.height

--- a/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
+++ b/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
@@ -44,7 +44,7 @@ import com.unciv.utils.Concurrency
  *  inverting the fade-and-scale-in. Callbacks registered with [Popup.closeListeners] will run before the animation starts.
  *  Use [afterCloseCallback] instead if you need a notification after the animation finishes and the Popup is cleaned up.
  *
- *  Using the new constructor taking a target [Actor], it will receive a decoration symbol over its bottom right,
+ *  Using the new `onRightClick` replacement [addContextMenu], the target actor will receive a decoration symbol over its bottom right,
  *  permanent on Android but on hover only on desktop.
  */
 open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, Scrollability.None) {
@@ -91,7 +91,7 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
      *  @param actor Target [Actor]. This popup will be shown centered relative to it, and it will get a visual indicator.
      */
     @Suppress("deprecation")
-    constructor(stage: Stage, actor: Group, align: Int = Align.topRight) : this(stage, actor.getAlignedPosition(align))
+    constructor(stage: Stage, actor: Actor, align: Int = Align.topRight) : this(stage, actor.getAlignedPosition(align))
 
     private val container: Container<Table> = Container()
     private val animationDuration = 0.33f

--- a/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
+++ b/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
@@ -75,8 +75,8 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
      *  @param stage The stage this will be shown on, passed to Popup and used for clamping **`position`**
      *  @param position stage coordinates to show this centered over - clamped so that nothing is clipped outside the [stage]
      */
-    @Deprecated("Use the constructor taking a target actor instead.") // TODO remove deprecation and make ctor private
-    constructor(stage: Stage, position: Vector2) : this(stage) {
+    @Suppress("unused") // False positive
+    private constructor(stage: Stage, position: Vector2) : this(stage) {
         clickBehindToClose = true
         keyShortcuts.add(KeyCharAndCode.BACK) { close() }
         innerTable.remove()
@@ -90,7 +90,6 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
      *  @param stage The stage this will be shown on, passed to Popup and used for clamping **`position`**
      *  @param actor Target [Actor]. This popup will be shown centered relative to it, and it will get a visual indicator.
      */
-    @Suppress("deprecation")
     constructor(stage: Stage, actor: Actor, align: Int = Align.topRight) : this(stage, actor.getAlignedPosition(align))
 
     private val container: Container<Table> = Container()

--- a/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
+++ b/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
@@ -60,11 +60,6 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
         private const val indicatorXOffsetRelativeDesktop = 0.35f
         private val indicatorColor = Color.WHITE
 
-        /** Get stage coords of an [actor]'s top right corner, to help position an [AnimatedMenuPopup].
-         *  Note the Popup will center over this point.
-         */
-        fun getActorTopRight(actor: Actor): Vector2 = actor.getAlignedPosition(Align.topRight)
-
         private fun Actor.getAlignedPosition(align: Int) = localToStageCoordinates(getEdgePoint(align))
 
         fun Group.addContextMenu(indicatorMinSizeRelative: Float = 0.5f, factory: () -> AnimatedMenuPopup) {

--- a/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
+++ b/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
@@ -20,6 +20,7 @@ import com.unciv.models.metadata.GameSettings.LongPressIndicatorSetting
 import com.unciv.ui.components.SmallButtonStyle
 import com.unciv.ui.components.UncivTooltip
 import com.unciv.ui.components.UncivTooltip.Companion.getEdgePoint
+import com.unciv.ui.components.extensions.allChildren
 import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.KeyCharAndCode
@@ -51,7 +52,7 @@ import com.unciv.utils.Concurrency
  */
 open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, Scrollability.None) {
     companion object {
-        private const val indicatorAndroid = "OtherIcons/ContextMenuAvailableA"
+        const val indicatorAndroid = "OtherIcons/ContextMenuAvailableA"
         private const val indicatorDesktop = "OtherIcons/ContextMenuAvailableD"
         private const val maxIndicatorSize = 32f
         // These are partially to take up the "slack" inside the texture
@@ -65,6 +66,12 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
         fun Group.addContextMenu(indicatorMinSizeRelative: Float = 0.5f, factory: () -> AnimatedMenuPopup) {
             Helpers.addIndicator(this, indicatorMinSizeRelative)
             onRightClick { factory() }
+        }
+
+        fun Group.adjustContextMenuIndicators() {
+            for (icon in allChildren().filter { it.name == indicatorAndroid }) {
+                Helpers.adjustPosition(icon)
+            }
         }
     }
 
@@ -142,6 +149,14 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
             else addIndicatorDesktop(actor, indicatorMinSizeRelative)
         }
 
+        fun adjustPosition(actor: Actor) {
+            val setting = UncivGame.Current.settings.showLongPressIndicators
+            if (setting == LongPressIndicatorSetting.Off) return
+            if (setting != LongPressIndicatorSetting.Debug && Gdx.app.type == Application.ApplicationType.Android) return
+            val x = actor.parent.width + actor.width * indicatorXOffsetRelativeAndroid
+            actor.setPosition(x , 0f, Align.bottomRight)
+        }
+
         private fun getIndicatorSize(actor: Group, indicatorMinSizeRelative: Float): Float {
             val actorHeight = (actor as? Layout)?.prefHeight ?: actor.height
             return maxIndicatorSize.coerceAtMost(actorHeight * indicatorMinSizeRelative)
@@ -149,9 +164,11 @@ open class AnimatedMenuPopup private constructor (stage: Stage) : Popup(stage, S
 
         private fun addIndicatorAndroid(actor: Group, indicatorMinSizeRelative: Float) {
             val icon = ImageGetter.getImage(indicatorAndroid, indicatorColor)
+            icon.name = indicatorAndroid
             val size = getIndicatorSize(actor, indicatorMinSizeRelative)
             icon.setSize(size)
-            icon.setPosition(actor.width + size * indicatorXOffsetRelativeAndroid, 0f, Align.bottomRight)
+            val x = ((actor as? Layout)?.prefWidth ?: actor.width) + size * indicatorXOffsetRelativeAndroid
+            icon.setPosition(x , 0f, Align.bottomRight)
             actor.addActor(icon)
         }
 

--- a/core/src/com/unciv/ui/popups/CityScreenConstructionMenu.kt
+++ b/core/src/com/unciv/ui/popups/CityScreenConstructionMenu.kt
@@ -104,13 +104,13 @@ class CityScreenConstructionMenu(
     private fun canAddQueueTop() = construction !is PerpetualConstruction &&
         cityConstructions.canAddToQueue(construction)
             && !isConstructionImprovementCreationBuilding()
-    
+
     private fun addQueueTop() = cityConstructions.addToQueue(construction, addToTop = true)
 
     @Readonly
     private fun canAddAllQueues() = allCitiesEntryValid {
         it.canAddToQueue(construction)
-                && !isConstructionImprovementCreationBuilding() 
+                && !isConstructionImprovementCreationBuilding()
         // A Perpetual that is already queued can still be added says canAddToQueue, but here we don't want to count that
                 && !(construction is PerpetualConstruction && it.isBeingConstructedOrEnqueued(constructionName))
     }
@@ -121,7 +121,7 @@ class CityScreenConstructionMenu(
         allCitiesEntryValid {
             (it.canAddToQueue(construction) && !isConstructionImprovementCreationBuilding())
                     || it.isEnqueuedForLater(constructionName) }
-    
+
     private fun addAllQueuesTop() = forAllCities {
         val index = it.constructionQueue.indexOf(constructionName)
         if (index > 0)

--- a/core/src/com/unciv/ui/popups/CityScreenConstructionMenu.kt
+++ b/core/src/com/unciv/ui/popups/CityScreenConstructionMenu.kt
@@ -29,7 +29,7 @@ class CityScreenConstructionMenu(
     private val city: City,
     private val construction: IConstruction,
     private val onButtonClicked: () -> Unit
-) : AnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
+) : AnimatedMenuPopup(stage, positionNextTo) {
 
     // These are only readability shorteners
     private val cityConstructions = city.cityConstructions

--- a/core/src/com/unciv/ui/popups/ScrollableAnimatedMenuPopup.kt
+++ b/core/src/com/unciv/ui/popups/ScrollableAnimatedMenuPopup.kt
@@ -1,8 +1,9 @@
 package com.unciv.ui.popups
 
-import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
 import com.unciv.ui.components.widgets.AutoScrollPane
 
 /**
@@ -13,8 +14,9 @@ import com.unciv.ui.components.widgets.AutoScrollPane
  */
 abstract class ScrollableAnimatedMenuPopup(
     stage: Stage,
-    position: Vector2
-) : AnimatedMenuPopup(stage, position) {
+    actor: Actor,
+    align: Int = Align.topRight
+) : AnimatedMenuPopup(stage, actor, align) {
 
     /** The API of this Widget is moved to [createScrollableContent], [createFixedContent], [createWrapperTable]. */
     final override fun createContentTable(): Table? {

--- a/core/src/com/unciv/ui/popups/UnitUpgradeMenu.kt
+++ b/core/src/com/unciv/ui/popups/UnitUpgradeMenu.kt
@@ -41,7 +41,7 @@ class UnitUpgradeMenu(
     private val enable: Boolean,
     private val callbackAfterAnimation: Boolean = false,
     private val onButtonClicked: () -> Unit
-) : ScrollableAnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
+) : ScrollableAnimatedMenuPopup(stage, positionNextTo) {
 
     private val unitToUpgradeTo by lazy { unitAction.unitToUpgradeTo }
 

--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -25,24 +25,7 @@ internal class DebugTab(
     optionsPopup: OptionsPopup
 ): OptionsPopupTab(optionsPopup) {
     override fun lateInitialize() {
-        if (GUI.isWorldLoaded()) {
-            val simulateButton = "Simulate until turn:".toTextButton()
-            val simulateTextField = UncivTextField.Numeric("Turn", DebugUtils.SIMULATE_UNTIL_TURN, integerOnly = true)
-            val invalidInputLabel = "This is not a valid integer!".toLabel().also { it.isVisible = false }
-            simulateButton.onClick {
-                val simulateUntilTurns = simulateTextField.value?.toInt()
-                if (simulateUntilTurns == null) {
-                    invalidInputLabel.isVisible = true
-                    return@onClick
-                }
-                DebugUtils.SIMULATE_UNTIL_TURN = simulateUntilTurns
-                invalidInputLabel.isVisible = false
-                GUI.getWorldScreen().nextTurn()
-            }
-            add(simulateButton)
-            add(simulateTextField).row()
-            add(invalidInputLabel).colspan(2).row()
-        }
+        if (GUI.isWorldLoaded()) addSimulationControls()
 
         addCheckbox("Supercharged", DebugUtils::SUPERCHARGED)
         addCheckbox("View entire map", DebugUtils::VISIBLE_MAP, updateWorld = true)
@@ -87,6 +70,25 @@ internal class DebugTab(
         addSeparator()
 
         super.lateInitialize()
+    }
+
+    private fun addSimulationControls() {
+        val simulateButton = "Simulate until turn:".toTextButton()
+        val simulateTextField = UncivTextField.Numeric("Turn", DebugUtils.SIMULATE_UNTIL_TURN, integerOnly = true)
+        val invalidInputLabel = "This is not a valid integer!".toLabel().also { it.isVisible = false }
+        simulateButton.onClick {
+            val simulateUntilTurns = simulateTextField.value?.toInt()
+            if (simulateUntilTurns == null) {
+                invalidInputLabel.isVisible = true
+                return@onClick
+            }
+            DebugUtils.SIMULATE_UNTIL_TURN = simulateUntilTurns
+            invalidInputLabel.isVisible = false
+            GUI.getWorldScreen().nextTurn()
+        }
+        add(simulateButton)
+        add(simulateTextField).row()
+        add(invalidInputLabel).colspan(2).row()
     }
 
     private fun GameInfo.unlockAllTechs() {

--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.files.MapSaver
 import com.unciv.logic.files.UncivFiles
+import com.unciv.models.metadata.GameSettings
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.ui.components.extensions.addSeparator
@@ -43,6 +44,7 @@ internal class DebugTab(
         addSelectBox("Gdx Scene2D debug", BaseScreen::enableSceneDebug, SceneDebugMode.entries) { _, _ ->
             (stage as UncivStage).setSceneDebugMode()
         }
+        addSelectBox("Show long-press indicators", settings::showLongPressIndicators, GameSettings.LongPressIndicatorSetting.entries)
 
         //TODO This was wrapped then colspan(2) before - look
         addSlider("Unique misspelling threshold", RulesetCache.uniqueMisspellingThreshold, 0.0, 0.5, 0.05) { value, _ ->

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.unciv.GUI
+import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.GameSettings.ScreenSize
 import com.unciv.models.skins.SkinCache
 import com.unciv.models.tilesets.TileSetCache
@@ -52,6 +53,9 @@ internal class DisplayTab(
         addCheckbox("Show minimap", settings::showMinimap, updateWorld = true)
         addCheckbox("Show tutorials", settings.showTutorials, updateWorld = true, newRow = false) { settings.showTutorials = it }
         addResetTutorials()
+        addCheckbox("Show long-press indicators", settings.showLongPressIndicators.toBoolean()) {
+            settings.showLongPressIndicators = GameSettings.LongPressIndicatorSetting.of(it)
+        }
         addCheckbox("Show zoom buttons in world screen", settings::showZoomButtons, true)
         addCheckbox("Never close popups by clicking outside", settings::forbidPopupClickBehindToClose)
         addCheckbox("Use circles to indicate movable tiles", settings::useCirclesToIndicateMovableTiles, updateWorld = true)

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -42,10 +42,11 @@ import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
-import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.components.widgets.ColorMarkupLabel
 import com.unciv.ui.components.widgets.ExpanderTab
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.popups.AnimatedMenuPopup.Companion.addContextMenu
+import com.unciv.ui.popups.AnimatedMenuPopup.Companion.adjustContextMenuIndicators
 import com.unciv.ui.popups.CityScreenConstructionMenu
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Concurrency
@@ -164,6 +165,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         lowerTableScrollCell.maxHeight(
             (stageHeight - upperTable.height - 2 * posFromEdge).coerceAtLeast(20f)
         )
+        constructionsQueueTable.adjustContextMenuIndicators()
     }
 
     private fun updateButtons(construction: IConstruction?) {
@@ -404,6 +406,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                     updateVisualScroll()
                 }
                 lowerTable.pack()
+                availableConstructionsTable.adjustContextMenuIndicators()
             }
         }
     }
@@ -453,7 +456,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
 
         table.onClick { selectQueueEntry(constructionQueueIndex) }
         if (cityScreen.canCityBeChanged()) {
-            table.onRightClick {
+            table.addContextMenu {
                 selectQueueEntry(constructionQueueIndex) {
                     CityScreenConstructionMenu(cityScreen.stage, table, cityScreen.city, construction) {
                         cityScreen.city.reassignPopulation()
@@ -466,7 +469,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         return table
     }
 
-    private fun selectQueueEntry(constructionQueueIndex: Int, onBeforeUpdate: () -> Unit = {}) {
+    private fun <T> selectQueueEntry(constructionQueueIndex: Int, onBeforeUpdate: () -> T): T {
         if (constructionQueueIndex in 0..<cityScreen.city.cityConstructions.constructionQueue.size) {
             cityScreen.selectConstructionFromQueue(constructionQueueIndex)
             selectedQueueEntry = constructionQueueIndex
@@ -474,10 +477,12 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             cityScreen.clearSelection()
             selectedQueueEntry = -1
         }
-        onBeforeUpdate()
+        val result = onBeforeUpdate()
         cityScreen.update()  // Not before CityScreenConstructionMenu or table will have no parent to get stage coords
         ensureQueueEntryVisible()
+        return result
     }
+    private fun selectQueueEntry(constructionQueueIndex: Int) = selectQueueEntry(constructionQueueIndex) {}
 
     private fun highlightQueueEntry(queueEntry: Table, highlight: Boolean) {
         queueEntry.background =
@@ -591,7 +596,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
 
         if (!cityScreen.canCityBeChanged()) return pickConstructionButton
 
-        pickConstructionButton.onRightClick {
+        pickConstructionButton.addContextMenu {
             if (cityScreen.selectedConstruction != construction) {
                 // Ensure context is visible
                 cityScreen.selectConstruction(construction)

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -86,7 +86,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
     private val miniQueueHeight = 54f
     private val posFromEdge = CityScreen.posFromEdge
     private val stageHeight = cityScreen.stage.height
-    
+
     private val highlightColor = Color.GREEN.darken(0.4f)
 
     /** Gets or sets visibility of [both widgets][CityConstructionsTable] */
@@ -105,7 +105,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             tintColor = ImageGetter.CHARCOAL
         )
         queueExpander = ExpanderTab(
-            "Construction queue", 
+            "Construction queue",
             onChange = { cityScreen.update() },
             defaultPad = 0f,
             // keep lowerTable at fixed position
@@ -114,7 +114,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         )
 
         upperTable.defaults().left().top()
-        
+
         // The construction queue is collapsed by default, so there's more vertical space for the
         // available-constructions-table. When the user decides to expand the
         // queue, we can use the majority of available vertical space (3/4 of stage height)!
@@ -126,7 +126,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         upperTable.add(buttonsTable)
             .height("".toTextButton().height) // constant height in order to not let the lowerTable jump
             .padBottom(pad).row()
-        
+
         availableConstructionsScrollPane = ScrollPane(availableConstructionsTable.addBorder(2f, Color.WHITE))
         availableConstructionsScrollPane.setOverscroll(false, false)
         availableConstructionsTable.background = BaseScreen.skinStrings.getUiBackground(
@@ -171,7 +171,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         /** [UniqueType.MayBuyConstructionsInPuppets] support - we need a buy button for civs that could buy items in puppets */
         if (cityScreen.city.isPuppet && !cityScreen.city.getMatchingUniques(UniqueType.MayBuyConstructionsInPuppets).any()) return
         buttonsTable.clear()
-        
+
         for (button in buyButtonFactory.getBuyButtons(construction)) {
             buttonsTable.add(button).width(120f).padRight(10f)
         }
@@ -187,7 +187,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             val lowerButton = getLowerPriorityButton(selectedQueueEntry, constructionName, cityScreen.city)
             lowerButton.setEnabled(selectedQueueEntry != queue.lastIndex && cityScreen.canCityBeChanged())
             buttonsTable.add(lowerButton).padRight(5f)
-            
+
             if (cityScreen.canCityBeChanged() && !queueExpander.isOpen && selectedQueueEntry in 1..4)
                 buttonsTable.add(getRemoveFromQueueButton(selectedQueueEntry, cityScreen.city)).padLeft(10f)
         }
@@ -290,16 +290,16 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         for (entry in constructionsSequence.filter { it.shouldBeDisplayed(cityConstructions) }) {
 
             val useStoredProduction = entry is Building || !cityConstructions.isBeingConstructedOrEnqueued(entry.name)
-            
-            // this is susceptible to comodification since ANY change in unique sources - for example a new building - 
+
+            // this is susceptible to comodification since ANY change in unique sources - for example a new building -
             //   can cause comodification change
             // This is however rare enough and short enough in duration that a second run will work
             val buttonText = try {
                 cityConstructions.getTurnsToConstructionString(entry, useStoredProduction).trim()
-            } catch (ex: Exception){
+            } catch (_: Exception){
                 cityConstructions.getTurnsToConstructionString(entry, useStoredProduction).trim()
             }
-            
+
             val resourcesRequired = if (entry is BaseUnit)
                 entry.getResourceRequirementsPerTurn(city.civ.state)
                 else entry.getResourceRequirementsPerTurn(city.state)
@@ -473,7 +473,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         } else {
             cityScreen.clearSelection()
             selectedQueueEntry = -1
-        }    
+        }
         onBeforeUpdate()
         cityScreen.update()  // Not before CityScreenConstructionMenu or table will have no parent to get stage coords
         ensureQueueEntryVisible()
@@ -527,7 +527,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         val statIcons = if (construction is Building)
             " " + Stat.entries.filter { construction.isStatRelated(it, cityScreen.city) }.map { it.character }.joinToString("")
         else ""
-        
+
         val constructionNameText = "${construction.name.tr(hideIcons = true)}$statIcons"
 
         constructionTable.add(constructionNameText.toLabel(fontColor = textColor, hideIcons = true).apply { wrap=true })
@@ -689,7 +689,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             else -> UncivSound.Click
         }
     }
-    
+
     private fun getMovePriorityButton(
         arrowDirection: Int,
         binding: KeyboardBinding,
@@ -771,7 +771,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
     }
 
     private fun resizeAvailableConstructionsScrollPane() {
-        availableConstructionsScrollPane.height = 
+        availableConstructionsScrollPane.height =
             min(availableConstructionsTable.prefHeight, lowerTableScrollCell.maxHeight)
         lowerTable.pack()
     }

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
@@ -134,15 +134,13 @@ class GlobalPoliticsDiagramGroup(
         }
     }
 
-    private class DiagramLegendPopup(stage: Stage, diagram: Actor) : AnimatedMenuPopup(stage, diagram.getCenterInStageCoordinates()) {
+    private class DiagramLegendPopup(stage: Stage, diagram: Actor) : AnimatedMenuPopup(stage, diagram, Align.center) {
         init {
             touchable = Touchable.enabled
             onActivation { close() }
         }
 
         companion object {
-            private fun Actor.getCenterInStageCoordinates(): Vector2 = localToStageCoordinates(Vector2(width / 2, height / 2))
-
             const val lineWidth = 3f  // a little thicker than the actual diagram
             const val lowContrastWidth = 4f
             const val lineLength = 120f

--- a/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayMenu.kt
@@ -19,7 +19,7 @@ class AutoPlayMenu(
     positionNextTo: Actor,
     private val nextTurnButton: NextTurnButton,
     private val worldScreen: WorldScreen
-) : AnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
+) : AnimatedMenuPopup(stage, positionNextTo) {
 
     private val autoPlay: AutoPlay = worldScreen.autoPlay
 

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.unciv.logic.civilization.managers.TurnManager
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
+import com.unciv.ui.components.UncivTooltip.Companion.removeTooltips
 import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.input.KeyboardBinding
@@ -26,6 +27,7 @@ class NextTurnButton(
     private var nextTurnAction = Default
     private val unitsDueLabel = Label("", BaseScreen.skin)
     private val unitsDueCell: Cell<Label>
+
     init {
         pad(15f)
         onActivation { nextTurnAction.action(worldScreen) }
@@ -49,11 +51,10 @@ class NextTurnButton(
             }
         }
 
-        isEnabled = nextTurnAction.getText (worldScreen) == "AutoPlay"
-            || (!worldScreen.hasOpenPopups() && worldScreen.isPlayersTurn
-                && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
-        if (isEnabled) addTooltip(KeyboardBinding.NextTurn) else addTooltip("")
-        
+        isEnabled = nextTurnAction.getText(worldScreen) == "AutoPlay" ||
+            (!worldScreen.hasOpenPopups() && worldScreen.isPlayersTurn && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
+        if (isEnabled) addTooltip(KeyboardBinding.NextTurn) else removeTooltips()
+
         worldScreen.smallUnitButton.update()
     }
 
@@ -61,7 +62,7 @@ class NextTurnButton(
         label.setText(nextTurnAction.getText(worldScreen).tr())
         label.color = nextTurnAction.color
         if (nextTurnAction.icon != null && ImageGetter.imageExists(nextTurnAction.icon!!))
-            iconCell.setActor(ImageGetter.getImage(nextTurnAction.icon).apply { 
+            iconCell.setActor(ImageGetter.getImage(nextTurnAction.icon).apply {
                 setSize(30f)
                 color = nextTurnAction.color
             })
@@ -72,7 +73,7 @@ class NextTurnButton(
             unitsDueLabel.setText(it.tr())
             unitsDueCell.setActor(unitsDueLabel)
         } ?: unitsDueCell.clearActor()
-        
+
         pack()
     }
 
@@ -81,5 +82,5 @@ class NextTurnButton(
         NextTurnAction.entries.first { it.isChoice(worldScreen) }
 
     @Readonly fun isNextUnitAction(): Boolean = nextTurnAction == NextTurnAction.NextUnit
-    
+
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -11,9 +11,9 @@ import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
-import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.images.IconTextButton
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.popups.AnimatedMenuPopup.Companion.addContextMenu
 import com.unciv.ui.popups.hasOpenPopups
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.worldscreen.WorldScreen
@@ -31,7 +31,6 @@ class NextTurnButton(
     init {
         pad(15f)
         onActivation { nextTurnAction.action(worldScreen) }
-        onRightClick { NextTurnMenu(stage, this, worldScreen) }
         keyShortcuts.add(KeyboardBinding.NextTurn)
         keyShortcuts.add(KeyboardBinding.NextTurnAlternate)
         labelCell.row()
@@ -53,7 +52,12 @@ class NextTurnButton(
 
         isEnabled = nextTurnAction.getText(worldScreen) == "AutoPlay" ||
             (!worldScreen.hasOpenPopups() && worldScreen.isPlayersTurn && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
-        if (isEnabled) addTooltip(KeyboardBinding.NextTurn) else removeTooltips()
+        if (isEnabled) {
+            addTooltip(KeyboardBinding.NextTurn)
+            addContextMenu { NextTurnMenu(stage, this, worldScreen) }
+        } else {
+            removeTooltips()
+        }
 
         worldScreen.smallUnitButton.update()
     }

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -31,7 +31,7 @@ class NextTurnButton(
     init {
         pad(15f)
         onActivation { nextTurnAction.action(worldScreen) }
-        onRightClick { NextTurnMenu(stage, this, this, worldScreen) }
+        onRightClick { NextTurnMenu(stage, this, worldScreen) }
         keyShortcuts.add(KeyboardBinding.NextTurn)
         keyShortcuts.add(KeyboardBinding.NextTurnAlternate)
         labelCell.row()

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
@@ -9,10 +9,9 @@ import com.unciv.ui.screens.worldscreen.WorldScreen
 
 class NextTurnMenu(
     stage: Stage,
-    positionNextTo: Actor,
-    private val nextTurnButton: NextTurnButton,
+    nextTurnButton: NextTurnButton,
     private val worldScreen: WorldScreen
-) : AnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
+) : AnimatedMenuPopup(stage, nextTurnButton) {
 
     init {
         // We need to activate the end turn button again after the menu closes

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
@@ -18,18 +18,17 @@ class NextTurnMenu(
         // We need to activate the end turn button again after the menu closes
         afterCloseCallback = { worldScreen.shouldUpdate = true }
     }
-    
+
     override fun createContentTable(): Table {
         val table = super.createContentTable()!!
-        table.add(getButton("Next Turn", KeyboardBinding.NextTurnMenuNextTurn) { 
-            worldScreen.nextTurn() 
+        table.add(getButton("Next Turn", KeyboardBinding.NextTurnMenuNextTurn) {
+            worldScreen.nextTurn()
         }).row()
         val automateUnitsAction = NextTurnAction.MoveAutomatedUnits
         if (automateUnitsAction.isChoice(worldScreen))
-            table.add(getButton("Move automated units", KeyboardBinding.NextTurnMenuMoveAutomatedUnits) { 
-                automateUnitsAction.action(worldScreen) 
+            table.add(getButton("Move automated units", KeyboardBinding.NextTurnMenuMoveAutomatedUnits) {
+                automateUnitsAction.action(worldScreen)
             }).row()
         return table
     }
 }
-

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
@@ -15,8 +15,8 @@ import com.unciv.ui.components.extensions.brighten
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
-import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.images.IconTextButton
+import com.unciv.ui.popups.AnimatedMenuPopup.Companion.addContextMenu
 import com.unciv.ui.popups.UnitUpgradeMenu
 import com.unciv.ui.screens.worldscreen.WorldScreen
 import yairm210.purity.annotations.Readonly
@@ -119,7 +119,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
                 // Works because our disable() extension also changes style, and because the normal click is ignored due to unitAction.action being null.
                 button.isDisabled = false
                 button.touchable = Touchable.enabled
-                button.onRightClick {
+                button.addContextMenu {
                     UnitUpgradeMenu(worldScreen.stage, button, unit, unitAction, enable = unitAction.action != null, callbackAfterAnimation = true) {
                         worldScreen.shouldUpdate = true
                     }


### PR DESCRIPTION
You've already seen how the context menu indicators look, in #14983. This adds them everywhere where they're appropriate for existing code. And since that means that the city menu will look a bit over-decorated on Android - since the indicator doesn't wait for Mouse-over - they now get a global opt-out in the settings.

One minor caveat: `AnimatedMenuPopup` is designed such that the content creator can decide on the fly that it's not needed after all - return `null` from `createContentTable`. The indicator-adding code runs well before that, so it doesn't check that case, and the hosting actor gets decorated even when the menu factory later does nothing. At the moment, I don't think the case can be triggered (in part thanks to the city construction "disable" feature) , but that may change in the future. `addContextMenu` _could_ be extended to run `createContentTable` one extra time to check for `null` - but nah, only if people complain.

This also updates the "core" of the indicators to cover more edge cases, so I'll wait with #14947 until this is done.