### PR TITLE
Preserve scroll position of civ list in victory screen after updating selection

### DIFF
--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -10,7 +10,6 @@ import com.unciv.ui.components.widgets.TabbedPager
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.packIfNeeded
-import com.unciv.ui.components.extensions.scrollTo
 import com.unciv.ui.components.input.OnClickListener
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -1,7 +1,6 @@
 package com.unciv.ui.screens.victoryscreen
 
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.Action
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
@@ -66,8 +65,8 @@ class VictoryScreenCharts(
     }
 
     private fun update() {
-        updateControls()
         updateChart()
+        updateControls()
     }
 
     private fun updateControls() {
@@ -93,15 +92,9 @@ class VictoryScreenCharts(
         }
         civButtonsTable.add().padBottom(20f).row()
         civButtonsTable.pack()
-        civButtonsScroll.layout()
         
-        // Restore scroll position on the next frame
-        civButtonsScroll.stage?.addAction(object : Action() {
-            override fun act(delta: Float): Boolean {
-                civButtonsScroll.scrollTo(0f, civButtonsScroll.maxY - scrollY, 0f, 0f)
-                return true
-            }
-        })
+        validate()
+        civButtonsScroll.scrollY = scrollY
     }
 
     private fun updateChart() {

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -70,7 +70,7 @@ class VictoryScreenCharts(
     }
 
     private fun updateControls() {
-        val scrollY = civButtonsScroll.scrollY
+        val oldScrollY = civButtonsScroll.scrollY
         civButtonsTable.clear()
         val sortedCivs = gameInfo.civilizations.asSequence()
             .filter { it.isMajorCiv() }
@@ -94,7 +94,7 @@ class VictoryScreenCharts(
         civButtonsTable.pack()
         
         validate()
-        civButtonsScroll.scrollY = scrollY
+        civButtonsScroll.scrollY = oldScrollY
     }
 
     private fun updateChart() {

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.screens.victoryscreen
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Action
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
@@ -9,6 +10,7 @@ import com.unciv.ui.components.widgets.TabbedPager
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.packIfNeeded
+import com.unciv.ui.components.extensions.scrollTo
 import com.unciv.ui.components.input.OnClickListener
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -70,6 +72,7 @@ class VictoryScreenCharts(
     }
 
     private fun updateControls() {
+        val scrollY = civButtonsScroll.scrollY
         civButtonsTable.clear()
         val sortedCivs = gameInfo.civilizations.asSequence()
             .filter { it.isMajorCiv() }
@@ -92,6 +95,14 @@ class VictoryScreenCharts(
         civButtonsTable.add().padBottom(20f).row()
         civButtonsTable.pack()
         civButtonsScroll.layout()
+        
+        // Restore scroll position on the next frame
+        civButtonsScroll.stage?.addAction(object : Action() {
+            override fun act(delta: Float): Boolean {
+                civButtonsScroll.scrollTo(0f, civButtonsScroll.maxY - scrollY, 0f, 0f)
+                return true
+            }
+        })
     }
 
     private fun updateChart() {


### PR DESCRIPTION
When selecting a civ to highlight in the rankings chart, the list would shoot back up to the top.

Example after selecting China further down in the list, it shoots to the top:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/73286042-e60d-4d9c-91ba-c17475780fac" />

This PR ensures the scroll position is preserved:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/a0dcc093-5d3f-4b0a-a4a2-39f0b20ed155" /> <img height="400" alt="image" src="https://github.com/user-attachments/assets/dc2ac3fc-61a6-4a74-b1c4-99d62be2c3e7" />

