### PR TITLE
Require CreatesOneImprovement targets be owned by constructing city

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -23,6 +23,7 @@ import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.PerpetualConstruction
 import com.unciv.models.ruleset.RejectionReasonType
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
@@ -763,7 +764,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             val finalTile = tile
                 ?: Automation.getTileForConstructionImprovement(city, improvementToPlace)
                 ?: return false // This was never reached in testing
-            finalTile.improvementFunctions.markForCreatesOneImprovement(improvementToPlace.name)
+            if (!tryPlaceCreateOneImprovementMarker(improvementToPlace, finalTile)) return false
             // postBuildEvent does the rest by calling cityConstructions.applyCreateOneImprovement
         }
 
@@ -859,8 +860,38 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         
         if (getTileForImprovement(improvement.name) == null) {
             val newTile = Automation.getTileForConstructionImprovement(city, improvement) ?: return
-            newTile.improvementFunctions.markForCreatesOneImprovement(improvement.name)
+            tryPlaceCreateOneImprovementMarker(improvement, newTile)
         }
+    }
+
+    /** Whether this city may mark its own [tile] to create [improvement] when construction completes. */
+    @Readonly
+    fun canPlaceCreateOneImprovementOn(improvement: TileImprovement, tile: Tile): Boolean =
+        tile.getCity() == city
+            && tile in city.tilesInRange
+            && !tile.isCityCenter()
+            && !tile.isMarkedForCreatesOneImprovement()
+            && tile.improvementFunctions.canBuildImprovement(improvement, city.state)
+
+    /**
+     * Try to mark [tile] so completing this construction will create [improvement] there.
+     *
+     * The tile must already belong to this city; reaching marker placement with another
+     * city's tile is invalid internal state and fails loudly.
+     *
+     * @return `true` if [tile] is now marked for [improvement], or `false` if it is not eligible.
+     */
+    fun tryPlaceCreateOneImprovementMarker(improvement: TileImprovement, tile: Tile): Boolean {
+        if (tile.getCity() == city && tile.isMarkedForCreatesOneImprovement(improvement.name))
+            return true
+        check(tile.getCity() == city) {
+            "Cannot mark ${tile.position} for ${UniqueType.CreatesOneImprovement.name} in ${city.name}: tile is owned by ${tile.getCity()?.name ?: "no city"}"
+        }
+        if (!canPlaceCreateOneImprovementOn(improvement, tile))
+            return false
+
+        tile.improvementFunctions.markForCreatesOneImprovement(improvement.name)
+        return true
     }
 
     @Readonly
@@ -915,10 +946,9 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         val tileForImprovement = requireNotNull(tile) {
             "Cannot queue ${construction.name} without a target tile for ${UniqueType.CreatesOneImprovement.name}"
         }
-        require(tileForImprovement.improvementFunctions.canBuildImprovement(improvementToCreate, city.state)) {
-            "Cannot queue ${construction.name}: ${improvementToCreate.name} cannot be built on ${tileForImprovement.position}"
+        require(tryPlaceCreateOneImprovementMarker(improvementToCreate, tileForImprovement)) {
+            "Cannot queue ${construction.name}: ${improvementToCreate.name} cannot be created on ${tileForImprovement.position}"
         }
-        tileForImprovement.improvementFunctions.markForCreatesOneImprovement(improvementToCreate.name)
     }
 
     /** Add a construction named [constructionName] to the end of the queue with all checks

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -260,7 +260,7 @@ class CityScreen(
             val improvementToPlace = pickTileData!!.improvement
             return when {
                 tile.isMarkedForCreatesOneImprovement() -> Color.BROWN to 0.7f
-                !tile.improvementFunctions.canBuildImprovement(improvementToPlace, city.state) -> Color.RED to 0.4f
+                !city.cityConstructions.canPlaceCreateOneImprovementOn(improvementToPlace, tile) -> Color.RED to 0.4f
                 isExistingImprovementValuable(tile) -> Color.ORANGE to 0.5f
                 tile.improvement != null -> Color.YELLOW to 0.6f
                 tile.turnsToImprovement > 0 -> Color.YELLOW to 0.6f
@@ -282,7 +282,7 @@ class CityScreen(
                 /** Support for [UniqueType.CreatesOneImprovement] */
                 tileGroup.tile == selectedQueueEntryTargetTile ->
                     tileGroup.layerMisc.addHexOutline(Color.BROWN)
