### PR TITLE
Fix integer division in settler location ring weighting

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -123,7 +123,7 @@ object CityLocationTileRanker {
                 //Ideally, we shouldn't really count the center tile, as it's converted into 1 production 2 food anyways with special cases treated above, but doing so can lead to AI moving settler back and forth until forever
                 for (nearbyTile in newCityTile.getTilesAtDistance(i)) {
                     tiles++
-                    tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap) * (3 / (i + 1))
+                    tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap) * (3f / (i + 1))
                     //Tiles close to the city can be worked more quickly, and thus should gain higher weight.
                 }
         }


### PR DESCRIPTION
# Fix integer division in settler location ring weighting

## Problem

`CityLocationTileRanker.rankTileToSettle` weights nearby tiles by ring distance using `3 / (i + 1)`. Both operands are `Int`, so Kotlin performs integer division and the weights come out as 3, 1, 1 for rings 0, 1 and 2 instead of the intended 3, 1.5, 1. As a result, ring 1 tiles are weighted the same as ring 2 tiles, even though tiles closer to the city can be worked sooner and the comment right below the line says they should gain higher weight.

## Fix

Use `3f / (i + 1)` so the division happens in floating point, giving the intended 3 / 1.5 / 1 falloff. One-character change.
