### PR TITLE
Replace arrow Unicode characters for wider compatibility

### DIFF
--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -152,8 +152,8 @@ object Fonts {
     // Alternatives: "↑" U+2191, "↓" U+2193 - much wider and weird spacing in some fonts (e.g. Verdana).
     // These are possibly the highest codepoints in use in Unciv -
     // Taken into account when limiting FontRulesetIcons codepoints (it respects the private area ending at U+F8FF)
-    const val sortUpArrow = '￪'         // U+FFEA 'half wide upward arrow'
-    const val sortDownArrow = '￬'       // U+FFEC 'half wide downward arrow'
+    const val sortUpArrow = '↑'         // U+2191 'upwards arrow'
+    const val sortDownArrow = '↓'       // U+2193 'downwards arrow'
     const val rightArrow = '→'          // U+2192, e.g. Battle table or event-based tutorials
     //endregion
 

--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -148,10 +148,6 @@ object Fonts {
     const val star = '✯'                // U+272F 'pinwheel star'
     const val status = '◉'              // U+25C9 'fisheye'
     // The following two are used for sort visualization.
-    // They may disappear (show as placeholder box) on Linux if you clean out asian fonts.
-    // Alternatives: "↑" U+2191, "↓" U+2193 - much wider and weird spacing in some fonts (e.g. Verdana).
-    // These are possibly the highest codepoints in use in Unciv -
-    // Taken into account when limiting FontRulesetIcons codepoints (it respects the private area ending at U+F8FF)
     const val sortUpArrow = '↑'         // U+2191 'upwards arrow'
     const val sortDownArrow = '↓'       // U+2193 'downwards arrow'
     const val rightArrow = '→'          // U+2192, e.g. Battle table or event-based tutorials

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -141,10 +141,10 @@ Note textures provided for such codepoints *do* respect aspect ratio, they do *n
 |   ∞    |  U+221E   | infinity                           | EmojiIcons/Infinity         |    *     |
 |   ⚙    |  U+2699   | gear                               | EmojiIcons/Production       |          |
 |   ⍾    |  U+237E   | bell symbol                        | EmojiIcons/Science          |          |
-|   ￪    |  U+FFEA   | halfwidth upwards arrow            | EmojiIcons/SortedAscending  |    *     |
+|   ↑    |  U+2191   | upwards arrow                      | EmojiIcons/SortedAscending  |    *     |
 |   ◉    |  U+25C9   | fisheye                            | EmojiIcons/SortedByStatus   |    *     |
 |   ⌚    |  U+231A   | watch                              | EmojiIcons/SortedByTime     |    *     |
-|   ￬    |  U+FFEC   | halfwidth upwards arrow            | EmojiIcons/SortedDescending |    *     |
+|   ↓    |  U+2193   | upwards arrow                      | EmojiIcons/SortedDescending |    *     |
 |   ✯    |  U+272F   | pinwheel star                      | EmojiIcons/Star             |    *     |
 |   ⏳    |  U+23F3   | hourglass                          | EmojiIcons/Turn             |          |
 |   ⅰ    |  U+2170   | small roman numeral one            | MayaCalendar/0              |          |


### PR DESCRIPTION
In the current font mapping, we are using half-width arrows. These are not available on many standard Linux installations and usually require a CJK font to be installed on the system to render correctly.

This PR switches them to widely available standard arrow characters.

### Visual Comparison

**Current Version (with fonts installed):**
<img width="400" height="400" alt="old" src="https://github.com/user-attachments/assets/dd9c6732-368b-40a2-82e3-de6ef1c52fb4" />

**Broken Rendering (missing fonts):**
<img width="400" height="400" alt="broken" src="https://github.com/user-attachments/assets/bc420791-400f-4cd1-94b7-fe2a5db90688" />

**New Version (using standard characters):**
<img width="400" height="400" alt="new" src="https://github.com/user-attachments/assets/cc4c8c50-1292-4ccc-9138-4801af7deba1" />

---
As far as I can tell, the other characters defined in `Fonts.kt` are fine. They map successfully to common standard fonts like `Adwaita Mono`, `FreeSerif`, `FreeSans`, `Noto Sans`, `JetBrainsMono`, or standard Nerd Fonts. The half-width arrows appear to be the only characters requiring CJK font support to render.

---
*P.S. I also personally prefer the look of the standard arrows more ;)*