-                pickTileData != null && city.tiles.contains(tileGroup.tile.position) ->
+                pickTileData != null && tileGroup.tile.getCity() == city && tileGroup.tile in city.tilesInRange ->
                     getPickImprovementColor(tileGroup.tile).run {
                         tileGroup.layerMisc.addHexOutline(first.cpy().apply { this.a = second }) }
             }
@@ -476,8 +476,7 @@ class CityScreen(
             val pickTileData = this.pickTileData!!
             this.pickTileData = null
             val improvement = pickTileData.improvement
-            if (tileInfo.improvementFunctions.canBuildImprovement(improvement, city.state)
-                && !tileInfo.isMarkedForCreatesOneImprovement()) {
+            if (city.cityConstructions.canPlaceCreateOneImprovementOn(improvement, tileInfo)) {
                 
                 if (pickTileData.isBuying) {
                     BuyButtonFactory(this).askToBuyConstruction(pickTileData.building, pickTileData.buyStat, tileInfo)

--- a/tests/src/com/unciv/logic/city/CityTest.kt
+++ b/tests/src/com/unciv/logic/city/CityTest.kt
@@ -100,7 +100,7 @@ class CityTest {
         val farm = testGame.ruleset.tileImprovements["Farm"]!!
         testCiv.tech.techsResearched.add(farm.techRequired!!)
         val building = createFarmPlacingBuilding()
-        val targetTile = testGame.setTileTerrain(HexCoord(1, 1), Constants.grassland)
+        val targetTile = testGame.setTileTerrain(HexCoord(1, 0), Constants.grassland)
 
         capitalCity.cityConstructions.addToQueue(building, tile = targetTile)
 
@@ -147,8 +147,7 @@ class CityTest {
         val farm = testGame.ruleset.tileImprovements["Farm"]!!
         testCiv.tech.techsResearched.add(farm.techRequired!!)
         val building = createFarmPlacingBuilding()
-        val targetTile = testGame.getTile(1, 1)
-        targetTile.baseTerrain = Constants.grassland
+        val targetTile = testGame.setTileTerrain(HexCoord(1, 0), Constants.grassland)
         capitalCity.cityConstructions.addToQueue(building, tile = targetTile)
 
         capitalCity.cityConstructions.removeFromQueue(0, false)

--- a/tests/src/com/unciv/logic/city/CityTest.kt
+++ b/tests/src/com/unciv/logic/city/CityTest.kt
@@ -19,7 +19,7 @@ class CityTest {
 
     @Before
     fun setUp() {
-        testGame.makeHexagonalMap(2)
+        testGame.makeHexagonalMap(4)
         testCiv = testGame.addCiv()
         capitalCity = testGame.addCity(testCiv, testGame.getTile(HexCoord.Zero))
     }
@@ -96,12 +96,11 @@ class CityTest {
     }
 
     @Test
-    fun `should mark selected tile when queueing CreatesOneImprovement building`() {
+    fun `should mark selected owned tile when queueing CreatesOneImprovement building`() {
         val farm = testGame.ruleset.tileImprovements["Farm"]!!
         testCiv.tech.techsResearched.add(farm.techRequired!!)
         val building = createFarmPlacingBuilding()
-        val targetTile = testGame.getTile(1, 1)
-        targetTile.baseTerrain = Constants.grassland
+        val targetTile = testGame.setTileTerrain(HexCoord(1, 1), Constants.grassland)
 
         capitalCity.cityConstructions.addToQueue(building, tile = targetTile)
 
@@ -124,6 +123,26 @@ class CityTest {
     }
 
     @Test
+    fun `should fail loudly when marking CreatesOneImprovement tile owned by another city`() {
+        val secondCity = testGame.addCity(testCiv, testGame.getTile(0, 2))
+        val targetTile = testGame.setTileTerrain(HexCoord(0, 1), Constants.grassland)
+        val farm = testGame.ruleset.tileImprovements["Farm"]!!
+
+        assertEquals(capitalCity, targetTile.getCity())
+        assertFalse(secondCity.cityConstructions.canPlaceCreateOneImprovementOn(farm, targetTile))
+
+        try {
+            secondCity.cityConstructions.tryPlaceCreateOneImprovementMarker(farm, targetTile)
+            fail("Expected marking another city's tile to fail")
+        } catch (ex: IllegalStateException) {
+            assertTrue(ex.message!!.contains("tile is owned by"))
+        }
+
+        assertEquals(capitalCity, targetTile.getCity())
+        assertFalse(targetTile.isMarkedForCreatesOneImprovement())
+    }
+
+    @Test
     fun `should clear marker when removing CreatesOneImprovement building from queue`() {
         val farm = testGame.ruleset.tileImprovements["Farm"]!!
         testCiv.tech.techsResearched.add(farm.techRequired!!)
@@ -138,8 +157,42 @@ class CityTest {
         assertFalse(capitalCity.cityConstructions.isBeingConstructedOrEnqueued(building.name))
     }
 
+    @Test
+    fun `should not mark CreatesOneImprovement tile outside city range`() {
+        val secondCity = testGame.addCity(testCiv, testGame.getTile(0, 2))
+        val targetTile = testGame.setTileTerrain(HexCoord(0, -4), Constants.grassland)
+        val farm = testGame.ruleset.tileImprovements["Farm"]!!
+        secondCity.expansion.takeOwnership(targetTile)
+
+        val markerPlaced = secondCity.cityConstructions.tryPlaceCreateOneImprovementMarker(farm, targetTile)
+
+        assertFalse(markerPlaced)
+        assertEquals(secondCity, targetTile.getCity())
+        assertFalse(targetTile.isMarkedForCreatesOneImprovement())
+    }
+
+    @Test
+    fun `should complete CreatesOneImprovement purchase on owned tile`() {
+        testGame.gameInfo.gameParameters.godMode = true
+        val secondCity = testGame.addCity(testCiv, testGame.getTile(0, 2))
+        val targetTile = testGame.setTileTerrain(HexCoord(0, 3), Constants.grassland)
+        val building = createFarmPlacingBuilding()
+
+        val purchased = secondCity.cityConstructions.purchaseConstruction(
+            building,
+            queuePosition = -1,
+            automatic = false,
+            tile = targetTile
+        )
+
+        assertTrue(purchased)
+        assertTrue(secondCity.cityConstructions.isBuilt(building.name))
+        assertEquals(secondCity, targetTile.getCity())
+        assertEquals("Farm", targetTile.improvement)
+        assertFalse(targetTile.isMarkedForCreatesOneImprovement())
+    }
+
     private fun createFarmPlacingBuilding() =
         testGame.createBuilding("Creates a [Farm] improvement on a specific tile")
-            .apply { ruleset = testGame.ruleset }
 
 }

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -274,6 +274,7 @@ class TestGame(vararg addGlobalUniques: String, forUITesting: Boolean = false) {
         createRulesetObject(ruleset.beliefs, *uniques) { Belief(type) }
     fun createBuilding(vararg uniques: String) =
         createRulesetObject(ruleset.buildings, *uniques) { Building() }
+            .apply { ruleset = gameInfo.ruleset }
     fun createResource(vararg uniques: String) =
         createRulesetObject(ruleset.tileResources, *uniques) { TileResource() }
 


### PR DESCRIPTION
## Summary

Fixes `CreatesOneImprovement` district placement so a city can only place the construction marker on tiles it already owns.

The city screen can expose same-civ tiles owned by another city when city ranges overlap. Those tiles are now treated as ineligible for `CreatesOneImprovement` placement by the constructing city. If lower-level marker placement is somehow called with another city-owned tile, it fails loudly instead of silently marking or transferring ownership.

## Problem

Civ6-style districts are represented as buildings that create a tile improvement on a selected tile.

The city screen could allow city 2 to select a tile owned by city 1 if the tile was otherwise buildable. City 2 would then complete the city building, but completion searched only city 2 owned tiles for the marker. The result was that the city building completed while the tile remained stuck under construction.

The important distinction is ownership, not current worked status.

## Changes

- Adds shared `CityConstructions` placement helpers for `CreatesOneImprovement` markers.
- Requires target tiles to be owned by the constructing city, inside that city workable range, non-city-center, unmarked, and buildable for the improvement.
- Makes marker placement fail loudly if called with a tile owned by another city.
- Uses the same placement eligibility in city-screen highlighting and click handling.
- Routes purchase and automated marker creation through the shared helper.
- Updates `TestGame.createBuilding()` to initialize building ruleset state for tests.
- Adds tests for owned-tile queueing, other-city tile rejection, out-of-range rejection, queue cleanup, and purchase/completion on an owned tile.

## Out of scope

Manual same-civ tile transfer may be useful, but this PR intentionally does not hide that inside district placement. Cities can already work eligible same-civ tiles owned by another city, so a future transfer feature should be explicit and limited to cases where ownership itself matters. One possible follow-up would show eligible other-city-owned tiles in a distinct color during district placement and ask whether to transfer the tile before allowing placement.

## Testing

```bash
./gradlew tests:test --tests com.unciv.logic.city.CityTest
./gradlew compileKotlin
./gradlew test
git diff --check
```