### PR TITLE
fix: Stop flagging conditional modifiers inside the display-only Comment unique

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -130,7 +130,20 @@ class UniqueValidator(val ruleset: Ruleset) {
             rulesetErrors += getExpressionParseErrors(complianceError, uniqueContainer, unique)
         }
 
-        for (modifier in unique.modifiers) {
+        if (unique.type == UniqueType.Comment) {
+            // A Comment is display-only text, so a `<...>` inside it is not a modifier at all.
+            // getModifiers() parses it as one anyway, and removeConditionals() then strips it
+            // from the text the user actually sees. Report that once, with both likely causes,
+            // instead of emitting a "not an acceptable modifier" line per parsed pseudo-modifier.
+            if (unique.modifiers.isNotEmpty())
+                rulesetErrors.add(
+                    "$prefix is a Comment containing \"<\", which is parsed as a modifier and" +
+                        " removed from the displayed text." +
+                        " This may be a conditional that was accidentally moved into the comment;" +
+                        " to reuse a translation inside a comment, use nested [] instead.",
+                    RulesetErrorSeverity.Warning, uniqueContainer, unique
+                )
+        } else for (modifier in unique.modifiers) {
             rulesetErrors += getModifierErrors(modifier, prefix, unique, uniqueContainer, severityToReport)
         }
 
@@ -274,7 +287,7 @@ class UniqueValidator(val ruleset: Ruleset) {
         if (modifier.type.targetTypes.none { it.isAcceptableModifierFor(unique) }) { // No target is a modifier for whatever
             rulesetErrors.add(
                 "$prefix contains the modifier \"${modifier.text}\"," +
-                        " which is not an acceptable modifier for this unique.",
+                    " which is not an acceptable modifier for this unique.",
                 RulesetErrorSeverity.Warning, uniqueContainer, unique
             )
         }

--- a/tests/src/com/unciv/uniques/UniqueErrorTests.kt
+++ b/tests/src/com/unciv/uniques/UniqueErrorTests.kt
@@ -18,6 +18,15 @@ import org.junit.runner.RunWith
 
 @RunWith(GdxTestRunner::class)
 class UniqueErrorTests {
+    private fun validateUnique(uniqueText: String) =
+        UniqueValidator(RulesetCache.getVanillaRuleset()).checkUnique(Unique(uniqueText), false, null)
+
+    private fun hasUnacceptableModifierWarning(uniqueText: String): Boolean =
+        validateUnique(uniqueText).any { it.text.contains("which is not an acceptable modifier for this unique") }
+
+    private fun commentAngleBracketWarnings(uniqueText: String) =
+        validateUnique(uniqueText).filter { it.text.contains("is a Comment containing") }
+
     @Test
     fun testMultipleUniqueTypesSameText() {
         val textToUniqueType = HashMap<String, UniqueType>()
@@ -100,6 +109,47 @@ class UniqueErrorTests {
         val uniqueWithSourceObject = Unique(uniqueText, sourceObjectType = UniqueTarget.Promotion)
         val errorListCorrectUniqueContainer = UniqueValidator(ruleset).checkUnique(uniqueWithSourceObject, false, null)
         assert(errorListCorrectUniqueContainer.getFinalSeverity() == RulesetErrorSeverity.OK)
+    }
+
+    @Test
+    fun testCommentUniqueWithAngleBracketsWarnsOnceInsteadOfPerModifier() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Comment [Adopt [Feudalism] <upon entering the [Medieval era]>]"
+
+        // The text inside a Comment is display-only, so it must not be validated as a modifier...
+        Assert.assertFalse(hasUnacceptableModifierWarning(uniqueText))
+
+        // ...but the modder still needs to know the `<...>` is parsed out and dropped from display,
+        // so exactly one warning fires, carrying both likely causes.
+        val warnings = commentAngleBracketWarnings(uniqueText)
+        Assert.assertEquals(1, warnings.size)
+        Assert.assertTrue(warnings.single().text.contains("removed from the displayed text"))
+        Assert.assertTrue(warnings.single().text.contains("use nested [] instead"))
+    }
+
+    @Test
+    fun testCommentUniqueWithMultipleAngleBracketsStillWarnsOnce() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Comment [see <one> and <two>]"
+
+        Assert.assertEquals(1, commentAngleBracketWarnings(uniqueText).size)
+    }
+
+    @Test
+    fun testPlainCommentUniqueHasNoValidationWarnings() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Comment [Plain display text]"
+
+        Assert.assertEquals(RulesetErrorSeverity.OK, validateUnique(uniqueText).getFinalSeverity())
+        Assert.assertTrue(commentAngleBracketWarnings(uniqueText).isEmpty())
+    }
+
+    @Test
+    fun testNonCommentUniqueStillRejectsUnacceptableModifier() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Blocks line-of-sight from tiles at same elevation <upon entering the [Medieval era]>"
+
+        Assert.assertTrue(hasUnacceptableModifierWarning(uniqueText))
     }
 
     @Test

