### PR TITLE
Fix crash when clearing a selected spy

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -163,7 +163,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
     fun update() {
         closeButton.isVisible = true
         
-        if (!presenter.shouldBeShown()) summaryPresenter
+        if (!presenter.shouldBeShown()) presenter = summaryPresenter
         presenter.update()
 
         // more efficient to do this check once for both


### PR DESCRIPTION
## Problem

When a selected spy is cleared through the red X action in the map overlay, `selectSpy(null)` leaves `SpyPresenter` as the active presenter with no selected spy.

`UnitTable.update` already checks whether the current presenter should still be shown, but the fallback line only evaluates `summaryPresenter` and discards the result. The update then reaches `SpyPresenter.updateWhenNeeded`, which dereferences `selectedSpy!!` and crashes.

## Fix

Assign `summaryPresenter` to `presenter` when the current presenter should no longer be shown. This makes the existing fallback check effective before the presenter is updated.
