### PR TITLE
Fix "Choose a music track" triggerable in unique builder and unit test

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -941,10 +941,8 @@ enum class UniqueType(
     PlaySound("Play [comment] sound", UniqueTarget.Triggerable, flags = UniqueFlag.setOfHiddenToUsers,
         docDescription = "See [Images and Audio](Images-and-Audio.md#sounds) for a list of available sounds."),
     GetLeaderTitle("Get the leader title of [leaderTitle]", UniqueTarget.Triggerable, flags = UniqueFlag.setOfHiddenToUsers),
-    ChooseMusic("Choose a music track for [unknown], [unknown], [unknown]", UniqueTarget.Triggerable, flags = UniqueFlag.setOfHiddenToUsers,
-        docDescription = CHOOSE_MUSIC_DOCSTRING) {
-        override fun parameterTypeMapInitializer() = arrayListOf<List<UniqueParameterType>>()
-    },
+    ChooseMusic("Choose a music track for [param], [param], [param]", UniqueTarget.Triggerable, flags = UniqueFlag.setOfHiddenToUsers,
+        docDescription = CHOOSE_MUSIC_DOCSTRING),
 
     //endregion
 
@@ -1115,7 +1113,7 @@ enum class UniqueType(
     /** For uniques that have "special" parameters that can accept multiple types, we can override them manually
      *  For 95% of cases, auto-matching is fine. */
     @Readonly
-    open fun parameterTypeMapInitializer(): ArrayList<List<UniqueParameterType>> {
+    internal open fun parameterTypeMapInitializer(): ArrayList<List<UniqueParameterType>> {
         val map = ArrayList<List<UniqueParameterType>>()
         for (placeholder in text.getPlaceholderParameters()) {
             val matchingParameterTypes = placeholder

--- a/core/src/com/unciv/ui/screens/UniqueBuilderScreen.kt
+++ b/core/src/com/unciv/ui/screens/UniqueBuilderScreen.kt
@@ -65,15 +65,19 @@ class UniqueBuilderScreen(ruleset: Ruleset) : PickerScreen() {
     }
 }
 
-class UniqueTable(isMainUnique: Boolean, val ruleset: Ruleset, stage: Stage,
-                  val onUniqueChange : () -> Unit) :Table() {
-    private val parameterSelectBoxTable = Table().apply { defaults().pad(5f) }
-    private val uniqueSelectBoxTable = Table()
+class UniqueTable(
+    isMainUnique: Boolean,
+    val ruleset: Ruleset,
+    stage: Stage,
+    val onUniqueChange: () -> Unit
+) :Table() {
+    // in order of presentation
+    private val uniqueTargetsSelectBox: SelectBox<UniqueTarget>
+    private val uniqueSelectBox = SelectBox<UniqueType>(BaseScreen.skin)
     private val uniqueSearchTextField = TextField("", BaseScreen.skin).apply { messageText = "Search" }
+    internal val uniqueTextField = TextField("Unique", BaseScreen.skin)
+    private val parameterSelectBoxTable = Table().apply { defaults().pad(5f) }
     private val uniqueErrorTable = Table().apply { defaults().pad(5f) }
-
-    val uniqueTextField = TextField("Unique", BaseScreen.skin)
-    private var uniqueTargetsSelectBox: SelectBox<UniqueTarget>
 
     init {
         this.stage = stage // required for width
@@ -92,71 +96,55 @@ class UniqueTable(isMainUnique: Boolean, val ruleset: Ruleset, stage: Stage,
         uniqueTargetsSelectBox.selected = UniqueTarget.Global
         uniqueTargetSelectBoxTable.add(uniqueTargetsSelectBox)
 
-        uniqueTargetSelectBoxTable.add(uniqueSelectBoxTable).row()
+        uniqueTargetSelectBoxTable.add(uniqueSelectBox).width(stage.width * 0.5f).row()
         // Row 2
-        uniqueTargetSelectBoxTable.add()
-        uniqueTargetSelectBoxTable.add(uniqueSearchTextField).row()
+        uniqueTargetSelectBoxTable.add() // shift search to below uniques selectbox
+        uniqueTargetSelectBoxTable.add(uniqueSearchTextField).center().row()
         add(uniqueTargetSelectBoxTable).row()
 
         uniqueTargetsSelectBox.onChange {
-            onUniqueTargetChange(uniqueTargetsSelectBox, ruleset)
+            onUniqueTargetChange()
         }
-        if (!isMainUnique) onUniqueTargetChange(uniqueTargetsSelectBox, ruleset)
+        if (!isMainUnique) onUniqueTargetChange()
+        uniqueSelectBox.onChange {
+            onUniqueSelected()
+        }
+        // Unique search
+        uniqueSearchTextField.onChange {
+            setUniqueSelectBoxItems()
+        }
 
         row()
+        uniqueTextField.onChange {
+            updateUnique()
+        }
         add(uniqueTextField).width(stage.width * 0.9f).row()
         add(parameterSelectBoxTable).row()
-
-
-        uniqueTextField.onChange {
-            updateUnique(ruleset, uniqueTextField)
-        }
 
         uniqueErrorTable.defaults().pad(5f)
         uniqueErrorTable.background = ImageGetter.getWhiteDotDrawable().tint(Color.DARK_GRAY)
         add(uniqueErrorTable).row()
     }
 
-    private fun onUniqueTargetChange(
-        uniqueTargetsSelectBox: SelectBox<UniqueTarget>,
-        ruleset: Ruleset,
-    ) {
-        val selected = uniqueTargetsSelectBox.selected
-        val uniqueSelectBox = SelectBox<UniqueType>(BaseScreen.skin)
-
-        fun setUniqueSelectBoxItems(){
-            val uniquesForTarget = UniqueType.entries.filter { it.canAcceptUniqueTarget(selected) }
-            val uniquesFiltered = uniquesForTarget.filter { it.getDeprecationAnnotation() == null }
-                .filter { it.text.contains(uniqueSearchTextField.text, ignoreCase = true) }
-            uniqueSelectBox.setItems(uniquesFiltered)
-        }
-
-        setUniqueSelectBoxItems()
-
-        uniqueSelectBox.onChange {
-            onUniqueSelected(uniqueSelectBox, uniqueTextField, ruleset, parameterSelectBoxTable)
-        }
-        onUniqueSelected(uniqueSelectBox, uniqueTextField, ruleset, parameterSelectBoxTable)
-
-        // Unique search
-        uniqueSearchTextField.onChange {
-            setUniqueSelectBoxItems()
-        }
-
-        uniqueSelectBoxTable.clear()
-        uniqueSelectBoxTable.add(uniqueSelectBox).width(stage.width * 0.5f).row()
+    private fun setUniqueSelectBoxItems() {
+        val oldType = uniqueSelectBox.selected
+        uniqueSelectBox.selection.clear()
+        val target = uniqueTargetsSelectBox.selected
+        val uniquesForTarget = UniqueType.entries.filter { it.canAcceptUniqueTarget(target) }
+        val uniquesFiltered = uniquesForTarget.filter { it.getDeprecationAnnotation() == null }
+            .filter { it.text.contains(uniqueSearchTextField.text, ignoreCase = true) }
+        uniqueSelectBox.setItems(uniquesFiltered)
+        if (oldType in uniquesFiltered)
+            uniqueSelectBox.selected = oldType
     }
 
-    private fun onUniqueSelected(
-        uniqueSelectBox: SelectBox<UniqueType>,
-        uniqueTextField: TextField,
-        ruleset: Ruleset,
-        parameterSelectBoxTable: Table
-    ) {
+    private fun onUniqueTargetChange() = setUniqueSelectBoxItems()
+
+    private fun onUniqueSelected() {
         val uniqueType = uniqueSelectBox.selected ?: return
 
         uniqueTextField.text = uniqueType.text
-        updateUnique(ruleset, uniqueTextField)
+        updateUnique()
 
         parameterSelectBoxTable.clear()
         for ((index, parameter) in uniqueType.text.getPlaceholderParameters().withIndex()) {
@@ -174,7 +162,7 @@ class UniqueTable(isMainUnique: Boolean, val ruleset: Ruleset, stage: Stage,
                     currentParams[index] = paramSelectBox.selected ?: return@onChange
                     val newText = uniqueType.text.fillPlaceholders(*currentParams.toTypedArray())
                     uniqueTextField.text = newText
-                    updateUnique(ruleset, uniqueTextField)
+                    updateUnique()
                 }
                 paramTable.add(paramSelectBox).row()
 
@@ -190,7 +178,7 @@ class UniqueTable(isMainUnique: Boolean, val ruleset: Ruleset, stage: Stage,
         }
     }
 
-    private fun updateUnique(ruleset: Ruleset, uniqueTextField: TextField) {
+    private fun updateUnique() {
         uniqueErrorTable.clear()
         uniqueErrorTable.add("Errors:".toLabel()).row()
 
@@ -207,6 +195,6 @@ class UniqueTable(isMainUnique: Boolean, val ruleset: Ruleset, stage: Stage,
     /** Needs to come AFTER the UniqueTable is registered in the UniqueBuilderScreen,
      * because it needs to update the final unique text */
     fun initialize() {
-        onUniqueTargetChange(uniqueTargetsSelectBox, ruleset)
+        onUniqueTargetChange()
     }
 }

--- a/core/src/com/unciv/ui/screens/UniqueBuilderScreen.kt
+++ b/core/src/com/unciv/ui/screens/UniqueBuilderScreen.kt
@@ -2,7 +2,9 @@ package com.unciv.ui.screens
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
@@ -18,6 +20,7 @@ import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.LanguageTable
 import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageTables
+import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.options.OptionsPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -76,6 +79,8 @@ class UniqueTable(
     private val uniqueSelectBox = SelectBox<UniqueType>(BaseScreen.skin)
     private val uniqueSearchTextField = TextField("", BaseScreen.skin).apply { messageText = "Search" }
     internal val uniqueTextField = TextField("Unique", BaseScreen.skin)
+    private val documentationLabel = WrappableLabel("", stage.width * 0.9f)
+    private val documentationCell: Cell<Actor?>
     private val parameterSelectBoxTable = Table().apply { defaults().pad(5f) }
     private val uniqueErrorTable = Table().apply { defaults().pad(5f) }
 
@@ -119,6 +124,9 @@ class UniqueTable(
             updateUnique()
         }
         add(uniqueTextField).width(stage.width * 0.9f).row()
+
+        documentationCell = add().width(stage.width * 0.9f).pad(0f)
+        row()
         add(parameterSelectBoxTable).row()
 
         uniqueErrorTable.defaults().pad(5f)
@@ -145,6 +153,14 @@ class UniqueTable(
 
         uniqueTextField.text = uniqueType.text
         updateUnique()
+
+        if (uniqueType.docDescription.isNullOrEmpty()) {
+            documentationCell.setActor(null).pad(0f)
+        } else {
+            documentationLabel.setText(uniqueType.docDescription)
+            documentationLabel.optimizePrefWidth()
+            documentationCell.setActor(documentationLabel).pad(10f)
+        }
 
         parameterSelectBoxTable.clear()
         for ((index, parameter) in uniqueType.text.getPlaceholderParameters().withIndex()) {

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -265,7 +265,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable
 
-??? example  "Choose a music track for [unknown], [unknown], [unknown]"
+??? example  "Choose a music track for [param], [param], [param]"
 	Parameters are unchecked, strings not matching existing tracks or flags are ignored.
 
 	See [Context-sensitive music](Images-and-Audio.md#context-sensitive-music-overview)
@@ -275,6 +275,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	The second parameter is a list of zero or more suffixes, comma-separated, used to specify a "mood", like Peace, War, Ambient etc. First track that matches wins.
 
 	The third parameter is a list of zero or more flags: PrefixMustMatch, SuffixMustMatch, SlowFade, PlaySingle, PlayDefaultFile.
+
+	Example: "Choose a music track for [Unknown], [Unknown], [Unknown]"
 
 	This unique is automatically hidden from users.
 

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -123,13 +123,11 @@ class BasicTests {
         var noUnknownParameters = true
         for (uniqueType in UniqueType.entries) {
             if (uniqueType.getDeprecationAnnotation() != null) continue
-            for (entry in uniqueType.parameterTypeMap.withIndex()) {
-                for (paramType in entry.value) {
-                    if (paramType == UniqueParameterType.Unknown) {
-                        val badParam = uniqueType.text.getPlaceholderParameters()[entry.index]
-                        println("${uniqueType.name} param[${entry.index}] type \"$badParam\" is unknown")
-                        noUnknownParameters = false
-                    }
+            val actualParameters = uniqueType.text.getPlaceholderParameters()
+            for ((index, parameterName) in actualParameters.withIndex()) {
+                if (uniqueType.parameterTypeMap[index].isEmpty()) {
+                    println("${uniqueType.name} param[${index}] type \"$parameterName\" is unknown")
+                    noUnknownParameters = false
                 }
             }
         }


### PR DESCRIPTION
Fixes #15021

Point is, the unit test was mistaken. Actually using `UniqueParameterType.Unknown` isn't evil, using a placeholder not listed in `UniqueParameterType` is. The symptom is an empty list in its `parameterTypeMap` place. Things like "param/mistake" can't be caught at the moment, not by using parameterTypeMap. To catch such things, add an "Invalid" UniqueParameterType, map instead of mapNotNull, and append ?: Invalid to the safeValueOf... Or let the unit test parse the string itself.

Oh, and I added something to the unique builder too:
<img width="1206" height="543" alt="Image" src="https://github.com/user-attachments/assets/097a5b67-80c4-4627-b387-282257ecb671" />
That's of course not doing markdown components as markdown, but is should help anyway.
