### PR TITLE
Fix great person escort target selection

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -537,7 +537,7 @@ object UnitAutomation {
             .firstOrNull {
                 val tile = it.currentTile
                 it.isCivilian() &&
-                        (it.hasUnique(UniqueType.FoundCity) || unit.isGreatPerson())
+                        (it.hasUnique(UniqueType.FoundCity) || it.isGreatPerson())
                         && !it.hasUnique(UniqueType.StrengthBonusInRadius) // Exlude great generals, as they move independently after all military units
                         && (tile == unit.currentTile || tile.militaryUnit == null && unit.movement.canMoveTo(tile))
                         && distanceToTiles.containsKey(tile)


### PR DESCRIPTION
## Summary

`UnitAutomation.tryAccompanySettlerOrGreatPerson` is meant to send a military unit to accompany a nearby settler or great person. The candidate filter checked `unit.isGreatPerson()` on the escorting unit instead of `it.isGreatPerson()` on the candidate civilian. Since the escorting unit is always a military unit at this point, that check was always false, so great people were never selected as escort targets and only settlers were escorted.

## Fix

Change the predicate to check `it.isGreatPerson()` so it evaluates the candidate civilian, matching the other predicates in the same lambda.