### PR TITLE
Fix force calculation when measuring military presence near border

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -543,7 +543,8 @@ object DiplomacyAutomation {
                 if (totalForce > forceCutoff)
                     continue
             }
-            println("${civInfo.civName} ${otherCiv.civName} ${100 * nearbyForce / totalForce}")
+            if (totalForce > forceCutoff)
+                continue
             // let's ask what's up
             ourDiplomacy.setFlag(
                 DiplomacyFlags.MilitaryPresenceNearBorderOrAttackedUsDespitePromise,

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -481,7 +481,7 @@ object DiplomacyAutomation {
                     || trade.trade.theirOffers.any { offer -> offer.name == offerName } }
     }
     
-    private const val MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND = 5
+    private const val MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND = 8
     private const val MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND = 50
     
     /**

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -510,7 +510,7 @@ object DiplomacyAutomation {
             nearbyForceByCiv.add(unit.civ, unit.getForceEvaluation())
         }
 
-        for (otherCiv in civInfo.getKnownCivs()) {
+        outer@ for (otherCiv in civInfo.getKnownCivs()) {
             // this ultimatum can currently only be made by AI to human players, to avoid abuse
             if (! otherCiv.isHuman())
                 continue
@@ -541,10 +541,8 @@ object DiplomacyAutomation {
             for (unit in otherCiv.units.getCivUnits().filter { it.isMilitary() }) {
                 totalForce += unit.getForceEvaluation()
                 if (totalForce > forceCutoff)
-                    break
+                    continue@outer
             }
-            if (totalForce > forceCutoff)
-                continue
             // let's ask what's up
             ourDiplomacy.setFlag(
                 DiplomacyFlags.MilitaryPresenceNearBorderOrAttackedUsDespitePromise,

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -541,7 +541,7 @@ object DiplomacyAutomation {
             for (unit in otherCiv.units.getCivUnits().filter { it.isMilitary() }) {
                 totalForce += unit.getForceEvaluation()
                 if (totalForce > forceCutoff)
-                    continue
+                    break
             }
             if (totalForce > forceCutoff)
                 continue

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -25,6 +25,8 @@ import com.unciv.utils.Log
 import com.unciv.utils.hashOf
 import yairm210.purity.annotations.Readonly
 import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.pow
 import kotlin.random.Random
 
@@ -482,7 +484,7 @@ object DiplomacyAutomation {
     }
     
     private const val MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND = 8
-    private const val MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND = 50
+    private const val MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND = 50 // minimum 1
     
     /**
      * Checks if any civ have positioned large portions of their troops along our borders.
@@ -510,30 +512,30 @@ object DiplomacyAutomation {
             nearbyForceByCiv.add(unit.civ, unit.getForceEvaluation())
         }
 
-        outer@ for (otherCiv in civInfo.getKnownCivs()) {
+        fun decideWhetherToDenounce(otherCiv: Civilization) {
             // this ultimatum can currently only be made by AI to human players, to avoid abuse
             if (! otherCiv.isHuman())
-                continue
+                return
             val ourDiplomacy = civInfo.getDiplomacyManager(otherCiv)!!
             // don't check violation if we are at war
             if (ourDiplomacy.diplomaticStatus == DiplomaticStatus.War)
-                continue
+                return
             // ignore if they promised they would not attack us
             if (ourDiplomacy.hasFlag(DiplomacyFlags.AgreedToNotAttackUs))
-                continue
+                return
             val theirDiplomacy = otherCiv.getDiplomacyManager(civInfo)!!
             // let's not doubt our allies
             if (ourDiplomacy.hasFlag(DiplomacyFlags.DeclarationOfFriendship)
                 || ourDiplomacy.hasFlag(DiplomacyFlags.DefensivePact)
                 || theirDiplomacy.hasOpenBorders)
-                continue
+                return
             // ignore if they only have a few units near our borders (relevant in early game)
             if (nearbyUnitCountByCiv[otherCiv] < MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND)
-                continue
+                return
             val threatAssessment = Automation.threatAssessment(civInfo, otherCiv)
             // ignore if they are weak, stay silent if they are too strong
             if (threatAssessment == ThreatLevel.VeryLow || threatAssessment == ThreatLevel.VeryHigh)
-                continue
+                return
             val nearbyForce = nearbyForceByCiv[otherCiv]
             // ignore if most of their military is elsewhere
             val forceCutoff = nearbyForce / (MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND / 100f)
@@ -541,7 +543,7 @@ object DiplomacyAutomation {
             for (unit in otherCiv.units.getCivUnits().filter { it.isMilitary() }) {
                 totalForce += unit.getForceEvaluation()
                 if (totalForce > forceCutoff)
-                    continue@outer
+                    return
             }
             // let's ask what's up
             ourDiplomacy.setFlag(
@@ -550,6 +552,9 @@ object DiplomacyAutomation {
                 true
             )
         }
+        
+        for (otherCiv in civInfo.getKnownCivs())
+            decideWhetherToDenounce(otherCiv)
     }
 
     /** Denounce if the AI's opinion of the other civ drops by this amount or more */

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -481,8 +481,8 @@ object DiplomacyAutomation {
                     || trade.trade.theirOffers.any { offer -> offer.name == offerName } }
     }
     
