### PR TITLE
Update UniqueTriggerActivation.kt so that rebels are spawned correctly through events

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -279,16 +279,17 @@ object UniqueTriggerActivation {
                 val civUnit = civInfo.getEquivalentUnit(baseUnit)
                 if (civUnit.isCityFounder() && civInfo.isOneCityChallenger())
                     return null
-                fun placeUnit(): Boolean {
-                    val placedUnit = when {
-                        // Else set the unit at the given tile
-                        tile != null -> civInfo.gameInfo.tileMap.placeUnitNearTile(tile.position,baseUnit,barbarians) ?: return false
-                        // Else set unit unit near other units if we have no cities
-                        civInfo.units.getCivUnits().any() ->
-                            civInfo.gameInfo.tileMap.placeUnitNearTile(civInfo.units.getCivUnits().first().currentTile.position,baseUnit,barbarians) ?: return false
 
-                        else -> return false
-                    }
+                // Choose a city as the placement anchor: use the relevant city if available, otherwise the first city
+                val placementCity = relevantCity ?: civInfo.cities.firstOrNull() ?: return null
+
+                fun placeUnit(): Boolean {
+                    val placedUnit = civInfo.gameInfo.tileMap.placeUnitNearTile(
+                        placementCity.getCenterTile().position,
+                        baseUnit,
+                        barbarians
+                    ) ?: return false
+
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
                         "[1] [${civUnit.name}] has rebelled against us!"
@@ -312,6 +313,8 @@ object UniqueTriggerActivation {
                 val civUnit = civInfo.getEquivalentUnit(baseUnit)
                 if (civUnit.isCityFounder() && civInfo.isOneCityChallenger())
                     return null
+
+                // Existing limit logic (based on the number of similar units the civ already owns)
                 val limit = civUnit.getMatchingUniques(UniqueType.MaxNumberBuildable)
                     .map { it.params[0].toInt() }.minOrNull()
                 val unitCount = civInfo.units.getCivUnits().count { it.name == civUnit.name }
@@ -324,18 +327,17 @@ object UniqueTriggerActivation {
 
                 if (actualAmount <= 0) return null
 
-                fun placeUnits(): Boolean {
-                    val placedUnits: MutableList<MapUnit> = mutableListOf()
-                    repeat(actualAmount) {
-                        val placedUnit = when {
-                            // Else set the unit at the given tile
-                            tile != null -> civInfo.gameInfo.tileMap.placeUnitNearTile(tile.position,baseUnit,barbarians) ?: return false
-                            // Else set unit unit near other units if we have no cities
-                            civInfo.units.getCivUnits().any() ->
-                                civInfo.gameInfo.tileMap.placeUnitNearTile(civInfo.units.getCivUnits().first().currentTile.position,baseUnit,barbarians) ?: return false
+                // Choose a city as the placement anchor
+                val placementCity = relevantCity ?: civInfo.cities.firstOrNull() ?: return null
 
-                            else -> null
-                        }
+                fun placeUnits(): Boolean {
+                    val placedUnits = mutableListOf<MapUnit>()
+                    repeat(actualAmount) {
+                        val placedUnit = civInfo.gameInfo.tileMap.placeUnitNearTile(
+                            placementCity.getCenterTile().position,
+                            baseUnit,
+                            barbarians
+                        )
                         if (placedUnit != null) placedUnits += placedUnit
                     }
                     if (placedUnits.isEmpty()) return false


### PR DESCRIPTION
There is a problem about rebel uniques that they are sometimes randomised to spawn at some random places. Now it has a stable spawn.
before:
<img width="880" height="785" alt="image" src="https://github.com/user-attachments/assets/e3773fff-eac7-47c1-86b8-5d2a28ae07c3" />
after:
<img width="1082" height="362" alt="image" src="https://github.com/user-attachments/assets/82faad57-eb1b-4ae3-aaa8-1984a8a60be2" />
