### PR TITLE
Cap force bonus from AdditionalAttacks based on movement points

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -28,6 +28,7 @@ import com.unciv.utils.yieldIfNotNull
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
+import kotlin.math.max
 import kotlin.math.pow
 
 // This is BaseUnit because Unit is already a base Kotlin class and to avoid mixing the two up
@@ -570,8 +571,12 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                     -> power *= 1.25f
                 UniqueType.MustSetUp // Must set up - 20 % penalty
                     -> power /= 1.20f
-                UniqueType.AdditionalAttacks // Extra attacks - 20% bonus per extra attack
-                    -> power *= (unique.params[0].toInt() * 20f).toPercent()
+                // Extra attacks - 20% bonus per extra attack (if sufficient movement)
+                UniqueType.AdditionalAttacks -> {
+                    val additionalAttacks = unique.params[0].toInt()
+                    val limit = if (isAirUnit()) Int.MAX_VALUE else movement - 1
+                    power *= (20f * max(additionalAttacks, limit)).toPercent()
+                }
                 else -> {}
             }
         }

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -28,7 +28,7 @@ import com.unciv.utils.yieldIfNotNull
 import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
-import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.pow
 
 // This is BaseUnit because Unit is already a base Kotlin class and to avoid mixing the two up
@@ -575,7 +575,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                 UniqueType.AdditionalAttacks -> {
                     val additionalAttacks = unique.params[0].toInt()
                     val limit = if (isAirUnit()) Int.MAX_VALUE else movement - 1
-                    power *= (20f * max(additionalAttacks, limit)).toPercent()
+                    power *= (20f * min(additionalAttacks, limit)).toPercent()
                 }
                 else -> {}
             }


### PR DESCRIPTION
If a unit can attack thrice but only has 2 movement, then it should only count as having 2 attacks for the purpose of force evaluation.
Air units don't use movement to attack, so they get the full bonus regardless.