### PR TITLE
More robust modcheck display of loading / json parsing errors

### DIFF
--- a/core/src/com/unciv/models/ruleset/RulesetCache.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetCache.kt
@@ -89,11 +89,11 @@ object RulesetCache : HashMap<String, Ruleset>() {
             modRuleset
         } catch (ex: Exception) {
             errorLines += "Exception loading mod '${modFolder.name()}':"
-            var cause: Throwable? = ex
-            while (cause != null) {
-                errorLines += "  ${cause.localizedMessage}"
-                cause = cause.cause
-            }
+            errorLines += "  ${ex.localizedMessage}"
+            val causes = generateSequence(ex as Throwable) { it.cause }
+            val cause = causes.firstOrNull { it.message?.contains("line", true) == true }
+                ?: causes.lastOrNull { it::class.java.name.startsWith("com.badlogic.gdx") }
+            cause?.let { errorLines += "  ${it.localizedMessage}" }
             null
         }
     }


### PR DESCRIPTION
As discussed in #15001
- Pro: Space on ModCheckTab may be scarce
- Pro: The full "cause" stack has duplicates
- Con: Unforeseen circumstances may choose a suboptimal cause? Hard to imagine, that's why it selects with a fallback.
- Oh, and I did ask Claude, being careful not to trigger its ingratiating mode, to compare and offer alternate approaches...

Will merge immediately as per discussion.