### PR TITLE
Fix attack crosshair creation

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/layers/TileLayerOverlay.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/layers/TileLayerOverlay.kt
@@ -24,7 +24,7 @@ class TileLayerOverlay(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup,
     private fun getUnexplored() = ImageGetter.getImage(strings.unexploredTile).setHexagonSize()
 
     fun showCrosshair(alpha: Float = 1f) {
-        if (crosshair != null){
+        if (crosshair == null) {
             crosshair = getCrosshair()
             addOwnedActor(crosshair!!)
             determineVisibility()


### PR DESCRIPTION
## Problem

`TileLayerOverlay.showCrosshair()` creates the crosshair actor only inside `if (crosshair != null)`. The field starts as `null`, and that branch contains its only assignment, so the first call can never create the actor. Attack crosshairs are consequently never displayed.

## Fix

Create the crosshair when the field is `null`, matching the lifecycle already used by `showHighlight()`. Repeated calls reuse the existing actor, while `hideCrosshair()` can still remove it and reset the field.
