### PR TITLE
Fix "on losing unit" triggers running when a new unit can't be placed

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
@@ -17,7 +17,8 @@
 		"RGB": [70, 138, 216],
 		"uniques": ["[+2] to Fertility for Map Generation",
             "Considered [Desirable] when determining start locations <on water maps>",
-            "Every [60] tiles with this terrain will receive a major deposit of a strategic resource."]
+            "Every [60] tiles with this terrain will receive a major deposit of a strategic resource.",
+            "Coastal Water"]
 	},
 	{
 		"name": "Grassland",

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -17,7 +17,8 @@
 		"RGB": [70, 138, 216],
 		"uniques": ["[+2] to Fertility for Map Generation",
 			"Considered [Desirable] when determining start locations <on water maps>",
-			"Every [60] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [60] tiles with this terrain will receive a major deposit of a strategic resource.",
+            "Coastal Water"]
 	},
 	{
 		"name": "Grassland",

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -11,7 +11,10 @@ object Constants {
     const val impassable = "Impassable"
     const val ocean = "Ocean"
 
-    /** The "Coast" _terrain_ */
+    /** The "Coast" _terrain_
+     *  @see com.unciv.models.ruleset.tile.Terrain.isCoast
+     */
+    @Deprecated("By PR #15123, except for tests. Remove use in Terrain and this deprecation after a grace period.")
     const val coast = "Coast"
     /** The "Coastal" terrain _filter_ */
     const val coastal = "Coastal"

--- a/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
@@ -174,12 +174,13 @@ class UnitManager(val civInfo: Civilization) {
         }
     }
 
-    fun removeUnit(mapUnit: MapUnit) {
+    fun removeUnit(mapUnit: MapUnit, updateCivInfo: Boolean = true) {
         // See comment in addUnit().
         val newList = getCivUnitsStartingAtNextDue().toMutableList()
         newList.remove(mapUnit)
         unitList = newList
         nextPotentiallyDueAt = 0
+        if (!updateCivInfo) return
 
         civInfo.updateStatsForNextTurn() // unit upkeep
         if (mapUnit.getResourceRequirementsPerTurn().isNotEmpty())

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -678,7 +678,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
                 tile.neighbors.filter { unit.movement.canPassThrough(it) }
 
         // both the civ name and actual civ need to be in here in order to calculate the canMoveTo...Darn
-        unit.assignOwner(civInfo, false)
+        unit.assignOwner(civInfo, updateCivInfo = false)
         // remember our first owner
         unit.originalOwner = civInfo.civID
 
@@ -724,7 +724,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         }
 
         if (unitToPlaceTile == null) {
-            civInfo.units.removeUnit(unit) // since we added it to the civ units in the previous assignOwner
+            civInfo.units.removeUnit(unit, updateCivInfo = false) // since we added it to the civ units in the previous assignOwner
             return null // we didn't actually create a unit...
         }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
@@ -163,7 +163,7 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
                     if (convertToTerrain.hasUnique(UniqueType.FreshWater) && tile.isAdjacentToCoast()) continue
                     val terrainObject = location.ruleset.terrains[convertTo] ?: continue
                     if (terrainObject.type == TerrainType.TerrainFeature && tile.baseTerrain !in terrainObject.occursOn) continue
-                    if (convertTo == Constants.coast)
+                    if (convertToTerrain.hasUnique(UniqueType.CoastalWater))
                         removeLakesNextToFutureCoast(location, tile)
                     if (terrainObject.type.isBaseTerrain) {
                         clearTile(tile)

--- a/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
@@ -159,17 +159,17 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
                     if (!unique.conditionalsApply(state)) continue
                     val convertTo = unique.params[0]
                     if (tile.baseTerrain == convertTo || convertTo in tile.terrainFeatures) continue
-                    val convertToTerrain = location.ruleset.terrains[convertTo]!!
+                    val convertToTerrain = location.ruleset.terrains[convertTo]
+                        ?: continue
                     if (convertToTerrain.hasUnique(UniqueType.FreshWater) && tile.isAdjacentToCoast()) continue
-                    val terrainObject = location.ruleset.terrains[convertTo] ?: continue
-                    if (terrainObject.type == TerrainType.TerrainFeature && tile.baseTerrain !in terrainObject.occursOn) continue
+                    if (convertToTerrain.type == TerrainType.TerrainFeature && tile.baseTerrain !in convertToTerrain.occursOn) continue
                     if (convertToTerrain.hasUnique(UniqueType.CoastalWater))
                         removeLakesNextToFutureCoast(location, tile)
-                    if (terrainObject.type.isBaseTerrain) {
+                    if (convertToTerrain.type.isBaseTerrain) {
                         clearTile(tile)
-                        tile.setBaseTerrain(terrainObject)
+                        tile.setBaseTerrain(convertToTerrain)
                     }
-                    if (terrainObject.type == TerrainType.TerrainFeature) {
+                    if (convertToTerrain.type == TerrainType.TerrainFeature) {
                         clearTile(tile, tile.terrainFeatures)
                         tile.addTerrainFeature(convertTo)
                     }

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -52,7 +52,7 @@ class Terrain : RulesetStatsObject() {
     val isMountain by lazy { hasUnique(UniqueType.OccursInChains) }
     val isHill by lazy { hasUnique(UniqueType.OccursInGroups) }
     val isFreshwater: Boolean by lazy { hasUnique(UniqueType.FreshWater) }
-    val isCoast: Boolean by lazy { type == TerrainType.Water && !isFreshwater && hasUnique(UniqueType.CoastalWater) }
+    val isCoast: Boolean by lazy { type == TerrainType.Water && !isFreshwater && (hasUnique(UniqueType.CoastalWater) || name == Constants.coast) }
     val isOcean: Boolean by lazy { type == TerrainType.Water && !isFreshwater && !isCoast }
     val isVegetation by lazy { hasUnique(UniqueType.Vegetation) }
     val isIce by lazy { type == TerrainType.TerrainFeature && impassable && occursOn.contains(Constants.ocean) }

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -52,7 +52,7 @@ class Terrain : RulesetStatsObject() {
     val isMountain by lazy { hasUnique(UniqueType.OccursInChains) }
     val isHill by lazy { hasUnique(UniqueType.OccursInGroups) }
     val isFreshwater: Boolean by lazy { hasUnique(UniqueType.FreshWater) }
-    val isCoast: Boolean by lazy { type == TerrainType.Water && !isFreshwater && (hasUnique(UniqueType.CoastalWater) || name == Constants.coast) }
+    val isCoast: Boolean by lazy { type == TerrainType.Water && !isFreshwater && hasUnique(UniqueType.CoastalWater) }
     val isOcean: Boolean by lazy { type == TerrainType.Water && !isFreshwater && !isCoast }
     val isVegetation by lazy { hasUnique(UniqueType.Vegetation) }
     val isIce by lazy { type == TerrainType.TerrainFeature && impassable && occursOn.contains(Constants.ocean) }


### PR DESCRIPTION
Fixes #15116 (third commit)
Read commit messages

Not treated:
- GameStarter with Rivers of Lava mod decides on lots of starting locations in "water" - not investigated. Possibly my parameters, possibly some weighing uniques missing...
- NewGameScreen runs a mapgen for a preview with invalid combined ruleset (base ruleset change triggers mapgen and _then_ deselects incompatible mods), but this fixes the crashes I found caused by that
- `Tile.isVegetation` entirely unused, 4 or 5 candidates