### PR TITLE
Fix dead civs friendship modifier using integer division

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -103,7 +103,7 @@ object DiplomacyAutomation {
         // Goes from 0 to -50 as more civs die
         // this is meant to prevent the game from stalemating when a group of friends
         // conquers all oposition
-        motivation -= deadCivs / allCivs * 50
+        motivation -= 50f * deadCivs / allCivs
 
         // Become more desperate as we have more wars
         motivation += civInfo.diplomacy.values.count { it.otherCiv.isMajorCiv() && it.diplomaticStatus == DiplomaticStatus.War } * 10


### PR DESCRIPTION
## Summary

In `DiplomacyAutomation.wantsToSignDeclarationOfFrienship`, the modifier that is supposed to scale from 0 to -50 as more major civs die was computed with `deadCivs / allCivs * 50`. Since both `deadCivs` and `allCivs` are `Int`, the division happens first in integer arithmetic and truncates to 0 whenever any major civ is still alive. As a result the penalty never applied in normal games, so automated civilizations kept signing friendships even when a group of friends had eliminated most of the opposition, which is exactly the stalemate the comment above the line says this modifier should prevent.

## Fix

Reorder the expression to `50f * deadCivs / allCivs` so the whole computation happens in float arithmetic. The modifier now scales proportionally from 0 to -50 with the fraction of dead civs, as the comment describes. No other behavior is changed.