### PR TITLE
Reorder map types based on popularity poll

### DIFF
--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -26,31 +26,32 @@ object MapGeneratedMainType {
 }
 
 object MapType {
-    const val perlin = "Perlin"
     const val pangaea = "Pangaea"
+    const val smallContinents = "Small Continents"
+    const val perlin = "Perlin"
+    const val fractal = "Fractal"
     const val continentAndIslands = "Continent and Islands"
+    const val archipelago = "Archipelago"
     const val twoContinents = "Two Continents"
     const val threeContinents = "Three Continents"
-    const val fourCorners = "Four Corners"
-    const val archipelago = "Archipelago"
-    const val fractal = "Fractal"
     const val innerSea = "Inner Sea"
     const val lakes = "Lakes"
-    const val smallContinents = "Small Continents"
+    const val fourCorners = "Four Corners"
     const val boreal = "Boreal"
     
+    // ordered based on popularity poll
     val allValues = listOf(
-        perlin,
         pangaea,
+        smallContinents,
+        perlin,
+        fractal,
         continentAndIslands,
+        archipelago,
         twoContinents,
         threeContinents,
-        fourCorners,
-        archipelago,
-        fractal,
         innerSea,
         lakes,
-        smallContinents,
+        fourCorners,
         boreal
     )
 


### PR DESCRIPTION
Poll results:

| Map type | Votes |
| ----- | -----|
| Small continents | 59 |
| Perlin | 46 |
| Fractal | 45 |
| Continent and islands | 41 |
| Pangaea | 38 |
| Archipelago | 31 |
| Two continents | 18 |
| Three continents | 16 |
| Inner sea | 9 |
| Lakes | 9 |
| Four corners | 7 |
| Boreal | 5 |

Being the default map type, I placed Pangaea on top despite not being the most popular.

<img width="644" height="470" alt="image" src="https://github.com/user-attachments/assets/f5bd748c-2a44-41a6-af8b-d59ddcc24552" />
