### PR TITLE
Fix getTilesWithEnemyUnitsInDistance dropping cached closer enemy tiles

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
@@ -94,7 +94,7 @@ class ThreatManager(val civInfo: Civilization) {
         // The list of tiles with distance that will be stored in distanceToClosestEnemyTiles
         val tileDataTilesWithEnemies: MutableList<Pair<Tile,Int>> = if (tileData?.tilesWithEnemies != null) tileData.tilesWithEnemies else mutableListOf()
 
-        if (tileData != null && tileData.distanceSearched >= maxDist) {
+        if (tileData != null) {
             // Add all tiles that we have previously found
             val tilesWithEnemiesIterator = tileDataTilesWithEnemies.listIterator()
             for (tileWithDistance in tilesWithEnemiesIterator) {

--- a/tests/src/com/unciv/logic/civilization/managers/ThreatManagerTests.kt
+++ b/tests/src/com/unciv/logic/civilization/managers/ThreatManagerTests.kt
@@ -134,6 +134,16 @@ class ThreatManagerTests {
     }
 
     @Test
+    fun `Find tiles with enemy units after extending search`() {
+        val centerTile = testGame.getTile(0,0)
+        testGame.addUnit("Warrior", enemyCiv, testGame.getTile(2,0))
+        testGame.addUnit("Warrior", enemyCiv, testGame.getTile(4,0))
+        assertEquals(1, threatManager.getTilesWithEnemyUnitsInDistance(centerTile, 3).count())
+        // Extending the search must still include the cached closer enemy tile
+        assertEquals(2, threatManager.getTilesWithEnemyUnitsInDistance(centerTile, 5).count())
+    }
+
+    @Test
     fun `Find distance to enemy after find tiles with enemy units`() {
         val centerTile = testGame.getTile(0,0)
         testGame.addUnit("Warrior", enemyCiv, testGame.getTile(3,0))


### PR DESCRIPTION
## Problem

`ThreatManager.getTilesWithEnemyUnitsInDistance` is documented to return all tiles with enemies within `maxDist`. When the cache already covers a smaller radius (`distanceSearched < maxDist`), the method only searched the new outer rings and returned only the newly found tiles. Enemy tiles already known from the earlier, closer search stayed in the cache but were missing from the returned list.

For example, with enemies at distance 2 and 4, calling the method with `maxDist = 3` and then `maxDist = 5` returned only the distance 4 tile on the second call.

## Fix

Re-check the cached enemy tiles whenever cache data exists, not only when the cached search already covers `maxDist`. Still-valid cached tiles are added to the result before the search is extended to the remaining rings. Stale cached tiles are removed exactly as before, so cache invalidation behavior is unchanged.

Cached entries never exceed `distanceSearched`, so the existing early exit for tiles beyond `maxDist` is unaffected when extending the search.
