### PR TITLE
Fix city-state war quest kill target

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/quests/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/quests/QuestManager.kt
@@ -560,7 +560,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
     fun wasAttackedBy(attacker: Civilization) {
         // Set target number units to kill
         val totalMilitaryUnits = attacker.units.getCivUnits().count { !it.isCivilian() }
-        val unitsToKill = (totalMilitaryUnits / 4).coerceAtMost(3)
+        val unitsToKill = (totalMilitaryUnits / 4).coerceAtLeast(3)
         unitsToKillForCiv[attacker.civID] = unitsToKill
 
         // Ask for assistance


### PR DESCRIPTION
## Summary

When a major civilization attacks a city-state, the "war with major" pseudo-quest asks other civs to kill some of the attacker's military units. The kill target is meant to be at least 3, scaling up with larger armies (one extra kill per 4 military units). The cleanup in #11224 accidentally inverted the bound to `coerceAtMost(3)`, so an attacker with 0 to 3 military units produced a kill target of 0. In that case the quest could be completed after a single kill despite showing a target of 0, and large armies no longer scaled the target above 3.

## Fix

Change `coerceAtMost(3)` to `coerceAtLeast(3)` in `QuestManager.wasAttackedBy`, restoring the intended floor of 3 kills while keeping the `totalMilitaryUnits / 4` scaling for large armies.