### PR TITLE
fix: Removed bad short-circuit - even for units with no movement, PathsToTilesWithinTurn should contain the current tile

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -843,7 +843,6 @@ class UnitMovement(val unit: MapUnit) {
         movementCostCache: HashMap<Int, Float>? = null,
         includeOtherEscortUnit: Boolean = true
     ): PathsToTilesWithinTurn {
-        if (unit.currentMovement <= 0f) return PathsToTilesWithinTurn()
         if (UncivGame.Current.settings.useAStarPathfinding) {
             if (!considerZoneOfControl) require(includeOtherEscortUnit)
             val pathingMap = if (!considerZoneOfControl) aStarPathingWithoutZoneControl
@@ -976,6 +975,7 @@ class PathfindingCache(private val unit: MapUnit) {
     }
 }
 
+/** Should contain current unit location even when it has no movement */
 class PathsToTilesWithinTurn : LinkedHashMap<Tile, UnitMovement.ParentTileAndTotalMovement>() {
     fun getPathToTile(tile: Tile): List<Tile> {
         if (!containsKey(tile)) {


### PR DESCRIPTION
The perf overhead isn't worth talking about either, it's fine

Resolves #15128