### PR TITLE
Fix unit healing turn check so automation does not idle on zero-healing tiles

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -23,6 +23,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsPillage
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsUpgrade
+import kotlin.math.ceil
 import yairm210.purity.annotations.Readonly
 import com.unciv.logic.automation.Timers.Companion.timeThis
 
@@ -423,7 +424,8 @@ object UnitAutomation {
         if (!(unit.getTile().isCityCenter() && unit.getTile().getCity()!!.health > 50)
             && unit.civ.threatManager.getDistanceToClosestEnemyUnit(unit.getTile(), noEnemyDistance) <= noEnemyDistance) return false
 
-        val healthRequiredPerTurn =  (100 - unit.health) / turns
+        // Round up, otherwise e.g. 99 health over 2 turns would give 0 required healing per turn
+        val healthRequiredPerTurn = ceil((100 - unit.health).toFloat() / turns).toInt()
         return healthRequiredPerTurn <= unit.rankTileForHealing(unit.getTile())
     }
 


### PR DESCRIPTION
## Summary

`UnitAutomation.canUnitHealInTurnsOnCurrentTile` computes the healing required per turn as `(100 - unit.health) / turns`. Since Kotlin integer division rounds down, a unit at 99 HP with `turns = 2` gets a required healing of 0 per turn. A tile with healing rank 0, such as neutral water, then satisfies the check, so the automation decides to wait there and heal even though the unit can never reach full health on that tile. The unit can end up idling forever instead of moving on or heading to a city.

## Fix

Round the required healing per turn up instead of down, so the method only returns true when the tile actually heals the unit to full within the requested number of turns. A damaged unit on a zero-healing tile now correctly fails the check and continues with the rest of its automation.