### PR TITLE
Preserve previous owner when cloning cities

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -177,6 +177,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         toReturn.isBeingRazed = isBeingRazed
         toReturn.attackedThisTurn = attackedThisTurn
         toReturn.foundingCiv = foundingCiv
+        toReturn.previousOwner = previousOwner
         toReturn.turnAcquired = turnAcquired
         toReturn.isPuppet = isPuppet
         toReturn.isOriginalCapital = isOriginalCapital


### PR DESCRIPTION
## Problem

`City.previousOwner` is set when a city changes hands and is used to detect a reconquest while the city is still in resistance. This prevents resistance from being applied again when the previous owner immediately retakes the city.

`City.clone()` does not copy `previousOwner`. Since cloned game state is used when advancing turns, the field is reset to an empty string while the resistance state remains. A later reconquest is then treated as a new conquest and resistance is applied again.

## Fix

Copy `previousOwner` in `City.clone()` together with the other persisted city fields.
