### PR TITLE
chore: Reorder GL thread decoupling for MusicController.playOverlay

### DIFF
--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -647,15 +647,17 @@ class MusicController {
         // newMusic() is GL-thread-safe (no OpenAL calls), so loading can happen here on any thread.
         // play() and dispose() make OpenAL calls, so those must run on the GL thread.
         val controller = MusicTrackController(volume, initialFadeVolume = if (fadeIn) 0f else 1f)
-        controller.load(file) {
+        controller.load(file) { newOverlay ->
+            val oldOverlay = overlay
+            overlay = null
+            newOverlay.music?.isLooping = isLooping
             Concurrency.runOnGLThread {
-                clearOverlay()
-                it.music?.isLooping = isLooping
-                it.play()
+                oldOverlay?.clear()
+                newOverlay.play()
                 //todo Needs to be called even when no fade desired to correctly set state - Think about changing that
-                it.startFade(MusicTrackController.State.FadeIn)
-                overlay = it
+                newOverlay.startFade(MusicTrackController.State.FadeIn)
             }
+            overlay = newOverlay
         }
     }
 


### PR DESCRIPTION
As proposed in https://github.com/yairm210/Unciv/commit/089df997b062764ee82d551f716d26cb0a2dbfd6#commitcomment-191825971

Edit: ... delay due to play-testing with focus on several "overlays" speaking concurrently, as can happen with tech discovered and trade proposals when processed quickly. Was never the intention to be supported, but, well, now it works, at the price of those background threads not being cancellable due to not being tracked. That doesn't mean _this_ PR is what is making it work, your commit did as far as I can tell, but this should be safer against race conditions.