### PR TITLE
Fix mediated peace treaty duration

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -199,7 +199,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 TradeOfferType.PeaceProposal -> {
                     // Convert PeaceProposal to peaceTreaty and apply to warring civs
                     val trade = Trade()
-                    val peaceOffer = TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, duration = offer.duration)
+                    val peaceOffer = TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, speed = from.gameInfo.speed)
                     trade.ourOffers.add(peaceOffer)
                     trade.theirOffers.add(peaceOffer)
                     


### PR DESCRIPTION
## Summary

When a peace deal between two other civs is mediated through a trade, the accepted PeaceProposal offer is converted into a peace treaty using the offer's own duration. Since PeaceProposal is an immediate offer type, its duration is always -1, so the resulting peace treaty had duration -1 and expired right away instead of enforcing the normal peace period.

This changes the conversion in `TradeLogic.acceptTrade` to build the peace treaty offer with the game speed, so it gets the standard peace deal duration, the same as a directly negotiated peace treaty. The PeaceProposal offer itself stays immediate.
