### PR TITLE
Fix incorrect resource quantities on mirrored maps

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -267,7 +267,6 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             tile.naturalWonder = mirrorTile.naturalWonder
             tile.setTerrainFeatures(mirrorTile.terrainFeatures)
             tile.tileResource = mirrorTile.tileResource
-            tile.resourceAmount = mirrorTile.resourceAmount
             tile.setImprovementBasic(mirrorTile.tileImprovement)
             
             for (neighbor in tile.neighbors){
@@ -277,10 +276,9 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             }
         }
 
-        //if (map.mapParameters.mirroring == MirroringType.none) return
+        if (map.mapParameters.mirroring == MirroringType.none) return
         for (tile in map.values) {
-            copyTile(tile, MirroringType.leftright)
-            //copyTile(tile, map.mapParameters.mirroring)
+            copyTile(tile, map.mapParameters.mirroring)
         }
     }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -267,6 +267,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             tile.naturalWonder = mirrorTile.naturalWonder
             tile.setTerrainFeatures(mirrorTile.terrainFeatures)
             tile.tileResource = mirrorTile.tileResource
+            tile.resourceAmount = mirrorTile.resourceAmount
             tile.setImprovementBasic(mirrorTile.tileImprovement)
             
             for (neighbor in tile.neighbors){

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -267,6 +267,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             tile.naturalWonder = mirrorTile.naturalWonder
             tile.setTerrainFeatures(mirrorTile.terrainFeatures)
             tile.tileResource = mirrorTile.tileResource
+            tile.resourceAmount = mirrorTile.resourceAmount
             tile.setImprovementBasic(mirrorTile.tileImprovement)
             
             for (neighbor in tile.neighbors){
@@ -276,9 +277,10 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             }
         }
 
-        if (map.mapParameters.mirroring == MirroringType.none) return
+        //if (map.mapParameters.mirroring == MirroringType.none) return
         for (tile in map.values) {
-            copyTile(tile, map.mapParameters.mirroring)
+            copyTile(tile, MirroringType.leftright)
+            //copyTile(tile, map.mapParameters.mirroring)
         }
     }
 


### PR DESCRIPTION
Red: Overwritten tile HAD strategic resource and got a luxury or bonus
Blue: Overwritten tile got a strategic but presumably undefined/default quantity?

<img width="1874" height="738" alt="image" src="https://github.com/user-attachments/assets/dcdb9c82-0a67-41b5-927d-0c494adf98d7" />

PR explicitly updates resource quantity for all mirrored tiles.