### PR TITLE
Fix map preview crash when changing rulesets

### DIFF
--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -545,6 +545,8 @@ class GameOptionsTable(
         gameParameters.victoryTypes.removeAll { it !in ruleset.victories.keys }
         if (gameParameters.victoryTypes.isEmpty())
             gameParameters.victoryTypes.addAll(ruleset.victories.keys)
+
+        (previousScreen as? NewGameScreen)?.refreshExampleMap()
     }
 
     private fun getModCheckboxes(isPortrait: Boolean = false): ModCheckboxTable {

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
@@ -77,5 +77,14 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen) : Table() {
         return scenarioOptionsTable.selectedScenario
     }
 
-    internal fun cancelBackgroundJobs() = savedMapOptionsTable.cancelBackgroundJobs()
+    internal fun cancelBackgroundJobs() {
+        generatedMapOptionsTable.cancelBackgroundJobs()
+        randomMapOptionsTable.cancelBackgroundJobs()
+        savedMapOptionsTable.cancelBackgroundJobs()
+    }
+
+    internal fun refreshExampleMap() {
+        generatedMapOptionsTable.generateExampleMap()
+        randomMapOptionsTable.generateExampleMap()
+    }
 }

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
@@ -143,19 +143,19 @@ class MapParametersTable(
         }
     }
 
-    internal fun generateExampleMap(){
+    internal fun generateExampleMap() {
         cancelBackgroundJobs()
         val generation = ++exampleMapGeneration
         val ruleset = if (previousScreen is NewGameScreen) previousScreen.ruleset.clone() else RulesetCache.getVanillaRuleset()
         val mapParametersForExample = if (forMapEditor) mapParameters else mapParameters.clone().apply { seed = 0 }
         exampleMapJob = Concurrency.run("Generate example map") {
             val exampleMap = MapGenerator(ruleset).generateMap(mapParametersForExample, GameParameters())
-            if (!isActive || generation != exampleMapGeneration) return@run
+            if (!isActive) return@run
             Concurrency.runOnGLThread {
                 if (generation != exampleMapGeneration) return@runOnGLThread
                 mapTypeExample.clear()
                 val mapPreview = LoadMapPreview(exampleMap, maxMapSize, maxMapSize)
-                if (!forMapEditor){
+                if (!forMapEditor) {
                     val label = "Example map".toLabel()
                     label.centerX(mapPreview)
                     label.y = mapPreview.height - label.height - 10f

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
@@ -19,6 +19,8 @@ import com.unciv.ui.components.widgets.*
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.victoryscreen.LoadMapPreview
 import com.unciv.utils.Concurrency
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 
 /** Table for editing [mapParameters]
  *
@@ -59,6 +61,9 @@ class MapParametersTable(
 
     private val maxMapSize = ((previousScreen as? NewGameScreen)?.getColumnWidth() ?: 200f) - 10f // There is 5px padding each side
     private val mapTypeExample = Table()
+    private var exampleMapJob: Job? = null
+    @Volatile
+    private var exampleMapGeneration = 0
 
     // Keep references (in the key) and settings value getters (in the value) of the 'advanced' sliders
     // in a HashMap for reuse later - in the reset to defaults button. Better here as field than as closure.
@@ -138,12 +143,16 @@ class MapParametersTable(
         }
     }
 
-    private fun generateExampleMap(){
-        val ruleset = if (previousScreen is NewGameScreen) previousScreen.ruleset else RulesetCache.getVanillaRuleset()
-        Concurrency.run("Generate example map") {
-            val mapParametersForExample = if (forMapEditor) mapParameters else mapParameters.clone().apply { seed = 0 }
+    internal fun generateExampleMap(){
+        cancelBackgroundJobs()
+        val generation = ++exampleMapGeneration
+        val ruleset = if (previousScreen is NewGameScreen) previousScreen.ruleset.clone() else RulesetCache.getVanillaRuleset()
+        val mapParametersForExample = if (forMapEditor) mapParameters else mapParameters.clone().apply { seed = 0 }
+        exampleMapJob = Concurrency.run("Generate example map") {
             val exampleMap = MapGenerator(ruleset).generateMap(mapParametersForExample, GameParameters())
+            if (!isActive || generation != exampleMapGeneration) return@run
             Concurrency.runOnGLThread {
+                if (generation != exampleMapGeneration) return@runOnGLThread
                 mapTypeExample.clear()
                 val mapPreview = LoadMapPreview(exampleMap, maxMapSize, maxMapSize)
                 if (!forMapEditor){
@@ -155,7 +164,18 @@ class MapParametersTable(
                 mapTypeExample.add(mapPreview)
                 pack()
             }
+        }.apply {
+            invokeOnCompletion {
+                if (generation == exampleMapGeneration)
+                    exampleMapJob = null
+            }
         }
+    }
+
+    internal fun cancelBackgroundJobs() {
+        exampleMapGeneration++
+        exampleMapJob?.cancel()
+        exampleMapJob = null
     }
 
     private fun addMapTypeSelectBox() {

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -59,6 +59,7 @@ class NewGameScreen(
     private val newGameOptionsTable: GameOptionsTable
     internal val playerPickerTable: PlayerPickerTable
     private val mapOptionsTable: MapOptionsTable
+    private var mapOptionsTableInitialized = false
 
     init {
         val isPortrait = isNarrowerThan4to3()
@@ -82,6 +83,7 @@ class NewGameScreen(
             updatePlayerPickerRandomLabel = { playerPickerTable.updateRandomNumberLabel() }
         )
         mapOptionsTable = MapOptionsTable(this)
+        mapOptionsTableInitialized = true
         closeButton.onActivation {
             mapOptionsTable.cancelBackgroundJobs()
             game.popScreen()
@@ -226,6 +228,11 @@ class NewGameScreen(
     /** Subtables may need an upper limit to their width - they can ask this function. */
     // In sync with isPortrait in init, here so UI details need not know about 3-column vs 1-column layout
     internal fun getColumnWidth() = floor(stage.width / (if (isNarrowerThan4to3()) 1 else 3))
+
+    internal fun refreshExampleMap() {
+        if (mapOptionsTableInitialized)
+            mapOptionsTable.refreshExampleMap()
+    }
 
     private fun initLandscape() {
         scrollPane.setScrollingDisabled(true,true)


### PR DESCRIPTION
Fixes #14952.

The map preview job was reading `NewGameScreen.ruleset` directly while changing mods or base rulesets clears and rebuilds that object. That could leave preview generation using a partially reloaded ruleset.

This snapshots the ruleset before starting preview generation, cancels stale preview jobs, and refreshes generated-map previews after a ruleset reload.

Tested:
- `./gradlew :desktop:compileKotlin`
- `./gradlew :tests:test --tests "com.unciv.*"`