### PR TITLE
Fix "Gain [amount]-[amount] [stat]" excluding the upper bound and crashing on equal bounds

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -825,7 +825,9 @@ object UniqueTriggerActivation {
                 ) return null
 
 
-                val randomValue = tileBasedRandom.nextInt(unique.params[0].toInt(), unique.params[1].toInt())
+                val firstValue = unique.params[0].toInt()
+                val secondValue = unique.params[1].toInt()
+                val randomValue = (minOf(firstValue, secondValue)..maxOf(firstValue, secondValue)).random(tileBasedRandom)
                 val finalStatAmount = if (unique.isModifiedByGameSpeed()) (randomValue * civInfo.gameInfo.speed.statCostModifiers[stat]!!).roundToInt()
                                             else randomValue
 


### PR DESCRIPTION
# Fix "Gain [amount]-[amount] [stat]" excluding the upper bound and crashing on equal bounds

## Problem

The `OneTimeGainStatRange` trigger ("Gain [amount]-[amount] [stat]") uses `Random.nextInt(from, until)`, whose upper bound is exclusive. As a result:

- The declared maximum can never be rolled, e.g. "Gain [20]-[50] [Gold]" only ever grants 20-49 Gold, even though the unique text implies an inclusive range.
- If both bounds are equal (e.g. "Gain [30]-[30] [Gold]"), `nextInt` throws `IllegalArgumentException`, crashing the game when the unique triggers.
- Inverted bounds (min > max) also throw instead of being handled gracefully.

## Fix

Roll the value with an inclusive `IntRange` instead, ordering the bounds first:

```kotlin
val firstValue = unique.params[0].toInt()
val secondValue = unique.params[1].toInt()
val randomValue = (minOf(firstValue, secondValue)..maxOf(firstValue, secondValue)).random(tileBasedRandom)
```

This makes the upper bound reachable, makes equal bounds simply yield that value, and treats inverted bounds as the same range instead of crashing. The same seeded `tileBasedRandom` is used, so trigger determinism is unchanged.
