### PR TITLE
Fix integer division in AI peace health check

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -415,7 +415,7 @@ object DiplomacyAutomation {
                 continue
             }
             
-            if (enemy.cities.any{ (it.health / it.getMaxHealth()) < 0.5f }) // We are just about to take their city!
+            if (enemy.cities.any { (it.health.toFloat() / it.getMaxHealth()) < 0.5f }) // We are just about to take their city!
                 continue
 
             if (civInfo.getStatForRanking(RankingType.Force) - 0.8f * civInfo.threatManager.getCombinedForceOfWarringCivs() > 0) {


### PR DESCRIPTION
## Problem

`DiplomacyAutomation.offerPeaceTreaty` checks whether an enemy city is below half health using:

```kotlin
it.health / it.getMaxHealth()
```

Both values are `Int`, so Kotlin performs integer division. Any damaged city produces `0`, even at 199/200 health, and the AI treats it as being below 50% health. This makes it refuse peace whenever any enemy city has taken damage.

## Fix

Convert `health` to `Float` before division so the comparison uses the actual health ratio. The strict `< 0.5f` threshold remains unchanged.
