### PR TITLE
Fix nuke AI fallout check using ground zero tile instead of affected tile

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
@@ -199,7 +199,7 @@ object AirUnitAutomation {
             else if (targetTile.owningCity != null) {
                 val owningCiv = targetTile.owningCity?.civ!!
                 // If there is a tile to add fallout to there is a 50% chance it will get fallout
-                if (!(tile.isWater || tile.isImpassible() || targetTile.hasFalloutEquivalent()))
+                if (!(targetTile.isWater || targetTile.isImpassible() || targetTile.hasFalloutEquivalent()))
                     explosionValue += evaluateCivValue(owningCiv, -40, 10)
                 // If there is an improvment to pillage
                 if (targetTile.improvement != null && !targetTile.improvementIsPillaged)


### PR DESCRIPTION
# Fix nuke AI fallout check using ground zero tile instead of affected tile

## Problem

In `AirUnitAutomation.getNukeLocationValue`, the loop over `tilesInBlastRadius` scores each `targetTile` for potential fallout, but the water and impassible checks were done on `tile`, the ground-zero tile, rather than on the `targetTile` being evaluated:

```kotlin
if (!(tile.isWater || tile.isImpassible() || targetTile.hasFalloutEquivalent()))
```

The actual fallout logic (`Nuke.applyPillageAndFallout`) checks each affected tile individually:

```kotlin
if (tile.isWater || tile.isImpassible() || tile.terrainFeatures.contains("Fallout")) return
```

So the AI misvalued blast-radius tiles whenever they differed from the center: targeting a land tile made it count fallout value for water/impassible neighbors that can never receive fallout, and targeting a water or impassible tile made it skip fallout value for all surrounding land tiles.

## Fix

Check `isWater` and `isImpassible()` on `targetTile`, matching the per-tile eligibility used when fallout is actually applied. One-line change.
