### PR TITLE
chore: FormattedLine List builder

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("kotlin")
@@ -19,4 +20,9 @@ kotlin {
 
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.compilerOptions {
+    freeCompilerArgs.set(listOf("-Xcontext-parameters"))
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -24,5 +24,5 @@ java {
 
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.compilerOptions {
-    freeCompilerArgs.set(listOf("-Xcontext-parameters"))
+    freeCompilerArgs.set(listOf("-XXLanguage:+ContextParameters"))
 }

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -5,7 +5,6 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.objectdescriptions.FormattedLineListBuilder.Companion.buildCivilopediaText
-import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import yairm210.purity.annotations.Readonly
 import java.util.*
@@ -94,6 +93,7 @@ class Speed : RulesetObject() {
 
     override fun makeLink(): String = "Speed/$name"
     override fun getCivilopediaTextHeader() = FormattedLine(name, header = 2)
+    @Readonly
     override fun getCivilopediaTextLines(ruleset: Ruleset) = buildCivilopediaText {
         add("General speed modifier: [${modifier * 100}]%${Fonts.turn}")
         add("Production cost modifier: [${productionCostModifier * 100}]%${Fonts.production}")

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -4,6 +4,7 @@ import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.objectdescriptions.FormattedLineListBuilder.Companion.buildCivilopediaText
 import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import yairm210.purity.annotations.Readonly
@@ -93,23 +94,23 @@ class Speed : RulesetObject() {
 
     override fun makeLink(): String = "Speed/$name"
     override fun getCivilopediaTextHeader() = FormattedLine(name, header = 2)
-    override fun getCivilopediaTextLines(ruleset: Ruleset) = sequence {
-        yield(FormattedLine("General speed modifier: [${modifier * 100}]%${Fonts.turn}"))
-        yield(FormattedLine("Production cost modifier: [${productionCostModifier * 100}]%${Fonts.production}"))
-        yield(FormattedLine("Gold cost modifier: [${goldCostModifier * 100}]%${Fonts.gold}"))
-        yield(FormattedLine("Science cost modifier: [${scienceCostModifier * 100}]%${Fonts.science}"))
-        yield(FormattedLine("Culture cost modifier: [${cultureCostModifier * 100}]%${Fonts.culture}"))
-        yield(FormattedLine("Faith cost modifier: [${faithCostModifier * 100}]%${Fonts.faith}"))
-        yield(FormattedLine("Improvement build length modifier: [${improvementBuildLengthModifier * 100}]%${Fonts.turn}"))
-        yield(FormattedLine("Diplomatic deal duration: [$dealDuration] turns${Fonts.turn}"))
-        yield(FormattedLine("Gold gift influence gain modifier: [${goldGiftModifier * 100}]%${Fonts.gold}"))
-        yield(FormattedLine("City-state tribute scaling interval: [${cityStateTributeScalingInterval}] turns${Fonts.turn}"))
-        yield(FormattedLine("Barbarian spawn modifier: [${barbarianModifier * 100}]%${Fonts.strength}"))
-        yield(FormattedLine("Golden age length modifier: [${goldenAgeLengthModifier * 100}]%${Fonts.happiness}"))
-        yield(FormattedLine("Adjacent city religious pressure: [$religiousPressureAdjacentCity]${Fonts.faith}"))
-        yield(FormattedLine("Peace deal duration: [$peaceDealDuration] turns${Fonts.turn}"))
-        yield(FormattedLine("Start year: [" + ("{[${abs(startYear).toInt()}] " + (if (startYear < 0) "BC" else "AD") + "}]").tr()))
-        yieldAll(uniquesToCivilopediaTextLines())
-    }.toList()
+    override fun getCivilopediaTextLines(ruleset: Ruleset) = buildCivilopediaText {
+        add("General speed modifier: [${modifier * 100}]%${Fonts.turn}")
+        add("Production cost modifier: [${productionCostModifier * 100}]%${Fonts.production}")
+        add("Gold cost modifier: [${goldCostModifier * 100}]%${Fonts.gold}")
+        add("Science cost modifier: [${scienceCostModifier * 100}]%${Fonts.science}")
+        add("Culture cost modifier: [${cultureCostModifier * 100}]%${Fonts.culture}")
+        add("Faith cost modifier: [${faithCostModifier * 100}]%${Fonts.faith}")
+        add("Improvement build length modifier: [${improvementBuildLengthModifier * 100}]%${Fonts.turn}")
+        add("Diplomatic deal duration: [$dealDuration] turns${Fonts.turn}")
+        add("Gold gift influence gain modifier: [${goldGiftModifier * 100}]%${Fonts.gold}")
+        add("City-state tribute scaling interval: [${cityStateTributeScalingInterval}] turns${Fonts.turn}")
+        add("Barbarian spawn modifier: [${barbarianModifier * 100}]%${Fonts.strength}")
+        add("Golden age length modifier: [${goldenAgeLengthModifier * 100}]%${Fonts.happiness}")
+        add("Adjacent city religious pressure: [$religiousPressureAdjacentCity]${Fonts.faith}")
+        add("Peace deal duration: [$peaceDealDuration] turns${Fonts.turn}")
+        add("Start year: [" + ("{[${abs(startYear).toInt()}] " + (if (startYear < 0) "BC" else "AD") + "}]").tr())
+        addUniques()
+    }
     override fun getSortGroup(ruleset: Ruleset): Int = (modifier * 1000).toInt()
 }

--- a/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
@@ -6,6 +6,7 @@ import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.objectdescriptions.FormattedLineListBuilder.Companion.buildCivilopediaText
+import yairm210.purity.annotations.Readonly
 
 class Difficulty : RulesetObject() {
     override lateinit var name: String
@@ -47,8 +48,10 @@ class Difficulty : RulesetObject() {
 
     override fun getSortGroup(ruleset: Ruleset) = ruleset.difficulties.keys.indexOf(name)
 
-    private fun Float.toPercent() = (this * 100).toInt()
+    @Readonly
     override fun getCivilopediaTextLines(ruleset: Ruleset) = buildCivilopediaText {
+        fun Float.toPercent() = (this * 100).toInt()
+
         add("Player settings", header = 3)
         add("{Base happiness}: $baseHappiness ${Fonts.happiness}", indent = 1)
         add("{Extra happiness per luxury}: ${extraHappinessPerLuxury.toInt()} ${Fonts.happiness}", indent = 1)

--- a/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
@@ -5,8 +5,7 @@ import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.ui.components.fonts.Fonts
-import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
-import com.unciv.ui.screens.civilopediascreen.FormattedLine
+import com.unciv.ui.objectdescriptions.FormattedLineListBuilder.Companion.buildCivilopediaText
 
 class Difficulty : RulesetObject() {
     override lateinit var name: String
@@ -49,73 +48,71 @@ class Difficulty : RulesetObject() {
     override fun getSortGroup(ruleset: Ruleset) = ruleset.difficulties.keys.indexOf(name)
 
     private fun Float.toPercent() = (this * 100).toInt()
-    override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
-        val lines = ArrayList<FormattedLine>()
-        lines += FormattedLine("Player settings", header = 3)
-        lines += FormattedLine("{Base happiness}: $baseHappiness ${Fonts.happiness}", indent = 1)
-        lines += FormattedLine("{Extra happiness per luxury}: ${extraHappinessPerLuxury.toInt()} ${Fonts.happiness}", indent = 1)
-        lines += FormattedLine("{Research cost modifier}: ${researchCostModifier.toPercent()}% ${Fonts.science}", indent = 1)
-        lines += FormattedLine("{Unit cost modifier}: ${unitCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        lines += FormattedLine("{Building cost modifier}: ${buildingCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        lines += FormattedLine("{Policy cost modifier}: ${policyCostModifier.toPercent()}% ${Fonts.culture}", indent = 1)
-        lines += FormattedLine("{Unhappiness modifier}: ${unhappinessModifier.toPercent()}%", indent = 1)
-        lines += FormattedLine("{Bonus vs. Barbarians}: ${barbarianBonus.toPercent()}% ${Fonts.strength}", indent = 1)
-        lines += FormattedLine("{Barbarian spawning delay}: $barbarianSpawnDelay", indent = 1)
+    override fun getCivilopediaTextLines(ruleset: Ruleset) = buildCivilopediaText {
+        add("Player settings", header = 3)
+        add("{Base happiness}: $baseHappiness ${Fonts.happiness}", indent = 1)
+        add("{Extra happiness per luxury}: ${extraHappinessPerLuxury.toInt()} ${Fonts.happiness}", indent = 1)
+        add("{Research cost modifier}: ${researchCostModifier.toPercent()}% ${Fonts.science}", indent = 1)
+        add("{Unit cost modifier}: ${unitCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
+        add("{Building cost modifier}: ${buildingCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
+        add("{Policy cost modifier}: ${policyCostModifier.toPercent()}% ${Fonts.culture}", indent = 1)
+        add("{Unhappiness modifier}: ${unhappinessModifier.toPercent()}%", indent = 1)
+        add("{Bonus vs. Barbarians}: ${barbarianBonus.toPercent()}% ${Fonts.strength}", indent = 1)
+        add("{Barbarian spawning delay}: $barbarianSpawnDelay", indent = 1)
 
         if (playerBonusStartingUnits.isNotEmpty()) {
-            lines += FormattedLine()
-            lines += FormattedLine("{Bonus starting units}:", indent = 1)
+            space()
+            add("{Bonus starting units}:", indent = 1)
             playerBonusStartingUnits.groupBy { it }.map {
                 it.key to it.value.size     // name to Pair.first and count to Pair.second
             }.forEach {
                 // Through a virtual Unique was the simplest way to prevent white icons showing for stuff like eraSpecificUnit
-                lines += FormattedLine(Unique(if (it.second == 1) "[${it.first}]" else "${it.second} [${it.first}]"), indent = 2)
+                add(Unique(if (it.second == 1) "[${it.first}]" else "${it.second} [${it.first}]"), indent = 2)
             }
         }
 
-        lines += FormattedLine()
-        lines += FormattedLine("AI settings", header = 3)
-        lines += FormattedLine("{AI difficulty level}: {$aiDifficultyLevel}", indent = 1)
-        lines += FormattedLine("{AI city growth modifier}: ${aiCityGrowthModifier.toPercent()}% ${Fonts.food}", indent = 1)
-        lines += FormattedLine("{AI unit cost modifier}: ${aiUnitCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        lines += FormattedLine("{AI building cost modifier}: ${aiBuildingCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        lines += FormattedLine("{AI wonder cost modifier}: ${aiWonderCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        lines += FormattedLine("{AI building maintenance modifier}: ${aiBuildingMaintenanceModifier.toPercent()}% ${Fonts.gold}", indent = 1)
-        lines += FormattedLine("{AI unit maintenance modifier}: ${aiUnitMaintenanceModifier.toPercent()}% ${Fonts.gold}", indent = 1)
-        lines += FormattedLine("{AI unhappiness modifier}: ${aiUnhappinessModifier.toPercent()}%", indent = 1)
+        space()
+        add("AI settings", header = 3)
+        add("{AI difficulty level}: {$aiDifficultyLevel}", indent = 1)
+        add("{AI city growth modifier}: ${aiCityGrowthModifier.toPercent()}% ${Fonts.food}", indent = 1)
+        add("{AI unit cost modifier}: ${aiUnitCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
+        add("{AI building cost modifier}: ${aiBuildingCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
+        add("{AI wonder cost modifier}: ${aiWonderCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
+        add("{AI building maintenance modifier}: ${aiBuildingMaintenanceModifier.toPercent()}% ${Fonts.gold}", indent = 1)
+        add("{AI unit maintenance modifier}: ${aiUnitMaintenanceModifier.toPercent()}% ${Fonts.gold}", indent = 1)
+        add("{AI unhappiness modifier}: ${aiUnhappinessModifier.toPercent()}%", indent = 1)
 
         if (aiFreeTechs.isNotEmpty()) {
-            lines += FormattedLine()
-            lines += FormattedLine("{AI free techs}:", indent = 1)
+            space()
+            add("{AI free techs}:", indent = 1)
             aiFreeTechs.forEach {
-                lines += FormattedLine(it, link = "Technology/$it", indent = 2)
+                add(it, link = "Technology/$it", indent = 2)
             }
         }
         if (aiMajorCivBonusStartingUnits.isNotEmpty()) {
-            lines += FormattedLine()
-            lines += FormattedLine("{Major AI civilization bonus starting units}:", indent = 1)
+            space()
+            add("{Major AI civilization bonus starting units}:", indent = 1)
             aiMajorCivBonusStartingUnits.groupBy { it }.map {
                 it.key to it.value.size
             }.forEach {
-                lines += FormattedLine(Unique(if (it.second == 1) "[${it.first}]" else "${it.second} [${it.first}]"), indent = 2)
+                add(Unique(if (it.second == 1) "[${it.first}]" else "${it.second} [${it.first}]"), indent = 2)
             }
         }
         if (aiCityStateBonusStartingUnits.isNotEmpty()) {
-            lines += FormattedLine()
-            lines += FormattedLine("{City state bonus starting units}:", indent = 1)
+            space()
+            add("{City state bonus starting units}:", indent = 1)
             aiCityStateBonusStartingUnits.groupBy { it }.map {
                 it.key to it.value.size
             }.forEach {
-                lines += FormattedLine(Unique(if (it.second == 1) "[${it.first}]" else "${it.second} [${it.first}]"), indent = 2)
+                add(Unique(if (it.second == 1) "[${it.first}]" else "${it.second} [${it.first}]"), indent = 2)
             }
         }
 
-        lines += FormattedLine()
-        lines += FormattedLine("{Turns until barbarians enter player tiles}: $turnBarbariansCanEnterPlayerTiles ${Fonts.turn}")
-        lines += FormattedLine("{Gold reward for clearing barbarian camps}: $clearBarbarianCampReward ${Fonts.gold}")
+        space()
+        add("{Turns until barbarians enter player tiles}: $turnBarbariansCanEnterPlayerTiles ${Fonts.turn}")
+        add("{Gold reward for clearing barbarian camps}: $clearBarbarianCampReward ${Fonts.gold}")
 
-        uniquesToCivilopediaTextLines(lines)
-        return lines
+        addUniques()
     }
 
 }

--- a/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
@@ -6,6 +6,7 @@ import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.objectdescriptions.FormattedLineListBuilder.Companion.buildCivilopediaText
+import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import yairm210.purity.annotations.Readonly
 
 class Difficulty : RulesetObject() {
@@ -49,23 +50,23 @@ class Difficulty : RulesetObject() {
     override fun getSortGroup(ruleset: Ruleset) = ruleset.difficulties.keys.indexOf(name)
 
     @Readonly
-    override fun getCivilopediaTextLines(ruleset: Ruleset) = buildCivilopediaText {
+    override fun getCivilopediaTextLines(ruleset: Ruleset) = buildCivilopediaText(defaults = FormattedLine(indent = 1)) {
         fun Float.toPercent() = (this * 100).toInt()
 
-        add("Player settings", header = 3)
-        add("{Base happiness}: $baseHappiness ${Fonts.happiness}", indent = 1)
-        add("{Extra happiness per luxury}: ${extraHappinessPerLuxury.toInt()} ${Fonts.happiness}", indent = 1)
-        add("{Research cost modifier}: ${researchCostModifier.toPercent()}% ${Fonts.science}", indent = 1)
-        add("{Unit cost modifier}: ${unitCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        add("{Building cost modifier}: ${buildingCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        add("{Policy cost modifier}: ${policyCostModifier.toPercent()}% ${Fonts.culture}", indent = 1)
-        add("{Unhappiness modifier}: ${unhappinessModifier.toPercent()}%", indent = 1)
-        add("{Bonus vs. Barbarians}: ${barbarianBonus.toPercent()}% ${Fonts.strength}", indent = 1)
-        add("{Barbarian spawning delay}: $barbarianSpawnDelay", indent = 1)
+        add("Player settings", header = 3, indent = 0)
+        add("{Base happiness}: $baseHappiness ${Fonts.happiness}")
+        add("{Extra happiness per luxury}: ${extraHappinessPerLuxury.toInt()} ${Fonts.happiness}")
+        add("{Research cost modifier}: ${researchCostModifier.toPercent()}% ${Fonts.science}")
+        add("{Unit cost modifier}: ${unitCostModifier.toPercent()}% ${Fonts.production}")
+        add("{Building cost modifier}: ${buildingCostModifier.toPercent()}% ${Fonts.production}")
+        add("{Policy cost modifier}: ${policyCostModifier.toPercent()}% ${Fonts.culture}")
+        add("{Unhappiness modifier}: ${unhappinessModifier.toPercent()}%")
+        add("{Bonus vs. Barbarians}: ${barbarianBonus.toPercent()}% ${Fonts.strength}")
+        add("{Barbarian spawning delay}: $barbarianSpawnDelay")
 
         if (playerBonusStartingUnits.isNotEmpty()) {
             space()
-            add("{Bonus starting units}:", indent = 1)
+            add("{Bonus starting units}:")
             playerBonusStartingUnits.groupBy { it }.map {
                 it.key to it.value.size     // name to Pair.first and count to Pair.second
             }.forEach {
@@ -75,26 +76,26 @@ class Difficulty : RulesetObject() {
         }
 
         space()
-        add("AI settings", header = 3)
-        add("{AI difficulty level}: {$aiDifficultyLevel}", indent = 1)
-        add("{AI city growth modifier}: ${aiCityGrowthModifier.toPercent()}% ${Fonts.food}", indent = 1)
-        add("{AI unit cost modifier}: ${aiUnitCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        add("{AI building cost modifier}: ${aiBuildingCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        add("{AI wonder cost modifier}: ${aiWonderCostModifier.toPercent()}% ${Fonts.production}", indent = 1)
-        add("{AI building maintenance modifier}: ${aiBuildingMaintenanceModifier.toPercent()}% ${Fonts.gold}", indent = 1)
-        add("{AI unit maintenance modifier}: ${aiUnitMaintenanceModifier.toPercent()}% ${Fonts.gold}", indent = 1)
-        add("{AI unhappiness modifier}: ${aiUnhappinessModifier.toPercent()}%", indent = 1)
+        add("AI settings", header = 3, indent = 0)
+        add("{AI difficulty level}: {$aiDifficultyLevel}")
+        add("{AI city growth modifier}: ${aiCityGrowthModifier.toPercent()}% ${Fonts.food}")
+        add("{AI unit cost modifier}: ${aiUnitCostModifier.toPercent()}% ${Fonts.production}")
+        add("{AI building cost modifier}: ${aiBuildingCostModifier.toPercent()}% ${Fonts.production}")
+        add("{AI wonder cost modifier}: ${aiWonderCostModifier.toPercent()}% ${Fonts.production}")
+        add("{AI building maintenance modifier}: ${aiBuildingMaintenanceModifier.toPercent()}% ${Fonts.gold}")
+        add("{AI unit maintenance modifier}: ${aiUnitMaintenanceModifier.toPercent()}% ${Fonts.gold}")
+        add("{AI unhappiness modifier}: ${aiUnhappinessModifier.toPercent()}%")
 
         if (aiFreeTechs.isNotEmpty()) {
             space()
-            add("{AI free techs}:", indent = 1)
+            add("{AI free techs}:")
             aiFreeTechs.forEach {
                 add(it, link = "Technology/$it", indent = 2)
             }
         }
         if (aiMajorCivBonusStartingUnits.isNotEmpty()) {
             space()
-            add("{Major AI civilization bonus starting units}:", indent = 1)
+            add("{Major AI civilization bonus starting units}:")
             aiMajorCivBonusStartingUnits.groupBy { it }.map {
                 it.key to it.value.size
             }.forEach {
@@ -103,7 +104,7 @@ class Difficulty : RulesetObject() {
         }
         if (aiCityStateBonusStartingUnits.isNotEmpty()) {
             space()
-            add("{City state bonus starting units}:", indent = 1)
+            add("{City state bonus starting units}:")
             aiCityStateBonusStartingUnits.groupBy { it }.map {
                 it.key to it.value.size
             }.forEach {
@@ -111,11 +112,11 @@ class Difficulty : RulesetObject() {
             }
         }
 
+        defaults(FormattedLine())
         space()
         add("{Turns until barbarians enter player tiles}: $turnBarbariansCanEnterPlayerTiles ${Fonts.turn}")
         add("{Gold reward for clearing barbarian camps}: $clearBarbarianCampReward ${Fonts.gold}")
 
         addUniques()
     }
-
 }

--- a/core/src/com/unciv/ui/objectdescriptions/FormattedLineListBuilder.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/FormattedLineListBuilder.kt
@@ -4,6 +4,10 @@ import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
+import yairm210.purity.annotations.Cache
+import yairm210.purity.annotations.InternalState
+import yairm210.purity.annotations.LocalState
+import yairm210.purity.annotations.Readonly
 
 /**
  *  A builder for use in [ICivilopediaText.getCivilopediaTextLines][com.unciv.ui.screens.civilopediascreen.ICivilopediaText.getCivilopediaTextLines].
@@ -13,52 +17,14 @@ import com.unciv.ui.screens.civilopediascreen.FormattedLine
  *      * [space] or [separator] produce a vertical spacer or a horizontal line, names chosen for clarity to distinguish from [add].
  *      * [addUniques] will add all [uniques][IHasUniques.uniques] of a [IHasUniques] receiver and is a replacement for [uniquesToCivilopediaTextLines].
  */
-class FormattedLineListBuilder(capacity: Int = 16) {
-    private val lines = ArrayList<FormattedLine>(capacity)
-
-    fun add(
-        text: String,
-        link: String = "",
-        icon: String = "",
-        header: Int = 0,
-        indent: Int = 0,
-        color: String = "",
-        starred: Boolean = false,
-        centered: Boolean = false,
-        iconCrossed: Boolean = false
-    ) = lines.add(FormattedLine(text, link, icon, header = header, indent = indent, color = color, starred = starred, centered = centered, iconCrossed = iconCrossed))
-
-    fun add(line: FormattedLine) = lines.add(line)
-    fun add(unique: Unique, indent: Int = 0) = lines.add(FormattedLine(unique, indent))
-    fun add(extraImage: String, imageSize: Float) = lines.add(FormattedLine(extraImage = extraImage, imageSize = imageSize))
-
-    fun add(separator: SeparatorType) = separator.addTo(this)
-    fun space() = lines.add(FormattedLine())
-    fun separator() = lines.add(FormattedLine(separator = true))
-
-    fun add(newLines: Iterable<FormattedLine>) = lines.addAll(newLines)
-    fun add(newLines: Sequence<FormattedLine>) = lines.addAll(newLines)
-    fun <T> add(input: Iterable<T>, transform: T.() -> FormattedLine) {
-        for (item in input)
-            add(item.transform())
-    }
-
-    context(source: IHasUniques)
-    fun addUniques(
-        leadingSeparator: SeparatorType = SeparatorType.Space,
-        colorConsumesResources: Boolean = false,
-        exclude: Unique.() -> Boolean = { false }
-    ) {
-        val orderedUniques = source.uniqueObjects.asSequence()
-            .filterNot { it.isHiddenToUsers() || it.exclude() }
-
-        for ((index, unique) in orderedUniques.withIndex()) {
-            if (index == 0) add(leadingSeparator)
-            // Optionally special-case ConsumesResources to give it a reddish color. Also ensures link always points to the resource
-            // (the other constructor guesses the first object by name in the Unique parameters).
-            if (colorConsumesResources && unique.type == UniqueType.ConsumesResources)
-                add(unique.getDisplayText(), link = "Resources/${unique.params[1]}", color = "#F42")
-            else add(unique)
+interface FormattedLineListBuilder {
+    companion object {
+        @Readonly
+        fun buildCivilopediaText(capacity: Int = 16, block: FormattedLineListBuilder.() -> Unit): List<FormattedLine> {
+            @LocalState
+            val builder = FormattedLineListBuilderImpl(capacity)
+            builder.block()
+            return builder.build()
         }
     }
 
@@ -70,14 +36,108 @@ class FormattedLineListBuilder(capacity: Int = 16) {
         }, Line {
             override fun addTo(to: FormattedLineListBuilder) { to.separator() }
         };
+        @Readonly
         internal abstract fun addTo(to: FormattedLineListBuilder)
     }
 
-    companion object {
-        fun buildCivilopediaText(capacity: Int = 16, block: FormattedLineListBuilder.() -> Unit): List<FormattedLine> {
-            val builder = FormattedLineListBuilder(capacity)
-            builder.block()
-            return builder.lines
+    @Readonly
+    fun build(): List<FormattedLine>
+
+    @Readonly
+    fun add(
+        text: String,
+        link: String = "",
+        icon: String = "",
+        header: Int = 0,
+        indent: Int = 0,
+        color: String = "",
+        starred: Boolean = false,
+        centered: Boolean = false,
+        iconCrossed: Boolean = false
+    )
+
+    @Readonly
+    fun add(line: FormattedLine): Boolean
+    @Readonly
+    fun add(unique: Unique, indent: Int = 0): Boolean
+    @Readonly
+    fun add(extraImage: String, imageSize: Float): Boolean
+
+    @Readonly
+    fun add(newLines: Iterable<FormattedLine>): Boolean
+    @Readonly
+    fun add(newLines: Sequence<FormattedLine>): Boolean
+    @Readonly
+    fun <T> add(input: Iterable<T>, transform: T.() -> FormattedLine)
+
+    @Readonly
+    fun add(separator: SeparatorType)
+    @Readonly
+    fun space()
+    @Readonly
+    fun separator()
+
+    @Readonly
+    context(source: IHasUniques)
+    fun addUniques(
+        leadingSeparator: SeparatorType = SeparatorType.Space,
+        colorConsumesResources: Boolean = false,
+        exclude: Unique.() -> Boolean = { false }
+    )
+}
+
+@InternalState
+private class FormattedLineListBuilderImpl(capacity: Int = 16) : FormattedLineListBuilder {
+    @Cache
+    private val lines = ArrayList<FormattedLine>(capacity)
+
+    override fun build() = lines
+
+    override fun add(
+        text: String,
+        link: String,
+        icon: String,
+        header: Int,
+        indent: Int,
+        color: String,
+        starred: Boolean,
+        centered: Boolean,
+        iconCrossed: Boolean
+    ) {
+        lines.add(FormattedLine(text, link, icon, header = header, indent = indent, color = color, starred = starred, centered = centered, iconCrossed = iconCrossed))
+    }
+
+    override fun add(line: FormattedLine) = lines.add(line)
+    override fun add(unique: Unique, indent: Int) = lines.add(FormattedLine(unique, indent))
+    override fun add(extraImage: String, imageSize: Float) = lines.add(FormattedLine(extraImage = extraImage, imageSize = imageSize))
+
+    override fun add(separator: FormattedLineListBuilder.SeparatorType) = separator.addTo(this)
+    override fun space() { lines.add(FormattedLine()) }
+    override fun separator() { lines.add(FormattedLine(separator = true)) }
+
+    override fun add(newLines: Iterable<FormattedLine>) = lines.addAll(newLines)
+    override fun add(newLines: Sequence<FormattedLine>) = lines.addAll(newLines)
+    override fun <T> add(input: Iterable<T>, transform: T.() -> FormattedLine) {
+        for (item in input)
+            add(item.transform())
+    }
+
+    context(source: IHasUniques)
+    override fun addUniques(
+        leadingSeparator: FormattedLineListBuilder.SeparatorType,
+        colorConsumesResources: Boolean,
+        exclude: Unique.() -> Boolean
+    ) {
+        val orderedUniques = source.uniqueObjects.asSequence()
+            .filterNot { it.isHiddenToUsers() || it.exclude() }
+
+        for ((index, unique) in orderedUniques.withIndex()) {
+            if (index == 0) add(leadingSeparator)
+            // Optionally special-case ConsumesResources to give it a reddish color. Also ensures link always points to the resource
+            // (the other constructor guesses the first object by name in the Unique parameters).
+            if (colorConsumesResources && unique.type == UniqueType.ConsumesResources)
+                add(unique.getDisplayText(), link = "Resources/${unique.params[1]}", color = "#F42")
+            else add(unique)
         }
     }
 }

--- a/core/src/com/unciv/ui/objectdescriptions/FormattedLineListBuilder.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/FormattedLineListBuilder.kt
@@ -1,0 +1,83 @@
+package com.unciv.ui.objectdescriptions
+
+import com.unciv.models.ruleset.unique.IHasUniques
+import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.ui.screens.civilopediascreen.FormattedLine
+
+/**
+ *  A builder for use in [ICivilopediaText.getCivilopediaTextLines][com.unciv.ui.screens.civilopediascreen.ICivilopediaText.getCivilopediaTextLines].
+ *  * API: [buildCivilopediaText]. Within its `block`, use the following methods:
+ *      * [add] accepts combinations of [FormattedLine] parameters, [FormattedLine] itself, [Iterable]s or [Sequence]s of [FormattedLine],
+ *        or any other [Iterable] with a transform that produces [FormattedLine] from each element.
+ *      * [space] or [separator] produce a vertical spacer or a horizontal line, names chosen for clarity to distinguish from [add].
+ *      * [addUniques] will add all [uniques][IHasUniques.uniques] of a [IHasUniques] receiver and is a replacement for [uniquesToCivilopediaTextLines].
+ */
+class FormattedLineListBuilder(capacity: Int = 16) {
+    private val lines = ArrayList<FormattedLine>(capacity)
+
+    fun add(
+        text: String,
+        link: String = "",
+        icon: String = "",
+        header: Int = 0,
+        indent: Int = 0,
+        color: String = "",
+        starred: Boolean = false,
+        centered: Boolean = false,
+        iconCrossed: Boolean = false
+    ) = lines.add(FormattedLine(text, link, icon, header = header, indent = indent, color = color, starred = starred, centered = centered, iconCrossed = iconCrossed))
+
+    fun add(line: FormattedLine) = lines.add(line)
+    fun add(unique: Unique, indent: Int = 0) = lines.add(FormattedLine(unique, indent))
+    fun add(extraImage: String, imageSize: Float) = lines.add(FormattedLine(extraImage = extraImage, imageSize = imageSize))
+
+    fun add(separator: SeparatorType) = separator.addTo(this)
+    fun space() = lines.add(FormattedLine())
+    fun separator() = lines.add(FormattedLine(separator = true))
+
+    fun add(newLines: Iterable<FormattedLine>) = lines.addAll(newLines)
+    fun add(newLines: Sequence<FormattedLine>) = lines.addAll(newLines)
+    fun <T> add(input: Iterable<T>, transform: T.() -> FormattedLine) {
+        for (item in input)
+            add(item.transform())
+    }
+
+    context(source: IHasUniques)
+    fun addUniques(
+        leadingSeparator: SeparatorType = SeparatorType.Space,
+        colorConsumesResources: Boolean = false,
+        exclude: Unique.() -> Boolean = { false }
+    ) {
+        val orderedUniques = source.uniqueObjects.asSequence()
+            .filterNot { it.isHiddenToUsers() || it.exclude() }
+
+        for ((index, unique) in orderedUniques.withIndex()) {
+            if (index == 0) add(leadingSeparator)
+            // Optionally special-case ConsumesResources to give it a reddish color. Also ensures link always points to the resource
+            // (the other constructor guesses the first object by name in the Unique parameters).
+            if (colorConsumesResources && unique.type == UniqueType.ConsumesResources)
+                add(unique.getDisplayText(), link = "Resources/${unique.params[1]}", color = "#F42")
+            else add(unique)
+        }
+    }
+
+    enum class SeparatorType {
+        None {
+            override fun addTo(to: FormattedLineListBuilder) {}
+        }, Space {
+            override fun addTo(to: FormattedLineListBuilder) { to.space() }
+        }, Line {
+            override fun addTo(to: FormattedLineListBuilder) { to.separator() }
+        };
+        internal abstract fun addTo(to: FormattedLineListBuilder)
+    }
+
+    companion object {
+        fun buildCivilopediaText(capacity: Int = 16, block: FormattedLineListBuilder.() -> Unit): List<FormattedLine> {
+            val builder = FormattedLineListBuilder(capacity)
+            builder.block()
+            return builder.lines
+        }
+    }
+}

--- a/core/src/com/unciv/ui/objectdescriptions/FormattedLineListBuilder.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/FormattedLineListBuilder.kt
@@ -4,79 +4,128 @@ import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
+import com.unciv.ui.screens.civilopediascreen.ICivilopediaText
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.InternalState
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
 
-/**
- *  A builder for use in [ICivilopediaText.getCivilopediaTextLines][com.unciv.ui.screens.civilopediascreen.ICivilopediaText.getCivilopediaTextLines].
+/** A builder for use in [ICivilopediaText.getCivilopediaTextLines].
  *  * API: [buildCivilopediaText]. Within its `block`, use the following methods:
+ *      * [defaults] change the default values set in the [buildCivilopediaText] call.
  *      * [add] accepts combinations of [FormattedLine] parameters, [FormattedLine] itself, [Iterable]s or [Sequence]s of [FormattedLine],
  *        or any other [Iterable] with a transform that produces [FormattedLine] from each element.
- *      * [space] or [separator] produce a vertical spacer or a horizontal line, names chosen for clarity to distinguish from [add].
+ *        Therefore, [ICivilopediaText.civilopediaText] is a valid argument.
+ *      * [space] or [separator] produce a vertical spacer or a horizontal line, names chosen for clarity to distinguish from [add] (see [add]([SeparatorType]) for a dynamic version).
  *      * [addUniques] will add all [uniques][IHasUniques.uniques] of a [IHasUniques] receiver and is a replacement for [uniquesToCivilopediaTextLines].
  */
+// Note on all the `@Readonly` annotations: They are regrettably required, to allow use of the builder in @Readonly client code.
+// Read as @Readonly relative to the context of the builder, not referring to the build itself.
 interface FormattedLineListBuilder {
     companion object {
+        /** Starts a builder resulting in a `List<FormattedLine>`
+         *  @param defaults An instance of [FormattedLine] to copy default values from. Ignored by some [add] overloads, their Kdoc will indicate this.
+         *  @param capacity Initial capacity.
+         *  @param block Your code, having direct access to [FormattedLineListBuilder] methods.
+         */
         @Readonly
-        fun buildCivilopediaText(capacity: Int = 16, block: FormattedLineListBuilder.() -> Unit): List<FormattedLine> {
+        fun buildCivilopediaText(
+            defaults: FormattedLine = FormattedLine(),
+            capacity: Int = 16,
+            block: FormattedLineListBuilder.() -> Unit
+        ): List<FormattedLine> {
             @LocalState
-            val builder = FormattedLineListBuilderImpl(capacity)
+            val builder = FormattedLineListBuilderImpl(defaults, capacity)
             builder.block()
             return builder.build()
         }
     }
 
+    /** Allows dynamic vertical separators:
+     *
+     * [None] maps to nothing, [Space] to [space], Line to [separator]
+     */
     enum class SeparatorType {
         None {
-            override fun addTo(to: FormattedLineListBuilder) {}
+            override fun addTo(to: FormattedLineListBuilder, size: Int, color: String) {}
         }, Space {
-            override fun addTo(to: FormattedLineListBuilder) { to.space() }
+            override fun addTo(to: FormattedLineListBuilder, size: Int, color: String) { to.space() }
         }, Line {
-            override fun addTo(to: FormattedLineListBuilder) { to.separator() }
+            override fun addTo(to: FormattedLineListBuilder, size: Int, color: String) { to.separator(size, color) }
         };
         @Readonly
-        internal abstract fun addTo(to: FormattedLineListBuilder)
+        internal abstract fun addTo(to: FormattedLineListBuilder, size: Int, color: String)
     }
 
+    /** Called automatically, not part of the client API */
     @Readonly
     fun build(): List<FormattedLine>
 
+    /** Flexible line addition, allows all parameters the [FormattedLine] constructor does, but defaults each to the template set in [defaults]. */
     @Readonly
     fun add(
-        text: String,
-        link: String = "",
-        icon: String = "",
-        header: Int = 0,
-        indent: Int = 0,
-        color: String = "",
-        starred: Boolean = false,
-        centered: Boolean = false,
-        iconCrossed: Boolean = false
+        text: String = defaults().text,
+        link: String = defaults().link,
+        icon: String = defaults().icon,
+        extraImage: String = defaults().extraImage,
+        imageSize: Float = defaults().imageSize,
+        size: Int = defaults().size,
+        header: Int = defaults().header,
+        indent: Int = defaults().indent,
+        padding: Float = defaults().padding,
+        color: String = defaults().color,
+        separator: Boolean = defaults().separator,
+        starred: Boolean = defaults().starred,
+        centered: Boolean = defaults().centered,
+        iconCrossed: Boolean = defaults().iconCrossed
     )
 
+    /** Add a complete [FormattedLine], ignoring [defaults]. */
     @Readonly
-    fun add(line: FormattedLine): Boolean
-    @Readonly
-    fun add(unique: Unique, indent: Int = 0): Boolean
-    @Readonly
-    fun add(extraImage: String, imageSize: Float): Boolean
+    fun add(line: FormattedLine)
 
+    /** Add a line for a [Unique], ignoring [defaults] except for [indent].
+     *
+     *  See also: The [FormattedLine]`(Unique)` constructor for features like supporting automatic links for ruleset objects mentioned in Unique parameters.
+     */
     @Readonly
-    fun add(newLines: Iterable<FormattedLine>): Boolean
+    fun add(unique: Unique, indent: Int = defaults().indent)
+
+    /** Add an image, see [FormattedLine.extraImage]. */
     @Readonly
-    fun add(newLines: Sequence<FormattedLine>): Boolean
+    fun add(extraImage: String, imageSize: Float)
+
+    /** Add several lines, ignoring [defaults]. */
+    @Readonly
+    fun add(newLines: Iterable<FormattedLine>)
+
+    /** Add several lines, ignoring [defaults]. */
+    @Readonly
+    fun add(newLines: Sequence<FormattedLine>)
+
+    /** Add several lines, ignoring [defaults]. Each is built from one input element, transformed by [transform]. */
     @Readonly
     fun <T> add(input: Iterable<T>, transform: T.() -> FormattedLine)
 
+    /** Add a vertical separator of type [separator]. [size] (line thickness) and [color] are used for type [SeparatorType.Line]. */
     @Readonly
-    fun add(separator: SeparatorType)
+    fun add(separator: SeparatorType, size: Int = defaults().size, color: String = defaults().color)
+
+    /** Add a vertical space half the height of a normal line. */
     @Readonly
     fun space()
-    @Readonly
-    fun separator()
 
+    /** Add a horizontal line separator. [size] is the line thickness. */
+    @Readonly
+    fun separator(size: Int = defaults().size, color: String = defaults().color)
+
+    /** Add lines for the Uniques of [source], ignoring [defaults].
+     *
+     *  Supports automatic links for ruleset objects mentioned in Unique parameters.
+     *  @param leadingSeparator Used only when actual uniques content follows, calls [add]([SeparatorType]).
+     *  @param colorConsumesResources If set, ConsumesResources Uniques get a reddish color.
+     *  @param exclude Predicate that can exclude Uniques by returning `true` (defaults to return `false`).
+     */
     @Readonly
     context(source: IHasUniques)
     fun addUniques(
@@ -84,12 +133,25 @@ interface FormattedLineListBuilder {
         colorConsumesResources: Boolean = false,
         exclude: Unique.() -> Boolean = { false }
     )
+
+    /** Change the template default values are drawn from */
+    @Readonly
+    fun defaults(line: FormattedLine)
+    /** Retrieve the template default values are drawn from */
+    @Readonly
+    fun defaults(): FormattedLine
 }
 
 @InternalState
-private class FormattedLineListBuilderImpl(capacity: Int = 16) : FormattedLineListBuilder {
+private class FormattedLineListBuilderImpl(
+    defaults: FormattedLine,
+    capacity: Int
+) : FormattedLineListBuilder {
     @Cache
     private val lines = ArrayList<FormattedLine>(capacity)
+
+    @Cache
+    private var defaultsLine = defaults
 
     override fun build() = lines
 
@@ -97,26 +159,46 @@ private class FormattedLineListBuilderImpl(capacity: Int = 16) : FormattedLineLi
         text: String,
         link: String,
         icon: String,
+        extraImage: String,
+        imageSize: Float,
+        size: Int,
         header: Int,
         indent: Int,
+        padding: Float,
         color: String,
+        separator: Boolean,
         starred: Boolean,
         centered: Boolean,
         iconCrossed: Boolean
     ) {
-        lines.add(FormattedLine(text, link, icon, header = header, indent = indent, color = color, starred = starred, centered = centered, iconCrossed = iconCrossed))
+        lines.add(FormattedLine(text, link, icon, extraImage, imageSize, size, header, indent, padding, color, separator, starred, centered, iconCrossed))
     }
 
-    override fun add(line: FormattedLine) = lines.add(line)
-    override fun add(unique: Unique, indent: Int) = lines.add(FormattedLine(unique, indent))
-    override fun add(extraImage: String, imageSize: Float) = lines.add(FormattedLine(extraImage = extraImage, imageSize = imageSize))
+    override fun add(line: FormattedLine) {
+        lines.add(line)
+    }
+    override fun add(unique: Unique, indent: Int) {
+        lines.add(FormattedLine(unique, indent))
+    }
+    override fun add(extraImage: String, imageSize: Float) {
+        lines.add(FormattedLine(extraImage = extraImage, imageSize = imageSize))
+    }
 
-    override fun add(separator: FormattedLineListBuilder.SeparatorType) = separator.addTo(this)
-    override fun space() { lines.add(FormattedLine()) }
-    override fun separator() { lines.add(FormattedLine(separator = true)) }
+    override fun add(separator: FormattedLineListBuilder.SeparatorType, size: Int, color: String) =
+        separator.addTo(this, size, color)
+    override fun space() {
+        lines.add(FormattedLine())
+    }
+    override fun separator(size: Int, color: String) {
+        lines.add(FormattedLine(separator = true, size = size, color = color))
+    }
 
-    override fun add(newLines: Iterable<FormattedLine>) = lines.addAll(newLines)
-    override fun add(newLines: Sequence<FormattedLine>) = lines.addAll(newLines)
+    override fun add(newLines: Iterable<FormattedLine>) {
+        lines.addAll(newLines)
+    }
+    override fun add(newLines: Sequence<FormattedLine>) {
+        lines.addAll(newLines)
+    }
     override fun <T> add(input: Iterable<T>, transform: T.() -> FormattedLine) {
         for (item in input)
             add(item.transform())
@@ -140,4 +222,9 @@ private class FormattedLineListBuilderImpl(capacity: Int = 16) : FormattedLineLi
             else add(unique)
         }
     }
+
+    override fun defaults(line: FormattedLine) {
+        defaultsLine = line
+    }
+    override fun defaults() = defaultsLine
 }


### PR DESCRIPTION
Hey - github was overeager...

So this is inspired by #15013, and I got the new code in that PR converted to use this locally. Helps readability a lot.

@yairm210 - your take on another architectural change? On introducing context parameters - they make the builder helpers have cleaner call sites? Note there's two versions of the builder in here - straight and prepared for purity. If we adopt this and incrementally convert all the description helpers, then DescriptionHelpers.kt will become obsolete, and we could start marking all the methods of ICivilopediaText `@Readonly`...