### PR TITLE
Fix false ruleset validation positives from duplicate names

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -51,7 +51,7 @@ enum class RulesetFile(
     @Readonly val getRulesetObjects: Ruleset.() -> Sequence<IRulesetObject> = { emptySequence() },
     @Readonly val getUniques: Ruleset.() -> Sequence<Unique> = { getRulesetObjects().flatMap { it.uniqueObjects } },
     @Readonly val getINamed: Ruleset.() -> Sequence<INamed> = { getRulesetObjects() },
-    @Readonly val getNames: Ruleset.() -> Sequence<RulesetName> = { getINamed().map { it.toRulesetName(this) } }
+    @Readonly val getNames: Ruleset.() -> Sequence<RulesetName> = { getINamed().map { it.toRulesetName(this, getINamed) } }
 ) {
     Beliefs("Beliefs.json", { beliefs.values.asSequence() }),
     Buildings("Buildings.json", { buildings.values.asSequence() }),
@@ -534,14 +534,17 @@ class Ruleset {
             events += createHashmap(json().fromJsonFile(Array<Event>::class.java, eventsFile))
         }
 
-        // Tutorials exist per builtin ruleset or mod, but there's also a global file that's always loaded
-        // Note we can't rely on UncivGame.Current here, so we do the same thing getBuiltinRulesetFileHandle in RulesetCache does
-        if (Gdx.files != null) { // we're not running console mode
+        // Tutorials exist per builtin ruleset or mod, but there's also a global file that should always be loaded in a game.
+        // Note we can't rely on UncivGame.Current here, so we do the same thing getBuiltinRulesetFileHandle in RulesetCache does.
+        // Only load them when not running console mode, and only for base rulesets.
+        // (games with extensions should get them from the base, and having them loaded in all extension mods would have the
+        // extension as originRuleset in combined rulesets, not to mention wasting some memory).
+        if (modOptions.isBaseRuleset && Gdx.files != null) { // we're not running console mode
             val globalTutorialsFile = Gdx.files.internal("jsons").child(RulesetFile.Tutorials.filename)
             if (globalTutorialsFile.exists())
                 tutorials += createHashmap(json().fromJsonFile(Array<Tutorial>::class.java, globalTutorialsFile))
         }
-        
+
         val tutorialsFile = RulesetFile.Tutorials.file()
         if (tutorialsFile.exists())
             tutorials += createHashmap(json().fromJsonFile(Array<Tutorial>::class.java, tutorialsFile))

--- a/core/src/com/unciv/models/ruleset/RulesetName.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetName.kt
@@ -16,13 +16,26 @@ data class RulesetName(
 )
 
 @Readonly
-internal fun INamed.toRulesetName(ruleset: Ruleset): RulesetName =
+internal fun INamed.toRulesetName(ruleset: Ruleset, getINamed: (Ruleset.() -> Sequence<INamed>)? = null): RulesetName =
     RulesetName(
         name,
         this::class.simpleName ?: "RulesetObject",
-        (this as? IRulesetObject)?.originRuleset?.ifEmpty { ruleset.name } ?: ruleset.name
+        (this as? IRulesetObject)?.originRuleset?.ifEmpty { null } ?: findOrigin(ruleset, getINamed)
     )
 
 @Readonly
 internal fun Ruleset.rulesetName(name: String, source: String, originRuleset: String = this.name): RulesetName =
     RulesetName(name, source, originRuleset)
+
+@Readonly
+private fun INamed.findOrigin(ruleset: Ruleset, getINamed: (Ruleset.() -> Sequence<INamed>)?): String {
+    if (getINamed == null || ruleset.name.isNotEmpty())
+        return ruleset.name
+    val componentRulesets = ruleset.mods.mapNotNull { RulesetCache[it] }
+    for (i in componentRulesets.size - 1 downTo 0) { // asReversed isn't recognized as readonly
+        val componentRuleset = componentRulesets[i]
+        if (componentRuleset.getINamed().any { it.name == this.name })
+            return componentRuleset.name
+    }
+    return ""
+}

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -539,6 +539,7 @@ open class RulesetValidator protected constructor(
         val knownBenignSourceCollisions = setOf(
             setOf("BaseUnit", "UnitType"),
             setOf("BaseUnit", "Difficulty"),
+            setOf("BaseUnit", "Difficulty", "Tutorial"),
             setOf("BaseUnit", "UnitNameGroup"),
             setOf("Personality", "UnitNameGroup.unitNames"),
             setOf("Specialist", "UnitNameGroup")


### PR DESCRIPTION
The issue, example:
<img width="1621" height="1098" alt="image" src="https://github.com/user-attachments/assets/e7687764-16e2-43b6-b906-6ae7ac6b5e91" />

.. now that old mod doesn't touch specialists, tutorials, units or difficulties at all. It's flagged because
- A "benign" rule is missing
- Non-IRulesetObject things get "" as originRuleset when in a combined ruleset
- Global Tutorials lose their originRuleset when an extension mod is combined onto a base - oh! There's no need to load those in non-base mods at all!

Related: #14982