### PR TITLE
Fix join-war target force applying lower bound to enemy force sum

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
@@ -89,7 +89,7 @@ object DeclareWarPlanEvaluator {
             motivation -= 20f
         }
 
-        val targetForce = target.getStatForRanking(RankingType.Force) - 0.8f * target.getCivsAtWarWith().sumOf { it.getStatForRanking(RankingType.Force) }.coerceAtLeast(100)
+        val targetForce = (target.getStatForRanking(RankingType.Force) - 0.8f * target.getCivsAtWarWith().sumOf { it.getStatForRanking(RankingType.Force) }).coerceAtLeast(100f)
         val civForce = civInfo.getStatForRanking(RankingType.Force)
 
         // They need to be at least half the targets size, and we need to be stronger than the target together


### PR DESCRIPTION
# Fix join-war target force applying lower bound to enemy force sum

## Problem

In `DeclareWarPlanEvaluator.evaluateJoinWarPlan`, the target's effective force is meant to be its own force minus 80% of the combined force of the civs it is already at war with, clamped to a minimum:

```kotlin
val targetForce = target.getStatForRanking(RankingType.Force) - 0.8f * target.getCivsAtWarWith().sumOf { it.getStatForRanking(RankingType.Force) }.coerceAtLeast(100)
```

Due to precedence, `coerceAtLeast(100)` applies to the enemies' force sum instead of the final expression. This forces the subtracted term to at least 80 even when the target has no enemies (`sumOf` returns 0), and leaves `targetForce` unclamped, so it can go negative when the target is already fighting strong opponents. A negative or understated `targetForce` distorts the subsequent motivation checks (e.g. the `civToJoinForce < targetForce / 2` and `targetForce * multiplier` comparisons), making the AI misjudge whether joining the war is worthwhile.

## Fix

Apply the lower bound to the whole expression, matching how `civToJoinForce` is computed on the line just below:

```kotlin
val targetForce = (target.getStatForRanking(RankingType.Force) - 0.8f * target.getCivsAtWarWith().sumOf { it.getStatForRanking(RankingType.Force) }).coerceAtLeast(100f)
```
