### PR TITLE
Update to modern civ 5 culture cost formula

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -168,7 +168,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun getPolicyCultureCost(numberOfAdoptedPolicies: Int): Int {
-        var policyCultureCost = 25 + (numberOfAdoptedPolicies * 6).toDouble().pow(1.7)
+        var policyCultureCost = 25 + (numberOfAdoptedPolicies * 3).toDouble().pow(2.01)
         val worldSizeModifier = civInfo.gameInfo.tileMap.mapParameters.mapSize.getPredefinedOrNextSmaller().policyCostPerCityModifier
         var cityModifier = worldSizeModifier * (civInfo.cities.count { !it.isPuppet } - 1)
 


### PR DESCRIPTION
As discussed in the discord the formula currently used by unciv was changed in the June 2011 patch in Civ 5. A poll has been conducted with a reasonable majority for updating the formula to match the one used by civ 5.