### PR TITLE
Fix inverse personality modifier scaling

### DIFF
--- a/core/src/com/unciv/models/ruleset/nation/Personality.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Personality.kt
@@ -130,7 +130,7 @@ class Personality: RulesetObject() {
      */
     @Readonly
     fun inverseModifierFocus(value: PersonalityValue, weight: Float): Float {
-        return 1f - (inverseScaledFocus(value) - 2) * weight
+        return 1f + (inverseScaledFocus(value) - 1) * weight
     }
 
     /**


### PR DESCRIPTION
## Problem

`inverseModifierFocus` is documented as the inverted form of `modifierFocus`, with personality value 0 mapping toward 2, value 5 remaining centered at 1 and value 10 mapping toward 0.

The current expression simplifies to a value that increases with the original personality value. At full weight it produces 1, 2 and 3 for values 0, 5 and 10, so it is neither inverted nor centered in the documented 0 to 2 range. The affected construction scoring consequently makes aggressive civilizations value defensive city buildings more rather than less.

## Fix

Use the same centered weighting formula as `modifierFocus`, applied to `inverseScaledFocus`:

```kotlin
1f + (inverseScaledFocus(value) - 1) * weight
```

This restores the documented inverted 2, 1, 0 behavior at full weight while preserving the neutral multiplier at weight 0.
