### PR TITLE
Fix city bombard notifications not selecting cities

### DIFF
--- a/core/src/com/unciv/logic/civilization/NotificationActions.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationActions.kt
@@ -141,17 +141,15 @@ class MapUnitAction(
 ) : NotificationAction {
     constructor(unit: MapUnit) : this(unit.currentTile.position.toHexCoord(), unit.id)
     override fun execute(worldScreen: WorldScreen) {
-        val selectUnit = id != Constants.NO_ID // This is the unspecific "select any unit on that tile", specific works without this being on
-        val unit = if (selectUnit) 
-            worldScreen.selectedCiv.units.getUnitById(id) 
-        else
-            worldScreen.gameInfo.tileMap[location].getUnits().firstOrNull { it.id == id }
+        val unit = if (id != Constants.NO_ID)
+            worldScreen.selectedCiv.units.getUnitById(id)
+        else null
         if (unit != null) {
             val unitLocation = unit.currentTile.position.toHexCoord()
-            worldScreen.mapHolder.setCenterPosition(unitLocation, selectUnit = selectUnit, forceSelectUnit = unit)
+            worldScreen.mapHolder.setCenterPosition(unitLocation, forceSelectUnit = unit)
         }
         else {
-            worldScreen.mapHolder.setCenterPosition(location.toHexCoord(), selectUnit = false)
+            worldScreen.mapHolder.setCenterPosition(location.toHexCoord(), selectUnit = id == Constants.NO_ID)
         }
     }
     companion object {


### PR DESCRIPTION
## Problem

`MapUnitAction` without a unit ID is documented to select its tile, including selecting a city for bombard notifications. The current code sets `selectUnit` only when an ID is present, then handles the no-ID case by searching for a unit whose ID is `NO_ID`.

Real units cannot retain `NO_ID`, so that lookup always fails and the fallback centers the camera with selection disabled. Clicking a city bombard notification therefore moves the camera but does not select the city or open its bombard controls.

## Fix

Handle the optional ID directly:

- If the ID resolves to a unit, center and force-select that unit.
- If there is no ID, center and select the target tile.
- If a stored ID no longer resolves, center the original tile without selecting an unrelated unit.
