### PR TITLE
Add .atlas file type to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 *.kts  text eol=lf
 *.json text eol=lf
 *.properties text eol=lf
+*.atlas text eol=lf
 
 *.md   text eol=lf
 # This helps Windows to not mark the auto-generated docs as changed on every Unciv launch


### PR DESCRIPTION
This prevents line ending warnings like the following upon atlas generation:

<img width="360" height="25" alt="Line ending warning in GitHub Desktop" src="https://github.com/user-attachments/assets/3179d145-5139-43dc-9e75-be4ee5a0e0d6" />

I guessed the syntax based on the rest of .gitignore, so no promises this is correct, but it _does_ work.

I found this problem in #15072, thanks @SomeTroglodyte for pointing me to the fix.