### PR TITLE
Fix city population unassignment ignoring tile rank

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
@@ -238,8 +238,8 @@ class CityPopulationManager : IsPartOfGameInfoSerialization {
                 city.workedTiles.asSequence()
                         .map { city.tileMap[it] }
                         .minByOrNull {
-                            Automation.rankTileForCityWork(it, city)
-                            +(if (it.isLocked()) 10 else 0)
+                            Automation.rankTileForCityWork(it, city) +
+                                (if (it.isLocked()) 10 else 0)
                         }!!
             }
             val valueWorstTile = if (worstWorkedTile == null) 0f


### PR DESCRIPTION
## Problem

In `CityPopulationManager.unassignExtraPopulation`, the `minByOrNull` selector that picks the worst worked tile is split across two lines:

```kotlin
Automation.rankTileForCityWork(it, city)
+(if (it.isLocked()) 10 else 0)
```

Because the `+` starts a new line, Kotlin parses it as a unary plus on the lock penalty rather than as an addition. The rank call becomes a discarded statement, so the selector only returns 10 for locked tiles and 0 otherwise. When population must be unassigned, the tile rank is ignored entirely and the choice of which tile to stop working is effectively arbitrary among unlocked tiles.

## Fix

Move the `+` to the end of the first line so the selector returns the tile rank plus the lock penalty as a single expression, which is the original intent.
