### PR TITLE
Fix barbarian invasion quest notifying the wrong civilizations

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/quests/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/quests/QuestManager.kt
@@ -279,10 +279,10 @@ class QuestManager : IsPartOfGameInfoSerialization {
             && civ.cityStateFunctions.getNumThreateningBarbarians() >= 2) {
 
             civ.forEachKnownCiv {
-                if (it.isMajorCiv()
-                    && it.isAlive()
-                    && !it.isAtWarWith(civ)
-                    && it.getProximity(civ) <= Proximity.Far
+                if (!it.isMajorCiv()
+                    || !it.isAlive()
+                    || it.isAtWarWith(civ)
+                    || it.getProximity(civ) > Proximity.Far
                 ) return@forEachKnownCiv
                 it.addNotification(
                     "[${civ.civName}] is being invaded by Barbarians! Destroy Barbarians near their territory to earn Influence.",


### PR DESCRIPTION
## Summary

When a city-state is threatened by two or more barbarian units, it is supposed to notify all alive major civilizations that are at peace with it and within Far proximity, asking them to help clear the barbarians for influence. The QuestManager reorg in #14967 turned the positive recipient filter into an early `return@forEachKnownCiv` without negating the condition, so the intended recipients were skipped and the notification went to the opposite set instead, including dead civs, civs at war with the city-state, and civs on the other side of the map.

## Fix

Negate each clause of the guard condition in `tryBarbarianInvasion` in `QuestManager.kt` so the loop skips civs that are not major, not alive, at war with the city-state, or farther than Far proximity, and notifies the remaining ones. This restores the original recipient behavior with a minimal change.