### PR TITLE
Spiral map type

### DIFF
--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -38,6 +38,7 @@ object MapType {
     const val lakes = "Lakes"
     const val smallContinents = "Small Continents"
     const val boreal = "Boreal"
+    const val spiral = "Spiral"
     
     val allValues = listOf(
         perlin,
@@ -51,7 +52,8 @@ object MapType {
         innerSea,
         lakes,
         smallContinents,
-        boreal
+        boreal,
+        spiral
     )
 
     // All ocean tiles

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -196,21 +196,28 @@ class MapLandmassGenerator(
     }
     
     private fun createSpiral() {
-        val seed = randomness.RNG.nextInt().toDouble()
-        val spin = 1.5 // how quickly the spiral spins
-        val scale = spin * sqrt(tileMap.mapParameters.mapSize.radius.toDouble())
+        val radius = tileMap.mapParameters.mapSize.radius.toDouble()
+        
+        // config
+        val spinFactor = 4.5 * sqrt(radius) // how quickly the spiral spins
+        val noiseScale = 0.5 * sqrt(radius) // lower means more grainy noise
+        
         val flipX = if (randomness.RNG.nextBoolean()) -1 else 1
         val flipY = if (randomness.RNG.nextBoolean()) -1 else 1
+        val elevationSeed = randomness.RNG.nextInt().toDouble()
+        val divisor = tileMap.width // prevent stretching of spiral
         for (tile in tileMap.values) {
             val coordinate = HexMath.hex2WorldCoords(tile.position)
-            val divisor = tileMap.width // prevent stretching of spiral
-            val x = scale * coordinate.x / divisor * flipX
-            val y = scale * coordinate.y / divisor * flipY
+            val x = coordinate.x / divisor * flipX
+            val y = coordinate.y / divisor * flipY
             // spiral function with output range -1 to +1
-            var elevation = sin(atan2(y, x) - 3 * hypot(x, y))
-            elevation *= 0.25
-            elevation += 0.15 // more land than water
-            elevation += 0.20 * randomness.getPerlinNoise(tile, seed, scale=scale)
+            var elevation = sin(atan2(y, x) - spinFactor * hypot(x, y))
+            
+            // config
+            elevation *= 0.25 // adjust range
+            elevation += 0.15 // water level
+            elevation += 0.18 * randomness.getPerlinNoise(tile, elevationSeed, scale=noiseScale)
+            
             spawnLandOrWater(tile, elevation)
         }
     }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -196,7 +196,8 @@ class MapLandmassGenerator(
     
     private fun createSpiral() {
         val seed = randomness.RNG.nextInt().toDouble()
-        val scale = 1.5 * sqrt(tileMap.mapParameters.mapSize.radius.toDouble())
+        val spin = 1.5 // how quickly the spiral spins
+        val scale = spin * sqrt(tileMap.mapParameters.mapSize.radius.toDouble())
         val flipX = if (randomness.RNG.nextBoolean()) -1 else 1
         val flipY = if (randomness.RNG.nextBoolean()) -1 else 1
         for (tile in tileMap.values) {
@@ -205,9 +206,9 @@ class MapLandmassGenerator(
             val y = scale * coordinate.y / tileMap.width * flipY
             // spiral function with output range -1 to +1
             var elevation = sin(atan2(y, x) - 3 * sqrt(x.pow(2) + y.pow(2)))
-            elevation *= 0.2
-            elevation += 0.05
-            elevation += randomness.getPerlinNoise(tile, seed, scale=scale) * 0.25
+            elevation *= 0.25
+            elevation += 0.15
+            elevation += randomness.getPerlinNoise(tile, seed, scale=scale) * 0.15
             spawnLandOrWater(tile, elevation)
         }
     }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -7,9 +7,11 @@ import com.unciv.models.ruleset.tile.TerrainType
 import com.unciv.models.ruleset.unique.UniqueType
 import kotlin.math.E
 import kotlin.math.abs
+import kotlin.math.atan2
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
+import kotlin.math.sin
 import kotlin.math.sqrt
 
 class MapLandmassGenerator(
@@ -59,6 +61,7 @@ class MapLandmassGenerator(
             MapType.lakes -> createLakes()
             MapType.boreal -> createBoreal()
             MapType.smallContinents -> createSmallContinents()
+            MapType.spiral -> createSpiral()
         }
 
         if (tileMap.mapParameters.shape == MapShape.flatEarth) {
@@ -187,6 +190,24 @@ class MapLandmassGenerator(
             
             val broadLayerImpact = 0.55
             elevation += broadLayerImpact * randomness.getPerlinNoise(tile, broadNoiseSeed, scale=broadNoiseScale)
+            spawnLandOrWater(tile, elevation)
+        }
+    }
+    
+    private fun createSpiral() {
+        val seed = randomness.RNG.nextInt().toDouble()
+        val scale = 1.5 * sqrt(tileMap.mapParameters.mapSize.radius.toDouble())
+        val flipX = if (randomness.RNG.nextBoolean()) -1 else 1
+        val flipY = if (randomness.RNG.nextBoolean()) -1 else 1
+        for (tile in tileMap.values) {
+            val coordinate = HexMath.hex2WorldCoords(tile.position)
+            val x = scale * coordinate.x / tileMap.width * flipX
+            val y = scale * coordinate.y / tileMap.width * flipY
+            // spiral function with output range -1 to +1
+            var elevation = sin(atan2(y, x) - 3 * sqrt(x.pow(2) + y.pow(2)))
+            elevation *= 0.2
+            elevation += 0.05
+            elevation += randomness.getPerlinNoise(tile, seed, scale=scale) * 0.25
             spawnLandOrWater(tile, elevation)
         }
     }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -196,20 +196,21 @@ class MapLandmassGenerator(
     }
     
     private fun createSpiral() {
+        val elevationSeed = randomness.RNG.nextInt().toDouble()
         val radius = tileMap.mapParameters.mapSize.radius.toDouble()
+        val flipX = if (randomness.RNG.nextBoolean()) -1 else 1
+        val flipY = if (randomness.RNG.nextBoolean()) -1 else 1
+        val coordinateDivisor = tileMap.width // prevent stretching of spiral
         
         // config
         val spinFactor = 4.5 * sqrt(radius) // how quickly the spiral spins
         val noiseScale = 0.5 * sqrt(radius) // lower means more grainy noise
         
-        val flipX = if (randomness.RNG.nextBoolean()) -1 else 1
-        val flipY = if (randomness.RNG.nextBoolean()) -1 else 1
-        val elevationSeed = randomness.RNG.nextInt().toDouble()
-        val divisor = tileMap.width // prevent stretching of spiral
         for (tile in tileMap.values) {
             val coordinate = HexMath.hex2WorldCoords(tile.position)
-            val x = coordinate.x / divisor * flipX
-            val y = coordinate.y / divisor * flipY
+            val x = coordinate.x / coordinateDivisor * flipX
+            val y = coordinate.y / coordinateDivisor * flipY
+            
             // spiral function with output range -1 to +1
             var elevation = sin(atan2(y, x) - spinFactor * hypot(x, y))
             

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -8,6 +8,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import kotlin.math.E
 import kotlin.math.abs
 import kotlin.math.atan2
+import kotlin.math.hypot
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
@@ -202,10 +203,11 @@ class MapLandmassGenerator(
         val flipY = if (randomness.RNG.nextBoolean()) -1 else 1
         for (tile in tileMap.values) {
             val coordinate = HexMath.hex2WorldCoords(tile.position)
-            val x = scale * coordinate.x / tileMap.width * flipX
-            val y = scale * coordinate.y / tileMap.width * flipY
+            val divisor = tileMap.width // prevent stretching of spiral
+            val x = scale * coordinate.x / divisor * flipX
+            val y = scale * coordinate.y / divisor * flipY
             // spiral function with output range -1 to +1
-            var elevation = sin(atan2(y, x) - 3 * sqrt(x.pow(2) + y.pow(2)))
+            var elevation = sin(atan2(y, x) - 3 * hypot(x, y))
             elevation *= 0.25
             elevation += 0.15 // more land than water
             elevation += 0.20 * randomness.getPerlinNoise(tile, seed, scale=scale)

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -208,7 +208,7 @@ class MapLandmassGenerator(
             var elevation = sin(atan2(y, x) - 3 * sqrt(x.pow(2) + y.pow(2)))
             elevation *= 0.25
             elevation += 0.15 // more land than water
-            elevation += 0.15 * randomness.getPerlinNoise(tile, seed, scale=scale)
+            elevation += 0.20 * randomness.getPerlinNoise(tile, seed, scale=scale)
             spawnLandOrWater(tile, elevation)
         }
     }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -207,8 +207,8 @@ class MapLandmassGenerator(
             // spiral function with output range -1 to +1
             var elevation = sin(atan2(y, x) - 3 * sqrt(x.pow(2) + y.pow(2)))
             elevation *= 0.25
-            elevation += 0.15
-            elevation += randomness.getPerlinNoise(tile, seed, scale=scale) * 0.15
+            elevation += 0.15 // more land than water
+            elevation += 0.15 * randomness.getPerlinNoise(tile, seed, scale=scale)
             spawnLandOrWater(tile, elevation)
         }
     }


### PR DESCRIPTION
Inspiration from the "Donut" map type in Civ V.
Features a one-armed spiral that twirls outward from the center.
The water level is decreased slightly to allow civs to settle away from coast to escape ranged naval units.
Some noise has been added for less predictable coastlines.

<img width="651" height="792" alt="image" src="https://github.com/user-attachments/assets/52eef5d4-ba9d-47e6-b0f4-ef6bbb9ba9b9" />

<img width="651" height="792" alt="image" src="https://github.com/user-attachments/assets/e6549bf9-f72e-4299-aaf4-34f0c7f976af" />

<img width="651" height="792" alt="image" src="https://github.com/user-attachments/assets/7d49ff9a-be68-421f-a96e-4fb4afb1b22f" />

<img width="651" height="792" alt="image" src="https://github.com/user-attachments/assets/63b6be71-d878-4415-8465-5fe0fa849f77" />

<img width="651" height="643" alt="image" src="https://github.com/user-attachments/assets/99506411-5591-499f-921d-56e5e38fb12b" />

<img width="651" height="519" alt="image" src="https://github.com/user-attachments/assets/322352fe-cc49-4466-b8c8-9a6b724065b1" />

<img width="1980" height="1005" alt="image" src="https://github.com/user-attachments/assets/7ed950c3-4724-4b0b-aa65-fa0e74bb0260" />

<img width="1980" height="1005" alt="image" src="https://github.com/user-attachments/assets/07fab42b-8a90-4989-8045-3921f2ed2196" />