--- a/tests/src/com/unciv/uniques/UniqueErrorTests.kt
+++ b/tests/src/com/unciv/uniques/UniqueErrorTests.kt
@@ -19,6 +19,15 @@ import org.junit.runner.RunWith
 
 @RunWith(BaseTestRunner::class)
 class UniqueErrorTests {
+    private fun validateUnique(uniqueText: String) =
+        UniqueValidator(RulesetCache.getVanillaRuleset()).checkUnique(Unique(uniqueText), false, null)
+
+    private fun hasUnacceptableModifierWarning(uniqueText: String): Boolean =
+        validateUnique(uniqueText).any { it.text.contains("which is not an acceptable modifier for this unique") }
+
+    private fun commentAngleBracketWarnings(uniqueText: String) =
+        validateUnique(uniqueText).filter { it.text.contains("is a Comment containing") }
+
     @Test
     fun testMultipleUniqueTypesSameText() {
         val textToUniqueType = HashMap<String, UniqueType>()
@@ -117,6 +126,47 @@ class UniqueErrorTests {
     @Test
     fun testOneTimeGainStatRangeRejectsNonCivWideStats() {
         assertOnlyCivWideStatsError("Gain [5]-[10] [Production]", "Production")
+    }
+
+    @Test
+    fun testCommentUniqueWithAngleBracketsWarnsOnceInsteadOfPerModifier() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Comment [Adopt [Feudalism] <upon entering the [Medieval era]>]"
+
+        // The text inside a Comment is display-only, so it must not be validated as a modifier...
+        Assert.assertFalse(hasUnacceptableModifierWarning(uniqueText))
+
+        // ...but the modder still needs to know the `<...>` is parsed out and dropped from display,
+        // so exactly one warning fires, carrying both likely causes.
+        val warnings = commentAngleBracketWarnings(uniqueText)
+        Assert.assertEquals(1, warnings.size)
+        Assert.assertTrue(warnings.single().text.contains("removed from the displayed text"))
+        Assert.assertTrue(warnings.single().text.contains("use nested [] instead"))
+    }
+
+    @Test
+    fun testCommentUniqueWithMultipleAngleBracketsStillWarnsOnce() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Comment [see <one> and <two>]"
+
+        Assert.assertEquals(1, commentAngleBracketWarnings(uniqueText).size)
+    }
+
+    @Test
+    fun testPlainCommentUniqueHasNoValidationWarnings() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Comment [Plain display text]"
+
+        Assert.assertEquals(RulesetErrorSeverity.OK, validateUnique(uniqueText).getFinalSeverity())
+        Assert.assertTrue(commentAngleBracketWarnings(uniqueText).isEmpty())
+    }
+
+    @Test
+    fun testNonCommentUniqueStillRejectsUnacceptableModifier() {
+        RulesetCache.loadRulesets(noMods = true)
+        val uniqueText = "Blocks line-of-sight from tiles at same elevation <upon entering the [Medieval era]>"
+
+        Assert.assertTrue(hasUnacceptableModifierWarning(uniqueText))
     }
 
     @Test


### PR DESCRIPTION
## Summary
A Comment unique (UniqueType.Comment, "Comment [comment]", a display-only Displayable) that embeds conditional-style brackets in its text, e.g. "Comment [Adopt [Feudalism] <upon entering the [Medieval era]>]", triggers the UniqueValidator warning "contains the modifier ...

Fixes #14827
