### PR TITLE
Save keybindings when closing options outside

### DIFF
--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -122,17 +122,19 @@ class OptionsPopup(
             tabs.addPage("Debug", DebugTab(this), ImageGetter.getImage("OtherIcons/SecretOptions"), 24f)
         }
 
-        tabs.decorateHeader(getCloseButton {
-            screen.game.musicController.onChange(null)
-            center(screen.stage)
-            tabs.selectPage(-1, false)
-            settings.save()
-            onClose() // activate the passed 'on close' callback
-            close() // close this popup
-        })
+        tabs.decorateHeader(getCloseButton { close() })
 
         pack() // Needed to show the background.
         center(screen.stage)
+    }
+
+    override fun close() {
+        game.musicController.onChange(null)
+        center(stageToShowOn)
+        tabs.selectPage(-1, false)
+        settings.save()
+        onClose() // activate the passed 'on close' callback
+        super.close()
     }
 
     override fun setVisible(visible: Boolean) {


### PR DESCRIPTION
## Problem

Key binding changes are kept in the Keys tab controls until that tab is deactivated. The normal Options close button deactivates the current tab and saves settings before closing.

Options also allows closing by clicking outside the popup. That path calls `Popup.close()` directly, bypassing the close button cleanup. Key binding edits are therefore discarded, and other setting changes may remain unsaved until a later save.

## Fix

Move the existing Options cleanup into `OptionsPopup.close()` and make the header button call that method. Button, outside-click and programmatic close paths now all deactivate the current tab, save settings and run the existing close callback through one shared path.
