### PR TITLE
Avoid centering on non-visible wonder locations from politics overview hidden wonder locations

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -168,7 +168,7 @@ class GlobalPoliticsOverviewTable(
         for (wonder in allWorldWonders) {
             if (wonder.civ == civ) {
                 val wonderName = wonder.name.toLabel()
-                if (wonder.location != null) {
+                if (wonder.location != null && wonder.location.isVisible(viewingPlayer)) {
                     wonderName.onClick {
                         val worldScreen = UncivGame.Current.resetToWorldScreen()
                         worldScreen.mapHolder.setCenterPosition(wonder.location.position)


### PR DESCRIPTION
Fixes #15011 

### Summary

Prevents the Politics overview Wonders column from centering the map on a wonder location unless that location is currently visible to the viewing player.

### Details

The Politics overview listed wonders by owner and attached a click handler whenever `wonder.location != null`. That can expose the location of a wonder city/tile through fog of war.

This change keeps the existing display behavior, but only attaches the click-to-center action when `wonder.location.isVisible(viewingPlayer)` is true.

### Scope

I left the dedicated Wonders overview unchanged. It has a similar-looking click path, but location display there is already gated by `WonderStatus.NotFound` / `getLocationColumn()`. If you prefer an additional visibility guard there for robustness, I can add it separately.

### Testing

- `./gradlew.bat :core:compileKotlin --console=plain`