### PR TITLE
Fix AddInCapital city center clearing

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -20,7 +20,7 @@ object CivilianUnitAutomation {
     fun shouldClearTileForAddInCapitalUnits(unit: MapUnit, tile: Tile) =
         tile.isCityCenter() && tile.getCity()!!.isCapital()
         && !unit.hasUnique(UniqueType.AddInCapital)
-        && unit.civ.units.getCivUnits().any { unit.hasUnique(UniqueType.AddInCapital) }
+        && unit.civ.units.getCivUnits().any { it.hasUnique(UniqueType.AddInCapital) }
 
     fun automateCivilianUnit(unit: MapUnit, dangerousTiles: HashSet<Tile>) = timeThis<Unit>("automateCivilianUnit") {
         // To allow "found city" actions that can only trigger a limited number of times


### PR DESCRIPTION
## Summary

`CivilianUnitAutomation.shouldClearTileForAddInCapitalUnits` is meant to detect whether the civ owns any unit with the `AddInCapital` unique, so that a unit occupying the capital's city center moves out of the way. The `any` lambda checked `unit.hasUnique(UniqueType.AddInCapital)` instead of the iterated unit. Since `unit` is the incoming unit being automated, and the previous condition already requires it to lack `AddInCapital`, the predicate was always false and the city center was never cleared.

## Fix

Check the iterated unit inside the lambda by using `it.hasUnique(UniqueType.AddInCapital)`.