### PR TITLE
fix: Validate Personality uniques instead of blanket \"not supported\" warning

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -368,8 +368,7 @@ open class RulesetValidator protected constructor(
 
     protected open fun addPersonalityErrors(lines: RulesetErrorList) {
         for (personality in ruleset.personalities.values) {
-            if (personality.uniques.isNotEmpty())
-                lines.add("Personality Uniques are not supported", RulesetErrorSeverity.Warning, personality)
+            uniqueValidator.checkUniques(personality, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 

--- a/tests/src/com/unciv/uniques/RulesetValidatorTests.kt
+++ b/tests/src/com/unciv/uniques/RulesetValidatorTests.kt
@@ -2,15 +2,27 @@ package com.unciv.uniques
 
 import com.unciv.models.ruleset.Building
 import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.ruleset.nation.Personality
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.validation.RulesetErrorSeverity
+import com.unciv.models.translations.fillPlaceholders
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(GdxTestRunner::class)
 class RulesetValidatorTests {
+
+    private fun addPersonality(game: TestGame, name: String, vararg uniques: String): Personality {
+        return Personality().apply {
+            this.name = name
+            uniques.toCollection(this.uniques)
+            game.ruleset.personalities[name] = this
+        }
+    }
 
     @Test
     fun `ruleset validator warns about spy name collision with ruleset object`() {
@@ -111,6 +123,42 @@ class RulesetValidatorTests {
                 && it.text.contains("\"Park\"")
                 && it.text.contains("Building")
                 && it.text.contains("Nation.cities")
+        })
+    }
+
+    @Test
+    fun `ruleset validator accepts personality without uniques`() {
+        val game = TestGame()
+        addPersonality(game, "Reserved")
+
+        val errors = game.ruleset.getErrorList()
+
+        assertFalse(errors.any { it.text.contains("Personality Uniques are not supported") })
+    }
+
+    @Test
+    fun `ruleset validator accepts supported personality uniques`() {
+        val game = TestGame()
+        val unique = UniqueType.WillNotBuild.text.fillPlaceholders("Melee")
+        addPersonality(game, "Builder Avoider", unique)
+
+        val errors = game.ruleset.getErrorList()
+
+        assertFalse(errors.any { it.text.contains("Personality Uniques are not supported") })
+        assertFalse(errors.any { it.text.contains(unique) })
+    }
+
+    @Test
+    fun `ruleset validator warns about non personality uniques on personalities`() {
+        val game = TestGame()
+        addPersonality(game, "Unsupported Unique Holder", UniqueType.Unbuildable.text)
+
+        val errors = game.ruleset.getErrorList()
+
+        assertTrue(errors.any {
+            it.errorSeverityToReport == RulesetErrorSeverity.Warning
+                && it.text.contains(UniqueType.Unbuildable.text)
+                && it.text.contains("not allowed on its target type")
         })
     }
 }


### PR DESCRIPTION
## Summary
RulesetValidator.addPersonalityErrors() unconditionally emits the warning "Personality Uniques are not supported" for any Personality that has uniques. This contradicts UniqueType.kt, which defines a real, functional Personality-targeted unique: WillNotBuild (UniqueTarget.Personality), used in ConstructionAutomation and NextTurnAutomation to steer AI construction.

Fixes #15022