-    private const val MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND = 10
-    private const val MIN_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND  = 0.5f
+    private const val MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND = 8
+    private const val MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND = 50
     
     /**
      * Checks if any civ have positioned large portions of their troops along our borders.
@@ -503,9 +503,7 @@ object DiplomacyAutomation {
         val nearbyForceByCiv = Counter<Civilization>()
 
         for (tile in nearbyTiles) {
-            if (tile.militaryUnit == null)
-                continue
-            val unit = tile.militaryUnit!!
+            val unit = tile.militaryUnit ?: continue
             if (! unit.civ.isMajorCiv() || unit.civ == civInfo || unit.isInvisible(civInfo))
                 continue
             nearbyUnitCountByCiv.add(unit.civ, 1)
@@ -537,9 +535,11 @@ object DiplomacyAutomation {
             if (threatAssessment == ThreatLevel.VeryLow || threatAssessment == ThreatLevel.VeryHigh)
                 continue
             val nearbyForce = nearbyForceByCiv[otherCiv]
-            val totalForce = otherCiv.getStatForRanking(RankingType.Force)
-            // ignore if most of their force is elsewhere
-            if (nearbyForce.toFloat() / totalForce < MIN_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND)
+            val totalForce = otherCiv.units.getCivUnits()
+                .filter { it.isMilitary() }
+                .sumOf { it.getForceEvaluation() }
+            // ignore if most of their military is elsewhere
+            if (nearbyForce.toFloat() / totalForce < MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND / 100f)
                 continue
             // let's ask what's up
             ourDiplomacy.setFlag(

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -481,7 +481,7 @@ object DiplomacyAutomation {
                     || trade.trade.theirOffers.any { offer -> offer.name == offerName } }
     }
     
-    private const val MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND = 8
+    private const val MIN_UNITS_NEAR_BORDER_TO_ISSUE_DEMAND = 5
     private const val MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND = 50
     
     /**
@@ -535,12 +535,15 @@ object DiplomacyAutomation {
             if (threatAssessment == ThreatLevel.VeryLow || threatAssessment == ThreatLevel.VeryHigh)
                 continue
             val nearbyForce = nearbyForceByCiv[otherCiv]
-            val totalForce = otherCiv.units.getCivUnits()
-                .filter { it.isMilitary() }
-                .sumOf { it.getForceEvaluation() }
             // ignore if most of their military is elsewhere
-            if (nearbyForce.toFloat() / totalForce < MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND / 100f)
-                continue
+            val forceCutoff = nearbyForce / (MIN_PERCENT_FORCE_VALUE_NEAR_BORDER_TO_ISSUE_DEMAND / 100f)
+            var totalForce = 0
+            for (unit in otherCiv.units.getCivUnits().filter { it.isMilitary() }) {
+                totalForce += unit.getForceEvaluation()
+                if (totalForce > forceCutoff)
+                    continue
+            }
+            println("${civInfo.civName} ${otherCiv.civName} ${100 * nearbyForce / totalForce}")
             // let's ask what's up
             ourDiplomacy.setFlag(
                 DiplomacyFlags.MilitaryPresenceNearBorderOrAttackedUsDespitePromise,


### PR DESCRIPTION
`MapUnit.getForceEvaluation` is used to calculate force value of nearby units. Therefore it is inaccurate to compare it to total force as measured by `Civilization.statForRanking`, as this additionally penalizes water units, and has a multiplier for civ wide gold reserves. Instead we want to measure the total force using the same `MapUnit.getForceEvaluation` function.
One could consider caching this (civ wide military might already is) , but it is not used elsewhere, the calculation is only done in rare cases, and I added a short circuit for the (inner) loop to minimize computation.

Also changed:
Minimum units near border to issue demand: 10 -> 8
Rename constant and minor code quality.