### PR TITLE
implement "other" parameter for mapunit

### DIFF
--- a/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
+++ b/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
@@ -51,7 +51,7 @@ object GreatGeneralImplementation {
                 // The "Military" test is also supported deep down in unit.matchesFilter, a small
                 // optimization for the most common case, as this function is only called for `MapUnitCombatant`s
                 it.general.currentTile.aerialDistanceTo(unit.getTile()) <= it.radius
-                        && (it.filter == "Military" || unit.matchesFilter(it.filter))
+                        && (it.filter == "Military" || unit.matchesFilter(it.filter, state = it.general.cache.state))
             }
         val greatGeneralModifier = greatGeneral.maxByOrNull { it.bonus } ?: return Pair("",0)
 

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -637,12 +637,12 @@ class MapUnit : IsPartOfGameInfoSerialization {
                 || (civ.isCityState && civ.allyCiv == otherCiv)
     }
 
-    /** Implements [UniqueParameterType.MapUnitFilter][com.unciv.models.ruleset.unique.UniqueParameterType.MapUnitFilter] */
+    /** Implements [UniqueParameterType.MapUnitFilter][com.unciv.models.ruleset.unique.UniqueParameterType.MapUnitFilter] 
+     * Gets passed state explicitly when the unit applying the filter isn't this unit*/
     @Readonly
-    fun matchesFilter(filter: String, multiFilter: Boolean = true, state: GameContext = GameContext.EmptyState): Boolean {
-        return if (multiFilter) MultiFilter.multiFilter(filter, { matchesSingleFilter(it, state) })
+    fun matchesFilter(filter: String, multiFilter: Boolean = true, state: GameContext = GameContext.EmptyState): Boolean =
+        if (multiFilter) MultiFilter.multiFilter(filter, { matchesSingleFilter(it, state) })
         else matchesSingleFilter(filter, state)
-    }
 
     @Readonly
     private fun matchesSingleFilter(filter: String, state: GameContext = GameContext.EmptyState): Boolean {

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -639,13 +639,15 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     /** Implements [UniqueParameterType.MapUnitFilter][com.unciv.models.ruleset.unique.UniqueParameterType.MapUnitFilter] */
     @Readonly
-    fun matchesFilter(filter: String, multiFilter: Boolean = true): Boolean {
-        return if (multiFilter) MultiFilter.multiFilter(filter, ::matchesSingleFilter) else matchesSingleFilter(filter)
+    fun matchesFilter(filter: String, multiFilter: Boolean = true, state: GameContext = GameContext.EmptyState): Boolean {
+        return if (multiFilter) MultiFilter.multiFilter(filter, { matchesSingleFilter(it, state) })
+        else matchesSingleFilter(filter, state)
     }
 
     @Readonly
-    private fun matchesSingleFilter(filter: String): Boolean {
+    private fun matchesSingleFilter(filter: String, state: GameContext = GameContext.EmptyState): Boolean {
         return when (filter) {
+            "other" -> state.unit != this
             Constants.wounded, "wounded units" -> health < 100
             Constants.barbarians, "Barbarian" -> civ.isBarbarian
             "City-State" -> civ.isCityState

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -111,7 +111,7 @@ enum class UniqueParameterType(
     /** Implemented by [MapUnit.matchesFilter][com.unciv.logic.map.mapunit.MapUnit.matchesFilter] */
     MapUnitFilter("mapUnitFilter", Constants.wounded, null, "Map Unit Filters") {
         override val staticKnownValues = setOf(Constants.wounded, Constants.barbarians, "Barbarian",
-            "City-State", Constants.embarked, "Non-City")
+            "City-State", Constants.embarked, "Non-City", "other")
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = getErrorSeverityForFilter(parameterText, ruleset)
 


### PR DESCRIPTION
Implements "other" per the discussion in #15134.


This was done by optionally passing a GameContext object to mapunit.matchesFilter, currently this parameter is only passed by the GreatGeneralImplementation.getGreatGeneralBonus. It remains to be discussed if there are any other functions where "other" might be relevant.