### PR TITLE
Allow water unit production next to non-coastal water

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -203,7 +203,9 @@ class City : IsPartOfGameInfoSerialization, INamed {
     @Readonly fun isCapital(): Boolean = cityConstructions.builtBuildingUniqueMap.hasUnique(UniqueType.IndicatesCapital, state)
     @Readonly fun isCoastal(): Boolean = centerTile.isAdjacentToCoast()
     @Readonly fun isNaval(): Boolean = centerTile.isWater || isCoastal()
-    
+    @Readonly fun canBuildWaterUnits(): Boolean =
+        centerTile.isWater || centerTile.neighbors.any { it.isWater }
+
     @Readonly fun getBombardRange(): Int = civ.gameInfo.ruleset.modOptions.constants.baseCityBombardRange
     @Readonly fun getWorkRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityWorkRange
     @Readonly fun getExpandRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityExpandRange

--- a/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
@@ -59,7 +59,7 @@ class UnitManager(val civInfo: Civilization) {
         val citiesNotInResistance = civInfo.cities.filterNot { it.isInResistance() }
 
         // To allow cities on water tiles to be able to build water units.
-        val canSpawnUnitOnWater = city?.isNaval() == true
+        val canSpawnUnitOnWater = city?.canBuildWaterUnits() == true
         val cityToAddTo = when {
             unit.isWaterUnit && canSpawnUnitOnWater -> city
             unit.isWaterUnit ->

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -240,7 +240,7 @@ enum class RejectionReasonType(val shouldShow: Boolean, val errorMessage: String
     MustBeNextToTile(false, "Must be next to a specific tile"),
     MustNotBeNextToTile(false, "Must not be next to a specific tile"),
     MustOwnTile(false, "Must own a specific tile close by"),
-    WaterUnitsInCoastalCities(false, "May only built water units in coastal cities"),
+    WaterUnitsInCoastalCities(false, "May only build water units in cities on or next to water"),
     CanOnlyBeBuiltInSpecificCities(false, "Build requirements not met in this city"),
     MaxNumberBuildable(false, "Maximum number have been built or are being constructed"),
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -222,7 +222,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
 
         val stateForConditionals = city?.state ?: civ.state
 
-        if (city != null && isWaterUnit && !city.isNaval())
+        if (city != null && isWaterUnit && !city.canBuildWaterUnits())
             yield(RejectionReasonType.WaterUnitsInCoastalCities.toInstance())
 
         for (unique in getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals))

--- a/tests/src/com/unciv/logic/city/CityTest.kt
+++ b/tests/src/com/unciv/logic/city/CityTest.kt
@@ -96,6 +96,19 @@ class CityTest {
     }
 
     @Test
+    fun `should build water units next to non-coastal water`() {
+        testGame.setTileTerrain(HexCoord(1, 1), Constants.ocean)
+        val waterUnit = testGame.createBaseUnit("Melee Water").apply {
+            movement = 2
+            strength = 8
+        }
+
+        assertTrue(waterUnit.isBuildable(capitalCity.cityConstructions))
+        assertTrue(capitalCity.cityConstructions.completeConstruction(waterUnit))
+        assertEquals(waterUnit.name, capitalCity.getCenterTile().militaryUnit?.name)
+    }
+
+    @Test
     fun `should mark selected owned tile when queueing CreatesOneImprovement building`() {
         val farm = testGame.ruleset.tileImprovements["Farm"]!!
         testCiv.tech.techsResearched.add(farm.techRequired!!)


### PR DESCRIPTION
Fixes #15053.

In Civ V this normally comes up as a coastal-city rule, because water next to land is Coast on normal maps. Unciv has the same behavior on normal maps, but custom maps and mods can still put a city next to Ocean, Lakes, or another water terrain that is not marked as Coast. In those cases the city has water next to it, but the production check still rejects every water unit.

I added a small city check for whether the city is on water or has any adjacent water tile, and used it only for water unit construction and placement. I left the existing coastal and naval checks alone so other city rules keep their old meaning.

Not sure if I should keep the old rejection message `May only built water units in coastal cities` or change it for `May only build water units in cities on or next to water`.
