### PR TITLE
Fix inverted motivation term in join-war trust penalty

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
@@ -83,7 +83,7 @@ object DeclareWarPlanEvaluator {
         // We need to be able to trust the thirdCiv at least somewhat
         if (thirdCivDiplo.diplomaticStatus != DiplomaticStatus.DefensivePact &&
             thirdCivDiplo.opinionOfOtherCiv() + motivation * 2 < 80) {
-            motivation -= 80f - thirdCivDiplo.opinionOfOtherCiv() + motivation * 2
+            motivation -= 80f - (thirdCivDiplo.opinionOfOtherCiv() + motivation * 2)
         }
         if (!civToJoin.threatManager.getNeighboringCivilizations().contains(target)) {
             motivation -= 20f


### PR DESCRIPTION
# Fix inverted motivation term in join-war trust penalty

## Problem

In `DeclareWarPlanEvaluator.evaluateJoinWarPlan`, when we don't trust the civ asking us to join their war enough (`opinion + motivation * 2 < 80`), the penalty applied to the motivation was computed as:

```kotlin
motivation -= 80f - thirdCivDiplo.opinionOfOtherCiv() + motivation * 2
```

Due to operator precedence this evaluates as `(80f - opinion) + motivation * 2`, so the motivation term is *added* to the penalty instead of reducing it. The higher our motivation to attack the target, the harsher the trust penalty became, which is the opposite of the intent: subtract only the shortfall below the 80 threshold.

This is a regression from #11807, which converted motivation from `Int` to `Float` and dropped the parentheses from the original expression introduced in #11688:

```kotlin
motivation -= 80 - (thirdCivDiplo.opinionOfOtherCiv() + motivation * 2).toInt()
```

## Fix

Add the missing parentheses so the penalty is the actual shortfall:

```kotlin
motivation -= 80f - (thirdCivDiplo.opinionOfOtherCiv() + motivation * 2)
```

This makes the AI's decision to join wars consistent with the trust check guarding it: civs with high motivation and decent opinion are no longer over-penalized, and the penalty smoothly approaches zero as `opinion + motivation * 2` approaches 80.
