### PR TITLE
Fix mediated peace treaty duration and countdown

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -74,7 +74,7 @@ object DiplomacyTurnManager {
             TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, duration = durationLeft)
         )
         trades.add(treaty)
-        otherCiv.getDiplomacyManager(civInfo)!!.trades.add(treaty)
+        otherCiv.getDiplomacyManager(civInfo)!!.trades.add(treaty.reverse())
     }
 
 

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -199,9 +199,9 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 TradeOfferType.PeaceProposal -> {
                     // Convert PeaceProposal to peaceTreaty and apply to warring civs
                     val trade = Trade()
-                    val peaceOffer = TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, duration = offer.duration)
+                    val peaceOffer = TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, speed = from.gameInfo.speed)
                     trade.ourOffers.add(peaceOffer)
-                    trade.theirOffers.add(peaceOffer)
+                    trade.theirOffers.add(peaceOffer.copy())
                     
                     val thirdCiv = from.gameInfo.getCivilization(offer.name)
                     val tradePartnerDiplo = from.getDiplomacyManager(thirdCiv)!!
@@ -211,7 +211,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                     }
 
                     thirdCiv.getDiplomacyManager(from)!!.apply {
-                        trades.add(trade)
+                        trades.add(trade.reverse())
                         updateHasOpenBorders()
                     }
 

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -201,7 +201,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                     val trade = Trade()
                     val peaceOffer = TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, speed = from.gameInfo.speed)
                     trade.ourOffers.add(peaceOffer)
-                    trade.theirOffers.add(peaceOffer.copy())
+                    trade.theirOffers.add(peaceOffer)
                     
                     val thirdCiv = from.gameInfo.getCivilization(offer.name)
                     val tradePartnerDiplo = from.getDiplomacyManager(thirdCiv)!!


### PR DESCRIPTION
## Problem

When a peace deal between two other civilizations is mediated through a trade, the `PeaceProposal` is converted into a peace treaty using the proposal's duration. `PeaceProposal` is an immediate offer, so that duration is `-1` and the resulting treaty does not enforce the normal peace period.

The mediated and remade peace paths also store the same mutable `Trade` instance in both civilizations' diplomacy managers. Each manager decrements its trade durations at the end of its civilization's turn, so once the treaty has a real duration, the shared offers are decremented twice per round.

## Fix

Create the mediated peace treaty with the current game speed so it receives the standard peace-deal duration. Store `trade.reverse()` in the other civilization's diplomacy manager in both the mediated and remade paths. `Trade.reverse()` copies the offers, giving each manager its own countdown while preserving the expected offer orientation.

This includes the duration correction from #15132 and adds the missing ownership fix for both peace-treaty creation paths.
