### PR TITLE
Fix visual glitches caused by a Ruleset object with empty name

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/MusicControls.kt
+++ b/core/src/com/unciv/ui/components/extensions/MusicControls.kt
@@ -95,11 +95,13 @@ interface MusicControls {
     }
 
     fun Table.addMusicCurrentlyPlaying(music: MusicController) {
-        val label = WrappableLabel("", width - 10f, Color(0xffd0afff.toInt()), 16)
+        val expectedWidth = if (width == 0f) prefWidth else width
+        val label = WrappableLabel("", expectedWidth - 10f, Color(0xffd0afff.toInt()), 16, true)
         label.wrap = true
         add(label).padTop(20f).colspan(2).fillX().row()
         music.onChange {
             label.setText("Currently playing: [$it]".tr())
+            label.optimizePrefWidth()
         }
         firstAscendant(Popup::class.java)?.run {
             closeListeners.add { music.onChange(null) }

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -517,7 +517,7 @@ fun equalizeColumns(vararg tables: Table) {
             table.cells[column].run {
                 if (actor == null)
                 // Empty cells ignore minWidth, so just doing Table.add() for an empty cell in the top row will break this. Fix!
-                    setActor<Label>("".toLabel())
+                    setActor(neutralActor)
                 else if (Align.isCenterHorizontal(align)) (actor as? Label)?.run {
                     // minWidth acts like fillX, so Labels will fill and then left-align by default. Fix!
                     if (!Align.isCenterHorizontal(labelAlign))
@@ -528,6 +528,7 @@ fun equalizeColumns(vararg tables: Table) {
         table.invalidate()
     }
 }
+private val neutralActor = Actor().apply { touchable = Touchable.disabled }
 
 /** Retrieve a texture Pixmap without reload or ownership transfer, useable for read operations only.
  *

--- a/core/src/com/unciv/ui/components/fonts/FontRulesetIcons.kt
+++ b/core/src/com/unciv/ui/components/fonts/FontRulesetIcons.kt
@@ -39,7 +39,7 @@ object FontRulesetIcons {
         nextUnusedCharacterNumber = UNUSED_CHARACTER_CODES_START
 
         fun addChar(objectName: String, objectActor: Actor) {
-            if (nextUnusedCharacterNumber > UNUSED_CHARACTER_CODES_END) return
+            if (nextUnusedCharacterNumber > UNUSED_CHARACTER_CODES_END || objectName.isEmpty()) return
             val char = Char(nextUnusedCharacterNumber)
             nextUnusedCharacterNumber++
             rulesetObjectNameToChar[objectName] = char


### PR DESCRIPTION
Fixes #15006
Note: The changes in `equalizeColumns` and `addMusicCurrentlyPlaying` do fix the problem independently for their specific usecase, so with the `FontRulesetIcons` fix they're not strictly needed. They are still better than before, so I left them in.