### PR TITLE
Fix city-states always have personality "Friendly"

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Personalities.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Personalities.json
@@ -1093,7 +1093,7 @@
     }
   },
   {
-    "name": "Ram­khamhaeng",
+    "name": "Ramkhamhaeng",
     "production": 5,
     "food": 6,
     "gold": 5,

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -11,7 +11,6 @@ import com.unciv.logic.map.HexMath
 import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.mapgenerator.MapGenerator
 import com.unciv.logic.map.tile.Tile
-import com.unciv.models.metadata.GameParameters
 import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.Ruleset
@@ -34,18 +33,25 @@ import yairm210.purity.annotations.Readonly
  * details, are random, based on [GameContext.stateBasedRandom], which is based on the gameId, which
  *  is fully random per game.
  */
-object GameStarter {
-    // temporary instrumentation while tuning/debugging
-    private const val consoleTimings = false
-    private lateinit var gameSetupInfo: GameSetupInfo
+class GameStarter private constructor(
+    private val gameSetupInfo: GameSetupInfo
+) {
+    companion object {
+        // temporary instrumentation while tuning/debugging
+        private const val consoleTimings = false
 
-    fun startNewGame(gameSetupInfo: GameSetupInfo): GameInfo {
-        this.gameSetupInfo = gameSetupInfo
+        fun startNewGame(gameSetupInfo: GameSetupInfo): GameInfo =
+            GameStarter(gameSetupInfo).gameInfo
+    }
+
+    private val gameInfo = GameInfo()
+    private val rng = GameContext(gameInfo = gameInfo).stateBasedRandom("GameStarter")
+    private val ruleset: Ruleset
+    private lateinit var tileMap: TileMap
+
+    init {
         if (consoleTimings)
             debug("\nGameStarter run with parameters %s, map %s", gameSetupInfo.gameParameters, gameSetupInfo.mapParameters)
-
-        val gameInfo = GameInfo()
-        lateinit var tileMap: TileMap
 
         // In the case where we used to have an extension mod, and now we don't, we cannot "unselect" it in the UI.
         // We need to remove the dead mods so there aren't problems later.
@@ -60,7 +66,7 @@ object GameStarter {
             gameSetupInfo.gameParameters.baseRuleset = RulesetCache.getVanillaRuleset().name
 
         gameInfo.gameParameters = gameSetupInfo.gameParameters
-        val ruleset = RulesetCache.getComplexRuleset(gameInfo.gameParameters)
+        ruleset = RulesetCache.getComplexRuleset(gameInfo.gameParameters)
         val mapGen = MapGenerator(ruleset)
 
         // Make sure that a valid game speed is loaded (catches a base ruleset not using the default game speed)
@@ -72,11 +78,11 @@ object GameStarter {
         if (gameSetupInfo.mapParameters.name != "") runAndMeasure("loadMap") {
             tileMap = MapSaver.loadMap(gameSetupInfo.mapFile!!)
             // Don't override the map parameters - this can include if we world wrap or not!
-            phaseOneChosenCivs = chooseCivilizations(gameSetupInfo.gameParameters, gameInfo, ruleset, existingMap = true)
+            phaseOneChosenCivs = chooseCivilizations(existingMap = true)
         } else runAndMeasure("generateMap") {
             // The MapGen needs to know what civs are in the game to generate regions, starts and resources
-            phaseOneChosenCivs = chooseCivilizations(gameSetupInfo.gameParameters, gameInfo, ruleset, existingMap = false)
-            addCivilizations(gameSetupInfo.gameParameters, gameInfo, ruleset, phaseOneChosenCivs)
+            phaseOneChosenCivs = chooseCivilizations(existingMap = false)
+            addCivilizations(phaseOneChosenCivs)
             tileMap = mapGen.generateMap(gameSetupInfo.mapParameters, gameSetupInfo.gameParameters, gameInfo)
             tileMap.mapParameters = gameSetupInfo.mapParameters
             // Now forget them for a moment! MapGen can silently fail to place some city states, so then we'll use the old fallback method to place those.
@@ -85,14 +91,8 @@ object GameStarter {
 
         runAndMeasure("addCivilizations") {
             gameInfo.tileMap = tileMap
-            tileMap.gameInfo =
-                gameInfo // need to set this transient before placing units in the map
-            addCivilizations(
-                gameSetupInfo.gameParameters,
-                gameInfo,
-                ruleset,
-                phaseOneChosenCivs
-            ) // this is before gameInfo.setTransients, so gameInfo doesn't yet have the gameBasics
+            tileMap.gameInfo = gameInfo // need to set this transient before placing units in the map
+            addCivilizations(phaseOneChosenCivs) // this is before gameInfo.setTransients, so gameInfo doesn't yet have the gameBasics
         }
 
         runAndMeasure("Remove units") {
@@ -123,19 +123,19 @@ object GameStarter {
         }
 
         runAndMeasure("addCivStartingUnits") {
-            addCivStartingUnits(gameInfo)
+            addCivStartingUnits()
         }
 
         runAndMeasure("Policies") {
-            addCivPolicies(gameInfo, ruleset)
+            addCivPolicies()
         }
 
         runAndMeasure("Techs and Stats") {
-            addCivTechs(gameInfo, ruleset, gameSetupInfo)
+            addCivTechs()
         }
 
         runAndMeasure("Starting stats") {
-            addCivStats(gameInfo)
+            addCivStats()
         }
 
         // remove starting locations once we're done
@@ -147,13 +147,12 @@ object GameStarter {
         }
 
         // This triggers the one-time greeting from Nation.startIntroPart1/2
-        addPlayerIntros(gameInfo)
+        addPlayerIntros()
 
         UncivGame.Current.settings.apply {
             lastGameSetup = gameSetupInfo
             save()
         }
-        return gameInfo
     }
 
     private fun runAndMeasure(text: String, action: ()->Unit) {
@@ -164,7 +163,7 @@ object GameStarter {
         debug("GameStarter.%s took %s.%sms", text, delta/1000000L, (delta/10000L).rem(100))
     }
 
-    private fun addPlayerIntros(gameInfo: GameInfo) {
+    private fun addPlayerIntros() {
         gameInfo.civilizations.filter {
             // isNotEmpty should also exclude a spectator
             it.playerType == PlayerType.Human && it.nation.startIntroPart1.isNotEmpty()
@@ -173,7 +172,7 @@ object GameStarter {
         }
     }
 
-    private fun addCivTechs(gameInfo: GameInfo, ruleset: Ruleset, gameSetupInfo: GameSetupInfo) {
+    private fun addCivTechs() {
         fun Civilization.addTechSilently(name: String) {
             // check if the technology is in the ruleset and not already researched
             if (!ruleset.technologies.containsKey(name)) return
@@ -214,7 +213,7 @@ object GameStarter {
         }
     }
 
-    private fun addCivPolicies(gameInfo: GameInfo, ruleset: Ruleset) {
+    private fun addCivPolicies() {
         for (civInfo in gameInfo.civilizations.filter { !it.isBarbarian }) {
 
             // generic start with policy unique
@@ -235,7 +234,7 @@ object GameStarter {
         }
     }
 
-    private fun addCivStats(gameInfo: GameInfo) {
+    private fun addCivStats() {
         val ruleSet = gameInfo.ruleset
         val startingEra = gameInfo.gameParameters.startingEra
         val era = ruleSet.eras[startingEra]!!
@@ -246,13 +245,8 @@ object GameStarter {
     }
 
     @Readonly
-    private fun chooseCivilizations(
-        newGameParameters: GameParameters,
-        gameInfo: GameInfo,
-        ruleset: Ruleset,
-        existingMap: Boolean
-    ): List<Player> {
-        val rng = GameContext(gameInfo = gameInfo).stateBasedRandom("GameStarter.chooseCivilizations")
+    private fun chooseCivilizations(existingMap: Boolean): List<Player> {
+        val newGameParameters = gameSetupInfo.gameParameters
         val selectedPlayerNames = newGameParameters.players
             .map { it.chosenCiv }.toSet()
         @LocalState val randomNationsPool = (
@@ -354,12 +348,8 @@ object GameStarter {
         return chosenPlayers
     }
 
-    private fun addCivilizations(
-        newGameParameters: GameParameters,
-        gameInfo: GameInfo,
-        ruleset: Ruleset,
-        chosenPlayers: List<Player>
-    ) {
+    private fun addCivilizations(chosenPlayers: List<Player>) {
+        val newGameParameters = gameSetupInfo.gameParameters
         if (!newGameParameters.noBarbarians) {
             val barbs = ruleset.nations[Constants.barbarians]
             if (barbs != null) {
@@ -386,7 +376,7 @@ object GameStarter {
         }
     }
 
-    private fun addCivStartingUnits(gameInfo: GameInfo) {
+    private fun addCivStartingUnits() {
 
         val ruleSet = gameInfo.ruleset
         val tileMap = gameInfo.tileMap
@@ -402,13 +392,13 @@ object GameStarter {
             startScores[tile] = tile.stats.getTileStartScore(cityCenterMinStats)
         }
         val allCivs = gameInfo.civilizations.filter { !it.isBarbarian }
-        val landTilesInBigEnoughGroup = getCandidateLand(allCivs.size, tileMap, startScores)
+        val landTilesInBigEnoughGroup = getCandidateLand(allCivs.size, startScores)
 
         // First we get start locations for the major civs, on the second pass the city states (without predetermined starts) can squeeze in wherever
         val civNamesWithStartingLocations = tileMap.startingLocationsByNation.keys
         val bestCivs = allCivs.filter { (!it.isCityState || it.civID in civNamesWithStartingLocations)
             && !it.isSpectator()}
-        val bestLocations = getStartingLocations(bestCivs, tileMap, landTilesInBigEnoughGroup, startScores)
+        val bestLocations = getStartingLocations(bestCivs, landTilesInBigEnoughGroup, startScores)
         for ((civ, tile) in bestLocations) {
             // A nation can have multiple marked starting locations, of which the first pass may have chosen one
             tileMap.removeStartingLocations(civ.civID)
@@ -416,7 +406,7 @@ object GameStarter {
             tileMap.addStartingLocation(civ.civID, tile)
         }
 
-        val startingLocations = getStartingLocations(allCivs, tileMap, landTilesInBigEnoughGroup, startScores)
+        val startingLocations = getStartingLocations(allCivs, landTilesInBigEnoughGroup, startScores)
 
         // no starting units for Barbarians and Spectators
         determineStartingUnitsAndLocations(gameInfo, startingLocations, ruleSet)
@@ -442,9 +432,9 @@ object GameStarter {
             val startingLocation = startingLocations[civ]!!
 
             removeAncientRuinsNearStartingLocation(startingLocation)
-            val startingUnits = getStartingUnitsForEraAndDifficulty(civ, gameInfo, ruleset, startingEra)
-            adjustStartingUnitsForCityStatesAndOneCityChallenge(civ, gameInfo, startingUnits, settlerLikeUnits)
-            placeStartingUnits(civ, startingLocation, startingUnits, ruleset, ruleset.eras[startingEra]!!.startingMilitaryUnit, settlerLikeUnits)
+            val startingUnits = getStartingUnitsForEraAndDifficulty(civ, startingEra)
+            adjustStartingUnitsForCityStatesAndOneCityChallenge(civ, startingUnits, settlerLikeUnits)
+            placeStartingUnits(civ, startingLocation, startingUnits, ruleset.eras[startingEra]!!.startingMilitaryUnit, settlerLikeUnits)
 
             // Trigger any global or nation uniques that should be triggered.
             // We may need the starting location for some uniques, which is why we're doing it now
@@ -460,7 +450,7 @@ object GameStarter {
     }
 
     @Readonly
-    private fun getStartingUnitsForEraAndDifficulty(civ: Civilization, gameInfo: GameInfo, ruleset: Ruleset, startingEra: String): MutableList<String> {
+    private fun getStartingUnitsForEraAndDifficulty(civ: Civilization, startingEra: String): MutableList<String> {
         @LocalState val startingUnits = ruleset.eras[startingEra]?.getStartingUnits(ruleset)
             ?: throw Exception("Era $startingEra does not exist in the ruleset!")
 
@@ -478,11 +468,9 @@ object GameStarter {
     private fun getEquivalentUnit(
         civ: Civilization,
         unitParam: String,
-        ruleset: Ruleset,
         eraUnitReplacement: String,
         settlerLikeUnits: Map<String, BaseUnit>
     ): BaseUnit? {
-        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.getEquivalentUnit($unitParam,$eraUnitReplacement)")
         var unit = unitParam // We want to change it and this is the easiest way to do so
         if (unit == Constants.eraSpecificUnit) unit = eraUnitReplacement
         if (unit == Constants.settler && Constants.settler !in ruleset.units) {
@@ -507,11 +495,9 @@ object GameStarter {
 
     private fun adjustStartingUnitsForCityStatesAndOneCityChallenge(
         civ: Civilization,
-        gameInfo: GameInfo,
         startingUnits: MutableList<String>,
         settlerLikeUnits: Map<String, BaseUnit>
     ) {
-        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.adjustStartingUnitsForCityStatesAndOneCityChallenge")
         // Adjust starting units for city states
         if (civ.isCityState && !gameInfo.ruleset.modOptions.hasUnique(UniqueType.AllowCityStatesSpawnUnits)) {
             val startingSettlers = startingUnits.filter { settlerLikeUnits.contains(it) }
@@ -529,16 +515,15 @@ object GameStarter {
         }
     }
 
-    private fun placeStartingUnits(civ: Civilization, startingLocation: Tile, startingUnits: MutableList<String>, ruleset: Ruleset, eraUnitReplacement: String, settlerLikeUnits: Map<String, BaseUnit>) {
+    private fun placeStartingUnits(civ: Civilization, startingLocation: Tile, startingUnits: MutableList<String>, eraUnitReplacement: String, settlerLikeUnits: Map<String, BaseUnit>) {
         for (unit in startingUnits) {
-            val unitToAdd = getEquivalentUnit(civ, unit, ruleset, eraUnitReplacement, settlerLikeUnits)
+            val unitToAdd = getEquivalentUnit(civ, unit, eraUnitReplacement, settlerLikeUnits)
             if (unitToAdd != null) civ.units.placeUnitNearTile(startingLocation.position, unitToAdd)
         }
     }
 
     private fun getCandidateLand(
         civCount: Int,
-        tileMap: TileMap,
         startScores: HashMap<Tile, Float>
     ): Map<Tile, Float> {
         tileMap.assignContinents(TileMap.AssignContinentsMode.Ensure)
@@ -562,24 +547,23 @@ object GameStarter {
 
     private fun getStartingLocations(
         civs: List<Civilization>,
-        tileMap: TileMap,
         landTilesInBigEnoughGroup: Map<Tile, Float>,
         startScores: HashMap<Tile, Float>
     ): HashMap<Civilization, Tile> {
 
-        val civsOrderedByAvailableLocations = getCivsOrderedByAvailableLocations(civs, tileMap)
+        val civsOrderedByAvailableLocations = getCivsOrderedByAvailableLocations(civs)
 
         for (minimumDistanceBetweenStartingLocations in tileMap.tileMatrix.size / 6 downTo 0) {
-            val freeTiles = getFreeTiles(tileMap, landTilesInBigEnoughGroup, minimumDistanceBetweenStartingLocations)
+            val freeTiles = getFreeTiles(landTilesInBigEnoughGroup, minimumDistanceBetweenStartingLocations)
 
-            val startingLocations = getStartingLocationsForCivs(civsOrderedByAvailableLocations, tileMap, freeTiles, startScores, minimumDistanceBetweenStartingLocations)
+            val startingLocations = getStartingLocationsForCivs(civsOrderedByAvailableLocations, freeTiles, startScores, minimumDistanceBetweenStartingLocations)
             if (startingLocations != null) return startingLocations
         }
         throw Exception("Didn't manage to get starting tiles even with distance of 1?")
     }
 
     @Readonly
-    private fun getCivsOrderedByAvailableLocations(civs: List<Civilization>, tileMap: TileMap): List<Civilization> {
+    private fun getCivsOrderedByAvailableLocations(civs: List<Civilization>): List<Civilization> {
         return civs.shuffled()   // Order should be random since it determines who gets best start
             .sortedBy { civ ->
                 when {
@@ -593,7 +577,7 @@ object GameStarter {
     }
 
     @Readonly
-    private fun getFreeTiles(tileMap: TileMap, landTilesInBigEnoughGroup: Map<Tile, Float>, minimumDistanceBetweenStartingLocations: Int): MutableList<Tile> {
+    private fun getFreeTiles(landTilesInBigEnoughGroup: Map<Tile, Float>, minimumDistanceBetweenStartingLocations: Int): MutableList<Tile> {
         return landTilesInBigEnoughGroup.asSequence()
             .filter {
                 HexMath.getDistanceFromEdge(it.key.position, tileMap.mapParameters) >=
@@ -606,7 +590,6 @@ object GameStarter {
     // Mutating - updates freeTiles
     private fun getStartingLocationsForCivs(
         civsOrderedByAvailableLocations: List<Civilization>,
-        tileMap: TileMap,
         freeTiles: MutableList<Tile>,
         startScores: HashMap<Tile, Float>,
         minimumDistanceBetweenStartingLocations: Int
@@ -614,7 +597,7 @@ object GameStarter {
         val startingLocations = HashMap<Civilization, Tile>()
         for (civ in civsOrderedByAvailableLocations) {
 
-            val startingLocation = getCivStartingLocation(civ, tileMap, freeTiles, startScores)
+            val startingLocation = getCivStartingLocation(civ, freeTiles, startScores)
             startingLocation ?: break
 
             startingLocations[civ] = startingLocation
@@ -630,11 +613,9 @@ object GameStarter {
 
     private fun getCivStartingLocation(
         civ: Civilization,
-        tileMap: TileMap,
         freeTiles: MutableList<Tile>,
         startScores: HashMap<Tile, Float>,
     ): Tile? {
-        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.getCivStartingLocation")
         var startingLocation = tileMap.startingLocationsByNation[civ.civID]?.randomOrNull(rng)
         if (startingLocation == null) {
             startingLocation = tileMap.startingLocationsByNation[Constants.spectator]?.randomOrNull(rng)
@@ -643,7 +624,7 @@ object GameStarter {
             }
         }
         if (startingLocation == null && freeTiles.isNotEmpty())
-            startingLocation = getOneStartingLocation(civ, tileMap, freeTiles, startScores)
+            startingLocation = getOneStartingLocation(civ, freeTiles, startScores)
         // If startingLocation is null we failed to get all the starting tiles with this minimum distance
         return startingLocation
     }
@@ -651,11 +632,9 @@ object GameStarter {
     @Readonly
     private fun getOneStartingLocation(
         civ: Civilization,
-        tileMap: TileMap,
         freeTiles: MutableList<Tile>,
         startScores: HashMap<Tile, Float>
     ): Tile {
-        val rng = GameContext(civInfo = civ).stateBasedRandom("GameStarter.getOneStartingLocation")
         if (gameSetupInfo.gameParameters.noStartBias) {
             return freeTiles.random(rng)
         }

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -370,7 +370,7 @@ class GameStarter private constructor(
                 civ.playerId = player.playerId
                 civ.playerMinutesBeforeForceResign = newGameParameters.minutesUntilForceResign
             }
-            else if (!civ.cityStateFunctions.initCityState(ruleset, newGameParameters.startingEra, usedMajorCivs))
+            else if (!civ.cityStateFunctions.initCityState(ruleset, newGameParameters.startingEra, usedMajorCivs, rng))
                 continue
             gameInfo.civilizations.add(civ)
         }

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -27,11 +27,11 @@ import com.unciv.utils.debug
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
 
-/*
+/**
  * Starts a new game
  *
- * Map terrain is determinisic, but game setup, including start locations, resources, and other 
- * details, are random, based on GameContext.stateBasedRandom, which is based on the gameId, which
+ * Map terrain is determinisic, but game setup, including start locations, resources, and other
+ * details, are random, based on [GameContext.stateBasedRandom], which is based on the gameId, which
  *  is fully random per game.
  */
 object GameStarter {
@@ -192,8 +192,9 @@ object GameStarter {
                     civInfo.addTechSilently(tech)
 
             // generic start with technology unique
-            for (unique in civInfo.getMatchingUniques(UniqueType.StartsWithTech))
+            civInfo.forEachMatchingUnique(UniqueType.StartsWithTech) { unique ->
                 civInfo.addTechSilently(unique.params[0])
+            }
 
             // add all techs to spectators
             if (civInfo.isSpectator())
@@ -217,13 +218,13 @@ object GameStarter {
         for (civInfo in gameInfo.civilizations.filter { !it.isBarbarian }) {
 
             // generic start with policy unique
-            for (unique in civInfo.getMatchingUniques(UniqueType.StartsWithPolicy)) {
+            civInfo.forEachMatchingUnique(UniqueType.StartsWithPolicy) { unique ->
                 // get the parameter from the unique
                 val policyName = unique.params[0]
 
                 // check if the policy is in the ruleset and not already adopted
                 if (!ruleset.policies.containsKey(policyName) || civInfo.policies.isAdopted(policyName))
-                    continue
+                    return@forEachMatchingUnique
 
                 val policyToAdopt = ruleset.policies[policyName]!!
                 civInfo.policies.run {
@@ -322,7 +323,7 @@ object GameStarter {
         // ensure Spectators always first players
         val spectators = chosenPlayers.filter { it.chosenCiv == Constants.spectator }
         val otherPlayers = chosenPlayers.filterNot { it.chosenCiv == Constants.spectator }.toMutableList()
-        
+
         // Shuffle Major Civs
         if (newGameParameters.shufflePlayerOrder) otherPlayers.shuffle()
 
@@ -422,7 +423,7 @@ object GameStarter {
     }
 
     private fun removeAncientRuinsNearStartingLocation(startingLocation: Tile) {
-        for (tile in startingLocation.getTilesInDistance(3)) {
+        startingLocation.forEachTileAtDistance(3) { tile ->
             if (tile.tileImprovement != null && tile.tileImprovement!!.isAncientRuinsEquivalent()) {
                 tile.removeImprovement() // Remove ancient ruins in immediate vicinity
             }
@@ -445,7 +446,7 @@ object GameStarter {
             adjustStartingUnitsForCityStatesAndOneCityChallenge(civ, gameInfo, startingUnits, settlerLikeUnits)
             placeStartingUnits(civ, startingLocation, startingUnits, ruleset, ruleset.eras[startingEra]!!.startingMilitaryUnit, settlerLikeUnits)
 
-            // Trigger any global or nation uniques that should triggered.
+            // Trigger any global or nation uniques that should be triggered.
             // We may need the starting location for some uniques, which is why we're doing it now
             // This relies on gameInfo.ruleset already being initialized
             val startingTriggers = gameInfo.getGlobalUniques().uniqueObjects + civ.nation.uniqueObjects
@@ -620,6 +621,7 @@ object GameStarter {
 
             val distanceToNext = minimumDistanceBetweenStartingLocations /
                 (if (civ.isCityState) 2 else 1) // We allow city states to squeeze in tighter
+            @Suppress("DEPRECATION")
             freeTiles.removeAll(tileMap.getTilesInDistance(startingLocation.position, distanceToNext)
                 .toSet())
         }
@@ -672,6 +674,7 @@ object GameStarter {
                 startBias.equalsPlaceholderText("Avoid []") -> {
                     val tileToAvoid = startBias.getPlaceholderParameters()[0]
                     preferredTiles.filter { tile ->
+                        @Suppress("DEPRECATION")
                         !tile.getTilesInDistance(1).any {
                             it.matchesTerrainFilter(tileToAvoid, null)
                         }
@@ -679,6 +682,7 @@ object GameStarter {
                 }
                 startBias in tileMap.naturalWonders -> preferredTiles  // passthrough: already failed
                 else -> preferredTiles.filter { tile ->
+                    @Suppress("DEPRECATION")
                     tile.getTilesInDistance(1).any {
                         it.matchesTerrainFilter(startBias, null)
                     }

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -28,8 +28,7 @@ import kotlin.random.Random
 class CityStateFunctions(val civInfo: Civilization) {
 
     /** Attempts to initialize the city state, returning true if successful. */
-    fun initCityState(ruleset: Ruleset, startingEra: String, usedMajorCivs: Sequence<Nation>): Boolean {
-        val rng = civInfo.state.stateBasedRandom("CityStateFunctions.initCityState")
+    fun initCityState(ruleset: Ruleset, startingEra: String, usedMajorCivs: Sequence<Nation>, rng: Random): Boolean {
         val allMercantileResources = ruleset.tileResources.values.filter { it.hasUnique(UniqueType.CityStateOnlyResource) }.map { it.name }
         val uniqueTypes = HashSet<UniqueType>()    // We look through these to determine what kinds of city states we have
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -37,7 +37,8 @@ class CityStateFunctions(val civInfo: Civilization) {
         uniqueTypes.addAll(cityStateType.allyBonusUniqueMap.getAllUniques().mapNotNull { it.type })
 
         // CS Personality
-        civInfo.cityStatePersonality = CityStatePersonality.entries.random(rng)
+        civInfo.cityStatePersonality = CityStatePersonality.safeValueOf(civInfo.nation.personality)
+            ?: CityStatePersonality.entries.random(rng)
 
         // Mercantile bonus resources
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -45,7 +45,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         if (uniqueTypes.contains(UniqueType.CityStateUniqueLuxury)) {
             civInfo.cityStateResource = allMercantileResources.randomOrNull(rng)
         }
-        
+
         fun possibleUnits(): ArrayList<BaseUnit> {
             val units = ArrayList<BaseUnit>()
             for (unit in ruleset.units.values) {
@@ -91,7 +91,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         val randomSeed = capital.location.x * capital.location.y + 123f * civInfo.gameInfo.turns
         val winner: Civilization? = parties.randomWeighted(Random(randomSeed.toInt()))  { getVotesFromSpy(it) }?.civInfo
 
-        // There may be no winner, in that case all spies will loose 5 influence
+        // There may be no winner, in that case all spies will lose 5 influence
         if (winner == null) {
             // No spy won the election, the civs that tried to rig the election loose influence
             for (spy in spies) {
@@ -100,7 +100,7 @@ class CityStateFunctions(val civInfo: Civilization) {
             }
             return
         }
-        
+
         val allyCiv = civInfo.allyCiv
 
         // Winning civ gets influence and all others loose influence
@@ -120,7 +120,7 @@ class CityStateFunctions(val civInfo: Civilization) {
     }
 
     @Readonly
-    fun turnsForGreatPersonFromCityState(): Int = 
+    fun turnsForGreatPersonFromCityState(): Int =
         ((37 + civInfo.state.stateBasedRandom("CityStateFunctions.turnsForGreatPersonFromCityState").nextInt(7)) * civInfo.gameInfo.speed.modifier).toInt()
 
     /** Gain a random great person from the city state */
@@ -160,11 +160,11 @@ class CityStateFunctions(val civInfo: Civilization) {
                 city.cityConstructions.getConstructableUnits()
                 .filter { !it.isCivilian() && it.isLandUnit && it.uniqueTo == null }
                 // Does not make us go over any resource quota
-                .filter { it.getResourceRequirementsPerTurn(receivingCiv.state).none {
+                .filter { unit -> unit.getResourceRequirementsPerTurn(receivingCiv.state).none {
                     it.value > 0 && receivingCiv.getResourceAmount(it.key) < it.value
                 } }
                 .toList().randomOrNull(rng)
-        
+
         val militaryUnit = giftableUniqueUnit() // If the receiving civ has discovered the required tech and not the obsolete tech for our unique, always give them the unique
             ?: randomGiftableUnit() // Otherwise pick at random
             ?: return  // That filter _can_ result in no candidates, if so, quit silently
@@ -176,7 +176,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         militaryUnit.addConstructionBonuses(placedUnit, civInfo.getCapital()!!.cityConstructions)
 
         // Siam gets +10 XP for all CS units
-        for (unique in receivingCiv.getMatchingUniques(UniqueType.CityStateGiftedUnitsStartWithXp)) {
+        receivingCiv.forEachMatchingUnique(UniqueType.CityStateGiftedUnitsStartWithXp) { unique ->
             placedUnit.promotions.XP += unique.params[0].toInt()
         }
 
@@ -201,8 +201,9 @@ class CityStateFunctions(val civInfo: Civilization) {
         val gameProgressApproximate = min(civInfo.gameInfo.turns / (400f * speed.modifier), 1f)
         influenceGained *= 1 - (2/3f) * gameProgressApproximate
         influenceGained *= speed.goldGiftModifier
-        for (unique in donorCiv.getMatchingUniques(UniqueType.CityStateGoldGiftsProvideMoreInfluence))
+        donorCiv.forEachMatchingUnique(UniqueType.CityStateGoldGiftsProvideMoreInfluence) { unique ->
             influenceGained *= 1f + unique.params[0].toFloat() / 100f
+        }
 
         // Bonus due to "Invest" quests
         influenceGained *= civInfo.questManager.getInvestmentMultiplier(donorCiv)
@@ -294,7 +295,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         if (maxInfluence != null && maxInfluence.value.getInfluence() >= 60) {
             newAlly = maxInfluence.value.otherCiv
         }
-        
+
         if (oldAlly == newAlly) return
         civInfo.allyCiv = newAlly
 
@@ -307,8 +308,9 @@ class CityStateFunctions(val civInfo: Civilization) {
             )
             newAlly.cache.updateViewableTiles()
             newAlly.cache.updateCivResources()
-            for (unique in newAlly.getMatchingUniques(UniqueType.CityStateCanBeBoughtForGold))
+            newAlly.forEachMatchingUnique(UniqueType.CityStateCanBeBoughtForGold) { unique ->
                 newAlly.getDiplomacyManager(civInfo)!!.setFlag(DiplomacyFlags.MarriageCooldown, unique.params[0].toInt())
+            }
 
             // Join the wars of our new ally - loop through all civs they are at war with
             for (newEnemy in civInfo.gameInfo.civilizations.filter { it.isAtWarWith(newAlly) && it.isAlive() } ) {
@@ -369,6 +371,7 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     @Readonly
     fun canBeMarriedBy(otherCiv: Civilization): Boolean {
+        @Suppress("DEPRECATION")
         return (!civInfo.isDefeated()
                 && civInfo.isCityState
                 && civInfo.cities.any()
@@ -384,22 +387,22 @@ class CityStateFunctions(val civInfo: Civilization) {
             return
 
         otherCiv.addGold(-getDiplomaticMarriageCost())
-        
+
         val notificationLocation = civInfo.getCapital()!!.location
         otherCiv.addNotification("We have married into the ruling family of [${civInfo.civName}], bringing them under our control.",
             notificationLocation,
             NotificationCategory.Diplomacy, civInfo.civName,
             NotificationIcon.Diplomacy, otherCiv.civName)
-        
+
         for (civ in civInfo.gameInfo.civilizations.filter { it != otherCiv })
             civ.addNotification("[${otherCiv.civName}] has married into the ruling family of [${civInfo.civName}], bringing them under their control.",
                 notificationLocation,
                 NotificationCategory.Diplomacy, civInfo.civName,
                 NotificationIcon.Diplomacy, otherCiv.civName)
-        
+
         for (unit in civInfo.units.getCivUnits())
             unit.gift(otherCiv)
-        
+
 
         // Make sure this CS can never be liberated
         for (it in civInfo.gameInfo.getCities().filter { it.foundingCivObject == civInfo }) {
@@ -470,7 +473,7 @@ class CityStateFunctions(val civInfo: Civilization) {
             return modifiers
 
         val bullyRange = (civInfo.gameInfo.tileMap.tileMatrix.size / 10).coerceIn(5, 10)   // Longer range for larger maps
-        val inRangeTiles = civInfo.getCapital()!!.getCenterTile().getTilesInDistanceRange(1..bullyRange)
+        @Suppress("DEPRECATION") val inRangeTiles = civInfo.getCapital()!!.getCenterTile().getTilesInDistanceRange(1..bullyRange)
         val forceNearCity = inRangeTiles
             .sumOf { if (it.militaryUnit?.civ == demandingCiv)
                     it.militaryUnit!!.getForceEvaluation()
@@ -832,7 +835,7 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     @Readonly
     fun forEachUniqueProvidedByCityStates(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique) -> Unit) {
-        if (civInfo.isCityState) return 
+        if (civInfo.isCityState) return
         civInfo.forEachKnownCiv {
             if (!it.isCityState) return@forEachKnownCiv
             // We don't use DiplomacyManager.getRelationshipLevel for performance reasons - it tries to calculate getTributeWillingness which is heavy

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStatePersonality.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStatePersonality.kt
@@ -5,4 +5,8 @@ enum class CityStatePersonality {
     Neutral,
     Hostile,
     Irrational
+    ;
+    companion object {
+        fun safeValueOf(name: String?) = entries.firstOrNull { it.name == name }
+    }
 }

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.validation
 
 import com.unciv.Constants
+import com.unciv.logic.civilization.diplomacy.CityStatePersonality
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.EventChoice
 import com.unciv.models.ruleset.MilestoneType
@@ -162,6 +163,12 @@ internal class BaseRulesetValidator(
             lines.add("${nation.name} is of city-state type ${nation.cityStateType} which does not exist!", sourceObject = nation)
         if (nation.favoredReligion != null && nation.favoredReligion !in ruleset.religions)
             lines.add("${nation.name} has ${nation.favoredReligion} as their favored religion, which does not exist!", sourceObject = nation)
+        if (nation.personality != null) {
+            val unknownPersonality = if (nation.isCityState) CityStatePersonality.safeValueOf(nation.personality) == null
+                else nation.personality !in ruleset.personalities.keys
+            if (unknownPersonality)
+                lines.add("${nation.name} has personality ${nation.personality}, which does not exist!", sourceObject = nation)
+        }
     }
 
     override fun addPersonalityErrors(lines: RulesetErrorList) {

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
@@ -110,7 +110,8 @@ internal class ConsoleCivCommands : ConsoleCommandNode {
             val civ = Civilization(nation)
             if (nation.isCityState) {
                 val usedMajorCivs = civilizations.asSequence().filter { it.isMajorCiv() }.map { it.nation }
-                if (!civ.cityStateFunctions.initCityState(ruleset, gameInfo.gameParameters.startingEra, usedMajorCivs))
+                val rng = GameContext(gameInfo = gameInfo).stateBasedRandom("DevConsole civ add")
+                if (!civ.cityStateFunctions.initCityState(ruleset, gameInfo.gameParameters.startingEra, usedMajorCivs, rng))
                     throw ConsoleErrorException("City-state not allowed in this game")
             }
             civ.gameInfo = gameInfo

--- a/docs/Modders/Mod-file-structure/2-Civilization-related-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/2-Civilization-related-JSON-files.md
@@ -64,7 +64,7 @@ Each nation has the following structure:
 | cityStateType           | String                                                              | none     | Distinguishes major civilizations from city states (must be in [CityStateTypes.json](#citystatetypesjson))                                      |
 | startBias               | List of strings                                                     | empty    | Zero or more of: [terrainFilter](../Unique-parameters.md#terrainfilter) or "Avoid [terrainFilter]". [^S]                                        |
 | preferredVictoryType    | String                                                              | Neutral  | The victory type major civilizations will pursue (need not be specified in [VictoryTypes.json](5-Miscellaneous-JSON-files.md#victorytypesjson)) |
-| personality             | String                                                              | none     | The name of the personality specified in [Personalities.json](#personalitiesjson)                                                               |
+| personality             | String                                                              | none     | The name of the personality specified in [Personalities.json](#personalitiesjson) [^P]                                                          |
 | favoredReligion         | String                                                              | none     | The religion major civilization will choose if available when founding a religion. Must be in [Religions.json](#religionsjson)                  |
 | startIntroPart1         | String                                                              | none     | Introductory blurb shown to Player on game start... [^V]                                                                                        |
 | startIntroPart2         | String                                                              | none     | ... second paragraph. ___NO___ "TBD"!!! Leave empty to skip that alert.                                                                         |
@@ -105,6 +105,8 @@ regions" and startBias is processed differently (but you can expect single-entry
 best).
 
 [^V]: See [Supply Leader Voices](../Images-and-Audio.md#supply-leader-voices)
+
+[^P]: Personalities for city-states work differently. The default chooses one randomly, but a mod can also specify one of Friendly, Neutral, Hostile or Irrational (case-sensitive).
 
 ## Personalities.json
 
@@ -224,7 +226,7 @@ Each policy branch has the following structure:
 
 The "priorities" object defines the priority major civilizations' AI give to a policy branch. The AI
 chooses the policy branch with the highest sum of the peferred victory type listed here and the
-number flisted in the personality's priority. If two or more candidate branches have the same
+number listed in the personality's priority. If two or more candidate branches have the same
 priority, the AI chooses a random branch among the candidates.
 
 The object maps victory types to priority values for the major civilization using strings and

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -113,6 +113,7 @@ class BasicTests {
         ) { baseRuleset: BaseRuleset ->
             val ruleset = RulesetCache[baseRuleset.fullName]!!
             val modCheck = ruleset.getErrorList()
+            println(modCheck.getErrorText(unfiltered = true))
             modCheck.isNotOK()
         }
     }

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -24,6 +24,7 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.Promotion
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.ui.images.ImageGetter
+import kotlin.random.Random
 
 /**
  *  A testing game using a fresh clone of the Civ_V_GnK ruleset so it can be modded in-place.
@@ -172,7 +173,7 @@ class TestGame(vararg addGlobalUniques: String, forUITesting: Boolean = false) {
         // Add 1 tech to the player so the era is computed correctly
         civInfo.tech.addTechnology(ruleset.technologies.values.minBy { it.era() }.name)
         if (cityStateType != null) {
-            civInfo.cityStateFunctions.initCityState(ruleset, "Ancient era", emptySequence())
+            civInfo.cityStateFunctions.initCityState(ruleset, "Ancient era", emptySequence(), Random.Default)
         }
         return civInfo
     }


### PR DESCRIPTION
- Fixes #15010
- Refactor GameStarter into a class since having a lateinit var on the singleton is not the best idea. And if it needs that to pass state between member functions, do it right.
- Validates Nation.personality
- Fixes Siam's personality not working at all (now needed to pass tests, was also included in #15013)
- Allows modding City-state personality
- Another two files free of the "forEachX" warnings