### PR TITLE
Minor refactor

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -18,7 +18,7 @@ object BattleHelper {
     fun tryAttackNearbyEnemy(unit: MapUnit, stayOnTile: Boolean = false): Boolean {
         if (unit.hasUnique(UniqueType.CannotAttack)) return false
         val distanceToTiles = unit.movement.getDistanceToTiles()
-        val attackableEnemies = TargetHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles(), stayOnTile=stayOnTile)
+        val attackableEnemies = TargetHelper.getAttackableEnemies(unit, distanceToTiles, stayOnTile=stayOnTile)
             // Only take enemies we can fight without dying or are made to die
             .filter {
                 val defender = Battle.getMapCombatantOfTile(it.tileToAttack)


### PR DESCRIPTION
No need to immediately recompute `distanceToTiles` (`getAttackableEnemies` is readonly).