### PR TITLE
Fix German unique ability

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -191,8 +191,11 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
             if (gameInfo.turns < 10)
                 return null
             
+            val nearbyBarbarians = tile.getTilesInDistance(4)
+                .map { it.militaryUnit }.filterNotNull()
+                .count { it.civ.isBarbarian }
             // Too many barbarians around already?
-            if (tile.getTilesInDistance(4).count { it.militaryUnit?.civ?.isBarbarian ?: false } > 2)
+            if (nearbyBarbarians > 2)
                 return null
         }
 

--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -3,10 +3,12 @@ package com.unciv.logic.automation.civilization
 import com.unciv.Constants
 import com.unciv.logic.GameInfo
 import com.unciv.logic.IsPartOfGameInfoSerialization
+import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.TileMap
+import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
@@ -169,6 +171,90 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
         encampments.add(newCamp)
     }
 
+    /**
+     * Attempts to spawn a random barbarian [MapUnit] at or near the provided [Tile].
+     * @param allegiance Which [Civilization] should the unit belong to? Defaults to the barbarian civilization.
+     *                   If non-barbarian, there are fewer restrictions on whether a unit can be spawned or not.
+     * @return The newly spawned [MapUnit], or null if unsuccessful.
+     */
+    fun spawnBarbarian(
+        tile: Tile,
+        allegiance: Civilization = gameInfo.getBarbarianCivilization()
+    ): MapUnit? {
+        if (allegiance.isBarbarian) {
+            // Empty camp - spawn a defender
+            if (tile.militaryUnit == null)
+                // Try spawning a unit on this tile, return null if unsuccessful
+                return spawnUnit(tile.position, false)
+            
+            // Don't spawn wandering barbs too early
+            if (gameInfo.turns < 10)
+                return null
+            
+            // Too many barbarians around already?
+            if (tile.getTilesInDistance(4).count { it.militaryUnit?.civ?.isBarbarian ?: false } > 2)
+                return null
+        }
+
+        val canSpawnNaval = gameInfo.turns > 30
+        val validTiles = tile.neighbors.toList().filterNot {
+            it.isImpassible()
+                || it.isCityCenter()
+                || it.getFirstUnit() != null
+                || (it.isWater && !canSpawnNaval)
+                || (it.terrainHasUnique(UniqueType.FreshWater) && it.isWater) // No Lakes
+        }
+        if (validTiles.isEmpty())
+            return null
+
+        val rng = gameInfo.getBarbarianCivilization().state.stateBasedRandom("BarbarianManager.spawnBarbarian")
+        // Attempt to spawn a barbarian on a valid tile
+        return spawnUnit(tile.position, validTiles.random(rng).isWater, allegiance) 
+    }
+
+    /** Attempts to spawn a barbarian on [position], returns true if successful and false if unsuccessful. */
+    private fun spawnUnit(
+        position: HexCoord,
+        naval: Boolean,
+        allegiance: Civilization = gameInfo.getBarbarianCivilization()
+    ): MapUnit? {
+        updateBarbarianTech()
+        val unitToSpawn = chooseBarbarianUnit(naval)
+            ?: return null // return null if we didn't find a unit
+        val spawnedUnit = gameInfo.tileMap.placeUnitNearTile(position, unitToSpawn, allegiance)
+        return spawnedUnit
+    }
+
+    private fun updateBarbarianTech(){
+        val barbarianCiv = gameInfo.getBarbarianCivilization()
+        val allResearchedTechs = gameInfo.ruleset.technologies.keys.toMutableList()
+        for (civ in gameInfo.civilizations.filter { !it.isBarbarian && !it.isDefeated() }) {
+            allResearchedTechs.retainAll(civ.tech.techsResearched)
+        }
+        barbarianCiv.tech.techsResearched = allResearchedTechs.toHashSet()
+    }
+
+    @Readonly
+    private fun chooseBarbarianUnit(naval: Boolean): BaseUnit? {
+        // if we don't make this into a separate list then the retain() will happen on the Tech keys,
+        // which effectively removes those techs from the game and causes all sorts of problems
+        val barbarianCiv = gameInfo.getBarbarianCivilization()
+        val unitList = gameInfo.ruleset.units.values
+            .filter { it.isMilitary &&
+                !(it.hasUnique(UniqueType.CannotAttack) ||
+                    it.hasUnique(UniqueType.CannotBeBarbarian)) &&
+                (if (naval) it.isWaterUnit else it.isLandUnit) &&
+                it.isBuildable(barbarianCiv) }
+
+        if (unitList.isEmpty()) return null // No naval tech yet? Mad modders?
+
+        // Civ V weights its list by FAST_ATTACK or ATTACK_SEA AI types, we'll do it a bit differently
+        // getForceEvaluation is already conveniently biased towards fast units and against ranged naval
+        val weightings = unitList.map { it.getForceEvaluation().toFloat() }
+        val rng = GameContext(gameInfo = gameInfo).stateBasedRandom("BarbarianManager.chooseBarbarianUnit")
+
+        return unitList.randomWeighted(weightings, rng)
+    }
 }
 
 class Encampment() : IsPartOfGameInfoSerialization {
@@ -195,7 +281,8 @@ class Encampment() : IsPartOfGameInfoSerialization {
     fun update() {
         if (countdown > 0) // Not yet
             countdown--
-        else if (!destroyed && spawnBarbarian()) { // Countdown at 0, try to spawn a barbarian
+        // Countdown at 0, try to spawn a barbarian
+        else if (!destroyed && gameInfo.barbarians.spawnBarbarian(gameInfo.tileMap[position]) != null) { 
             // Successful
             spawnedUnits++
             resetCountdown()
@@ -212,77 +299,6 @@ class Encampment() : IsPartOfGameInfoSerialization {
             countdown = 15
             destroyed = true
         }
-    }
-
-    /** Attempts to spawn a Barbarian from this encampment. Returns true if a unit was spawned. */
-    private fun spawnBarbarian(): Boolean {
-        val tile = gameInfo.tileMap[position]
-
-        // Empty camp - spawn a defender
-        if (tile.militaryUnit == null) {
-            return spawnUnit(false) // Try spawning a unit on this tile, return false if unsuccessful
-        }
-
-        // Don't spawn wandering barbs too early
-        if (gameInfo.turns < 10)
-            return false
-
-        // Too many barbarians around already?
-        val barbarianCiv = gameInfo.getBarbarianCivilization()
-        if (tile.getTilesInDistance(4).count { it.militaryUnit?.civ == barbarianCiv } > 2)
-            return false
-
-        val canSpawnBoats = gameInfo.turns > 30
-        val validTiles = tile.neighbors.toList().filterNot {
-            it.isImpassible()
-                    || it.isCityCenter()
-                    || it.getFirstUnit() != null
-                    || (it.isWater && !canSpawnBoats)
-                    || (it.terrainHasUnique(UniqueType.FreshWater) && it.isWater) // No Lakes
-        }
-        if (validTiles.isEmpty()) return false
-
-        val rng = gameInfo.getBarbarianCivilization().state.stateBasedRandom("BarbarianManager.spawnBarbarian")
-        return spawnUnit(validTiles.random(rng).isWater) // Attempt to spawn a barbarian on a valid tile
-    }
-
-    /** Attempts to spawn a barbarian on [position], returns true if successful and false if unsuccessful. */
-    private fun spawnUnit(naval: Boolean): Boolean {
-        updateBarbarianTech()
-        val unitToSpawn = chooseBarbarianUnit(naval) ?: return false // return false if we didn't find a unit
-        val spawnedUnit = gameInfo.tileMap.placeUnitNearTile(position.toHexCoord(), unitToSpawn, gameInfo.getBarbarianCivilization())
-        return (spawnedUnit != null)
-    }
-    
-    private fun updateBarbarianTech(){
-        val barbarianCiv = gameInfo.getBarbarianCivilization()
-        val allResearchedTechs = gameInfo.ruleset.technologies.keys.toMutableList()
-        for (civ in gameInfo.civilizations.filter { !it.isBarbarian && !it.isDefeated() }) {
-            allResearchedTechs.retainAll(civ.tech.techsResearched)
-        }
-        barbarianCiv.tech.techsResearched = allResearchedTechs.toHashSet()
-    }
-
-    @Readonly
-    private fun chooseBarbarianUnit(naval: Boolean): BaseUnit? {
-        // if we don't make this into a separate list then the retain() will happen on the Tech keys,
-        // which effectively removes those techs from the game and causes all sorts of problems
-        val barbarianCiv = gameInfo.getBarbarianCivilization()
-        val unitList = gameInfo.ruleset.units.values
-            .filter { it.isMilitary &&
-                    !(it.hasUnique(UniqueType.CannotAttack) ||
-                            it.hasUnique(UniqueType.CannotBeBarbarian)) &&
-                    (if (naval) it.isWaterUnit else it.isLandUnit) &&
-                    it.isBuildable(barbarianCiv) }
-
-        if (unitList.isEmpty()) return null // No naval tech yet? Mad modders?
-
-        // Civ V weights its list by FAST_ATTACK or ATTACK_SEA AI types, we'll do it a bit differently
-        // getForceEvaluation is already conveniently biased towards fast units and against ranged naval
-        val weightings = unitList.map { it.getForceEvaluation().toFloat() }
-        val rng = GameContext(gameInfo = gameInfo).stateBasedRandom("BarbarianManager.chooseBarbarianUnit")
-
-        return unitList.randomWeighted(weightings, rng)
     }
 
     /** When a barbarian is spawned, seed the counter for next spawn */

--- a/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
+++ b/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
@@ -1,6 +1,5 @@
 package com.unciv.logic.battle
 
-import com.unciv.Constants
 import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.MapUnitAction
@@ -35,7 +34,6 @@ object BattleUnitCapture {
         // Therefore we run all functions before checking if one is true.
         val wasUnitCaptured = listOf(
             unitCapturedPrizeShipsUnique(attacker, defender),
-            unitCapturedFromEncampment(attacker, defender, attackedTile),
             unitGainFromDefeatingUnit(attacker, defender)
         ).any { it }
 
@@ -74,21 +72,6 @@ object BattleUnitCapture {
                 attacker.getCivInfo().addGold(unique.params[1].toInt())
                 unitCaptured = true
             }
-        }
-        return unitCaptured
-    }
-
-    private fun unitCapturedFromEncampment(attacker: MapUnitCombatant, defender: MapUnitCombatant, attackedTile: Tile): Boolean {
-        if (!defender.getCivInfo().isBarbarian) return false
-        if (attackedTile.improvement != Constants.barbarianEncampment) return false
-
-        var unitCaptured = false
-        // German unique - needs to be checked before we try to move to the enemy tile, since the encampment disappears after we move in
-
-        for (unique in attacker.getCivInfo()
-            .getMatchingUniques(UniqueType.GainFromEncampment)) {
-            attacker.getCivInfo().addGold(unique.params[0].toInt())
-            unitCaptured = true
         }
         return unitCaptured
     }

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -1045,7 +1045,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
         // German unique
         for (unique in civ.getMatchingUniques(UniqueType.GainFromEncampment)) {
-            goldGained += unique.params[0].toInt()
+            goldGained += unique.params[0].toInt() // todo support for gamespeed conditional
             val recruitedUnit = civ.gameInfo.barbarians.spawnBarbarian(tile, civ)
                 ?: continue
             recruitedUnit.health = 50

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -30,6 +30,7 @@ import java.text.DecimalFormat
 import kotlin.math.pow
 import kotlin.math.ulp
 import com.unciv.logic.automation.Timers.Companion.timeThis
+import com.unciv.logic.civilization.MapUnitAction
 
 
 /**
@@ -1042,9 +1043,24 @@ class MapUnit : IsPartOfGameInfoSerialization {
         var goldGained =
                 civ.getDifficulty().clearBarbarianCampReward * civ.gameInfo.speed.goldCostModifier
 
-        for (unique in civ.getMatchingUniques(UniqueType.GoldFromEncampmentsAndCities, cache.state)) {
-            goldGained *= unique.params[0].toPercent()
+        // German unique
+        for (unique in civ.getMatchingUniques(UniqueType.GainFromEncampment)) {
+            goldGained += unique.params[0].toInt()
+            val recruitedUnit = civ.gameInfo.barbarians.spawnBarbarian(tile, civ)
+                ?: continue
+            recruitedUnit.health = 50
+            recruitedUnit.currentMovement = 0f
+            civ.addNotification(
+                "An enemy [${recruitedUnit.name}] has joined us!",
+                MapUnitAction(recruitedUnit),
+                NotificationCategory.War,
+                recruitedUnit.name
+            )
         }
+        
+        // Songhai unique
+        for (unique in civ.getMatchingUniques(UniqueType.GoldFromEncampmentsAndCities, cache.state))
+            goldGained *= unique.params[0].toPercent()
 
         civ.addGold(goldGained.toInt())
         civ.addNotification(

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -1040,12 +1040,11 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
         tile.removeImprovement()
 
-        var goldGained =
-                civ.getDifficulty().clearBarbarianCampReward * civ.gameInfo.speed.goldCostModifier
+        var goldGained = civ.getDifficulty().clearBarbarianCampReward.toFloat()
 
         // German unique
         for (unique in civ.getMatchingUniques(UniqueType.GainFromEncampment)) {
-            goldGained += unique.params[0].toInt() // todo support for gamespeed conditional
+            goldGained += unique.params[0].toInt()
             val recruitedUnit = civ.gameInfo.barbarians.spawnBarbarian(tile, civ)
                 ?: continue
             recruitedUnit.health = 50
@@ -1057,6 +1056,8 @@ class MapUnit : IsPartOfGameInfoSerialization {
                 recruitedUnit.name
             )
         }
+        
+        goldGained *= civ.gameInfo.speed.goldCostModifier
         
         // Songhai unique
         for (unique in civ.getMatchingUniques(UniqueType.GoldFromEncampmentsAndCities, cache.state))


### PR DESCRIPTION
The `GainFromEncampment` unique:
- Should trigger upon clearing (destroying) an encampment, not upon killing a unit inside an encampment. This means it should not be possible for ranged attacks to trigger the unique + clear the encampment, and moving a unit into an empty camp should have a chance to trigger the unique.
- The recruited unit should be drawn randomly from the barbarian civ's unit pool at the time of trigger, not convert the unit that was killed.
- The unique should trigger after moving into the encampment, not before. This means that the attacking unit should always be positioned where the encampment once was, and the recruited unit should spawn nearby.
- The notification for clearing a camp should include the gold reward from the unique.
- The gold reward should be modifier by gamespeed. 

The implementation is largely moving some logic from `BattleUnitCapture.tryCaptureMilitaryUnit` (the unique is recruitment, not capture) to `MapUnit#clearEncampment` (called only by `MapUnit.moveThroughTile`).
Some methods were also moved from `Encampment` to `BarbarianManager`, to allow visibility from `MapUnit`. The main change there is adding a new parameter `allegiance`, which indicates which `Civilization` should own the spawned unit. It defaults to barbarians.

Tests (with 100% trigger chance):

Ranged attacks do not trigger the unique / clear the camp.
<img width="1445" height="1085" alt="image" src="https://github.com/user-attachments/assets/53c8f417-94ff-43b2-93e1-e22e08c733c1" />


Military units can trigger the unique when moving into the encampment.
The melee unit is positioned where the camp was.
The recruited unit is German and has 50 HP.
The notification displays the correct gold reward `(25 + 25) * 0.67 = 33`
<img width="1445" height="1085" alt="image" src="https://github.com/user-attachments/assets/1dff04a9-6536-4adb-b85a-75e5692e3136" />

Civilian units can also trigger the unique.
<img width="1445" height="1085" alt="image" src="https://github.com/user-attachments/assets/ba6efad4-0680-4348-9a8b-35b4582c56c5" />

Selecting the notification centers the map (partial screenshot) on the recruited unit and selects it.
<img width="1445" height="1085" alt="image" src="https://github.com/user-attachments/assets/8c68011c-c211-49c2-a65c-4e9d140e16f4" />
