### PR TITLE
chore: Lint A-star pathfinding classes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,8 @@ allprojects {
             "io.ktor.http.Url.segments",
             "io.ktor.http.Url.parameters",
             "io.ktor.http.Parameters.get",
+
+            "java.util.BitSet.clone",
         )
         wellKnownPureClasses = setOf(
         )

--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -46,6 +46,10 @@ import java.util.concurrent.atomic.AtomicReference
  * [UnitMovement.getDistanceToTiles], [AStar], [MapPathing.getPath], [MapPathing.getConnection], and
  * [MapPathing.getRoadPath].
  *
+ * Debugging help:
+ * - Set [VERBOSE_PATHFINDING_LOGS] to [ALWAYS_LOG] or to a specific starting coordinate.
+ * - Use [toDebugString] in a quick-watch
+ *
  * Future plans:
  * - createCityExpansionPathing
  *   - Useful for [UseGoldAutomation.maybeBuyCityTiles]
@@ -396,7 +400,8 @@ class PathingMap(
         @Suppress("unused")
         @VisibleForTesting
         val NEVER_LOG: HexCoord = HexCoord(0xFFFF,0xFFFF)
-        // can temporarily set this to a unit, civ, or tile position, to enable verbose logging for that thing's pathfinding
+        /** You can temporarily set this to a tile position, e.g. a unit's, or to [ALWAYS_LOG],
+         *  to enable verbose logging for that thing's pathfinding or for everything */
         @VisibleForTesting
         val VERBOSE_PATHFINDING_LOGS: HexCoord = NEVER_LOG
 

--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -1,6 +1,10 @@
 package com.unciv.logic.map
 
 import com.unciv.logic.automation.Timers.Companion.timeThis
+import com.unciv.logic.automation.civilization.MotivationToAttackAutomation
+import com.unciv.logic.automation.civilization.UseGoldAutomation
+import com.unciv.logic.automation.unit.RoadBetweenCitiesAutomation
+import com.unciv.logic.battle.TargetHelper
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.FixedPointMovement.Companion.FPM_ONE
@@ -12,6 +16,7 @@ import com.unciv.logic.map.RouteNode.Companion.MAX_MOVE_THIS_TURN
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.movement.MovementCost
 import com.unciv.logic.map.mapunit.movement.PathsToTilesWithinTurn
+import com.unciv.logic.map.mapunit.movement.UnitMovement
 import com.unciv.logic.map.mapunit.movement.UnitMovement.ParentTileAndTotalMovement
 import com.unciv.logic.map.tile.Tile
 import com.unciv.utils.Log
@@ -23,41 +28,41 @@ import yairm210.purity.annotations.Readonly
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * PathingMap is a class that coordinates the pathing caches and calculations.
+ * `PathingMap` is a class that coordinates the pathing caches and calculations.
  *
- * For the most part, all this class really does is manage the PathingMapCache automatically.
- * When pathing is requested, it builds an AStarPathfinder, which does the actual pathfinding, and
- * then the PathingMap merges the results back into its PathingMapCache. 
- * 
+ * For the most part, all this class really does is manage the [PathingMapCache] automatically.
+ * When pathing is requested, it builds an [AStarPathfinder], which does the actual pathfinding, and
+ * then the `PathingMap` merges the results back into its [PathingMapCache].
+ *
  * To calculate with different moveThroughPredicate, cost, or other conditions would invalidate the
- * cached "Node"s, so require a separate PathingMap.
- * 
- * The AStarPathfinder algorithm is uesd here because each tile is calculated exactly once, and the
+ * cached "Node"s, so require a separate `PathingMap`.
+ *
+ * The [AStarPathfinder] algorithm is used here because each tile is calculated exactly once, and the
  * resulting "Node" data can be reused for all subsequent pathfinding, even when pathfinding to
  * different targets.  This introduces a *very* minor bias in later paths toward earlier paths, but
  * only among routes of otherwise equal priority.
- * 
- * This completely replaces UnitMovement#getMovementToTilesAtPosition, UnitMovement#getShortestPath,
- * UnitMovement#getDistanceToTiles, AStar, MapPathing#getPath, MapPathing#getConnection, and 
- * MapPathing#MapPathing.getRoadPath.
- * 
+ *
+ * This completely replaces [UnitMovement.getMovementToTilesAtPosition], [UnitMovement.getShortestPath],
+ * [UnitMovement.getDistanceToTiles], [AStar], [MapPathing.getPath], [MapPathing.getConnection], and
+ * [MapPathing.getRoadPath].
+ *
  * Future plans:
  * - createCityExpansionPathing
- *   - Useful for UseGoldAutomation.maybeBuyCityTiles
+ *   - Useful for [UseGoldAutomation.maybeBuyCityTiles]
  * - Multiple start points.
- *   - Today, MotivationToAttackAutomation#getAttackPathsModifier does a separate BFS from each
+ *   - Today, [MotivationToAttackAutomation.getAttackPathsModifier] does a separate BFS from each
  *     city. Merging them would give a performance boost.
  * - Multiple target points.
- *   - Today, MotivationToAttackAutomation#getAttackPathsModifier does a separate BFS to each
+ *   - Today, [MotivationToAttackAutomation.getAttackPathsModifier] does a separate BFS to each
  *     city. Merging them would give a performance boost.
- *   - RoadBetweenCitiesAutomation#getRoadToConnectCityToCapital could just path from the capital
+ *   - [RoadBetweenCitiesAutomation.getRoadToConnectCityToCapital] could just path from the capital
  *     to each city, and tiles already connected would simply have a "cost" of zero.
- * - Add #getAttackableEnemies.
- *   - Right now TargetHelper#getAttackableEnemies is rediculously inefficient. For each tile we can
+ * - Add `getAttackableEnemies`.
+ *   - Right now [TargetHelper.getAttackableEnemies] is ridiculously inefficient. For each tile we can
  *     possibly attack from, for each tile in attack range, does it contain an enemy.  For long
  *     range units like Rocket Artillery, surrounded by roads, this causes most tiles to be analyzed
  *     37+ times. Instead, this class could ~BFS to (movement-1) + (range tiles), do a linear scan
- *     for enemies, and return the path to each enemy. Or similar.    
+ *     for enemies, and return the path to each enemy. Or similar.
  */
 @InternalState
 class PathingMap(
@@ -85,7 +90,7 @@ class PathingMap(
             Log.debug("#clear explicitly dumping caches for $debugMapType $debugId")
         cacheRef.set(null)
     }
-    
+
     @Suppress("purity")
     private fun fetchCache(): PathingMapCache {
         val latestKey = getCurrentCacheKey()
@@ -115,23 +120,23 @@ class PathingMap(
             if (VERBOSE_PATHFINDING_LOGS == latestKey.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#fetchCache() retrying cache fetch due to data race initializing cache $newCache")
             fetchCache()
-        }        
+        }
     }
 
 
     /**
-     * Constructs a sequence representing the path from the given destination tile back to the starting point.
-     * If the destination has not been reached, the sequence will be empty.
-     * 
-     * WARNING: If the path being analyzed exceeds maxTurns, then this returns a path of length 
+     * Constructs a list representing the path from the given destination tile back to the starting point.
+     * If the destination has not been reached, the list will be empty.
+     *
+     * WARNING: If the path being analyzed exceeds maxTurns, then this returns a path of length
      * maxTurns towards the destination, but the path will not actually reach the destination.
      *
      * @param destination The destination tile to trace the path to.
-     * @return A sequence of tiles representing the path from the destination to the starting point.
+     * @return A list of tiles representing the path from the destination to the starting point.
      */
     @Readonly
     @Suppress("purity")
-    fun getShortestPath(destination: Tile, maxTurns: Int = MAX_VALID_TURNS): List<Tile>? =timeThis("TileStatFunctions.getShortestPath") {
+    fun getShortestPath(destination: Tile, maxTurns: Int = MAX_VALID_TURNS): List<Tile>? = timeThis("PathingMap.getShortestPath") {
         val cache = fetchCache()
         if (destination.position == cache.key.startingPoint) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
@@ -141,7 +146,7 @@ class PathingMap(
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#getShortestPath emulating no-movement-pathing bug to $destination for $debugMapType $debugId")
             return listOf()
-            
+
         }
         // if we don't already know the shortest path, and might yet find it, search
         val targetNode = RouteNode(cache.routeNodes[destination.zeroBasedIndex])
@@ -196,7 +201,7 @@ class PathingMap(
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#getMovementToTilesAtPosition returning cached tilesSameTurn[len=${tilesSameTurn.size}] for $debugMapType $debugId")
             return tilesSameTurn
-        } 
+        }
         // if we've already calculated the results, return that
         // otherwise, find all tiles we can reach this turn, plus 1 tile extra, to make sure we
         // include enemies we would otherwise reach this turn.
@@ -210,9 +215,9 @@ class PathingMap(
     }
 
     /**
-     * finds the closest tile that match a predicate.
-     * 
-     * If there are multiple matches with the same movement cost, then this uses 
+     * Finds the closest tile that matches a predicate.
+     *
+     * If there are multiple matches with the same movement cost, then this uses
      * tile-owner-relationship as a tiebreaker, followed by zeroBasedIndex (roughly, distance from
      * center of map).
      *
@@ -230,19 +235,19 @@ class PathingMap(
         = bfsStepUntilDestination(fetchCache(), endSearchPredicate, timeLimitTurns)
 
     /**
-     * finds all tiles in attack range that match a predicate.
+     * Finds all tiles in attack range that match a predicate.
      *
      * This does not cache the results of the predicate matching, and so has to check all tiles
      * starting from the origin, even if the tiles' nodes have already been cached from prior
      * pathfinding. However, this uses/generates the same cached nodes as the other pathfinding
-     * (movement cost, relationship level, shortest route, damage numbers, etc), so if any other 
+     * (movement cost, relationship level, shortest route, damage numbers, etc), so if any other
      * pathing also occurs before or after, then these checks are effectively free.
-     * 
+     *
      * If you do not care about movement cost, then the BFS class is probably faster.
      *
      * IMPORTANT NOTE: This does NOT consider sight obstacles (hills/mountains) in the attack range.
      *
-     * IMPORTANT NOTE: The results of this method are not cached.  The *nodes* are cached , but the list of tiles
+     * IMPORTANT NOTE: The results of this method are not cached.  The *nodes* are cached , but the list of tiles isn't.
      **/
     fun bfsAllMatchingTiles(timeLimitTurns: Int, tilePredicate: EndSearchPredicate): List<Tile> {
         val results = ArrayList<Tile>()
@@ -341,14 +346,14 @@ class PathingMap(
             tileMap,
         )
         val result = finder.stepUntilDestination()
-        
+
         // now merge the pathfinder's tilesChecked and tilesToCheck back into the shared PathingData
         // again using a synchronized block not just for thread-safety, but also to ensure atomicity
         cache.mergePathfindingFork(finder.cache)
-        
+
         return result
     }
-    
+
     override fun toString(): String {
         val cache = cacheRef.get()
         return "${javaClass.simpleName}[debugMapType=$debugMapType debugId=$debugId key=${cache?.key}]"
@@ -358,7 +363,7 @@ class PathingMap(
 
     companion object {
         const val MAX_VALID_TURNS = RouteNode.MAX_VALID_TURNS
-        
+
         // Functional interfaces used here to prevent Kotlin from Boxing the return values
         @FunctionalInterface
         fun interface TilePredicate {
@@ -394,7 +399,7 @@ class PathingMap(
         // can temporarily set this to a unit, civ, or tile position, to enable verbose logging for that thing's pathfinding
         @VisibleForTesting
         val VERBOSE_PATHFINDING_LOGS: HexCoord = NEVER_LOG
-        
+
         @Readonly
         fun createUnitPathingMap(unit: MapUnit, considerZoneOfControl: Boolean = true, includeEscortUnit: Boolean = true): PathingMap {
             val name = if (!considerZoneOfControl) "createUnitPathingMapNoZoc"
@@ -406,7 +411,7 @@ class PathingMap(
             val getCurrentCacheKey = {
                 val escort = if (includeEscortUnit && unit.isEscorting()) unit.getOtherEscortUnit() else null
                 PathingMapCacheKey(
-                    unit.currentTile.position, 
+                    unit.currentTile.position,
                     fpmFromMovement(unit.currentMovement).coerceAtMost(escort?.currentMovement?.toFixedPointMove() ?: MAX_MOVE_THIS_TURN),
                     fpmFromMovement(selfFullMove.coerceAtMost(if (escort != null) otherUntilFullMove else MAX_VALID_TURNS)),
                     )
@@ -476,7 +481,7 @@ class PathingMap(
                 { tile -> tile.getOwner()?.getDiplomacyManager(civ)?.relationshipIgnoreAfraid() ?: RelationshipLevel.Favorable }
             )
         }
-        
+
         @Readonly
         private fun civPathExistCacheKey(startingPoint: HexCoord) = PathingMapCacheKey(startingPoint, MAX_MOVE_THIS_TURN, MAX_MOVE_THIS_TURN)
 

--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -410,7 +410,7 @@ class PathingMap(
             val name = if (!considerZoneOfControl) "createUnitPathingMapNoZoc"
                 else if (!includeEscortUnit) "createUnitPathingMapNoEscort"
                 else "createUnitPathingMap"
-            // These two precalculated because for some reason they're rediculously slow
+            // These two precalculated because for some reason they're ridiculously slow
             val selfFullMove = unit.getMaxMovement()
             val otherUntilFullMove = if (includeEscortUnit) unit.getOtherEscortUnit()?.getMaxMovement() ?: MAX_VALID_TURNS else MAX_VALID_TURNS
             val getCurrentCacheKey = {

--- a/core/src/com/unciv/logic/map/PathingMapCache.kt
+++ b/core/src/com/unciv/logic/map/PathingMapCache.kt
@@ -15,75 +15,75 @@ import java.util.Formatter
 import java.util.Locale
 
 
-/*
+/**
  * All the information we need about a route node, crammed into a single Long
- * 
+ *
  * If we avoid passing this to any methods that are erased, such as generics, then we can eliminate
- * allocations, leading to huge performance improvements.  
- * API oddities: 
- * - Due to the bitfield cramming, extrating the Tile, or ParentTile, requires passing in a TileMap,
+ * allocations, leading to huge performance improvements.
+ * API oddities:
+ * - Due to the bitfield cramming, extracting the Tile, or ParentTile, requires passing in a TileMap,
  *   so we can look up the tile from that.
- * 
- * Squeezing it into a Long requires a lot of careful considerations.  Not only avoiding passing it 
+ *
+ * Squeezing it into a Long requires a lot of careful considerations.  Not only avoiding passing it
  * to methods with type erasure, but also ensuring that we squeeze everything into 63 bits, and also
- * fast compatability with PrioritizedNode, and also PrioritizedNode's Comparitor. 
- * - If we pack the bits just right, then the PrioritizedNode comparator can simply compare the 
+ * fast compatibility with [PrioritizedNode], and also PrioritizedNode's Comparator.
+ * - If we pack the bits just right, then the PrioritizedNode comparator can simply compare the
  *   entire Long directly.  So we want to store the highest priority values in the most significant
- *   bits, and the lowest priority values into the least significant bits. 
+ *   bits, and the lowest priority values into the least significant bits.
  * - Packing everything into bits requires careful consideration of ranges, and then also for
  *   floats, consideration of precision and accuracy.
- * - PrioritizedNode needs almost all of the values, so we need to make sure everything that needs
- *   fits in 63 bits.
- * 
+ * - PrioritizedNode needs almost all of the values, so we need to make sure everything that is
+ *   needed fits in 63 bits.
+ *
  * Movement needs to be stored in fixed-point, in a base that can represent increments of 0.1
  *   move for railroads, and also increments of 1/3 for normal roads, uniquely. Base 30 (10x3) is
  *   the obvious choice, as it can store both road fractions with no precision loss whatsoever. So
  *   movement of 3.666 is stored as 110 (3.666*30), and restored as 3.666 (73/30). This can actually
- *   make the code simpler, as the rounding during conversion eliminates all floating point 
- *   rounding, so we no longer need to worry about minimumMovementEpsilon. The fastest unit in the
+ *   make the code simpler, as the rounding during conversion eliminates all floating point
+ *   rounding, so we no longer need to worry about [minimumMovementEpsilon][com.unciv.Constants.minimumMovementEpsilon]. The fastest unit in the
  *   base game is the Missile Cruiser with 7 movement. The fastest LAND units in the base game have
  *   6 movement.  There are a few techs which can give double movement under specific conditions, so
  *   we want to allow ~14 movement. Thus, the biggest value we need to store is 420 (14*30), which
  *   requires 9 bits. (This actually allows movements up to 17, which is nice for mod support).
- * 
+ *
  * Fields, in order from least to highest priority:
- * - tileIdx: the zeroBasedIndex, which is trivial to convert to/from Tile instances. Maximum map 
- *   size is radius 500, or 748501 tiles, so this takes 20 bits. Not strictly needed by RouteNode, 
- *   but handy. 
- * - relationshipLevel: Used as a tiebreaker when pathing through tiles owned by different civs.
+ * - [tileIdx]: the [zeroBasedIndex][Tile.zeroBasedIndex], which is trivial to convert to/from [Tile] instances.
+ *   Maximum map size is radius 500, or 748501 tiles, so this takes 20 bits.
+ *   Not strictly needed by [RouteNode], but handy.
+ * - [relationshipLevel]: Used as a tie-breaker when pathing through tiles owned by different civs.
  *   Unowned tiles are considered Allies. Stored as (7-ordinal), so that Ally=0, and is the highest
  *   priority. In the future, this can be reduced to 2, or even 1 bits, if needed.
- * - pbmMoveThisTurn: (pbm=PauseBeforeMountains) How much movement we would have used this turn, if
+ * - [pbmMoveThisTurn]: (pbm=PauseBeforeMountains) How much movement we would have used this turn, if
  *   we had ended a turn right before entering damaging terrain.  0 if the terrain is not damaging.
  *   This is used to retroactively calculate how far we could enter mountains if we had already
  *   moved some before entering damaging terrain. This is stored as fixed-point, base 30, in 9 bits.
- * - moveUsedThisTurn: How much movement we have used this turn so far.  This is stored as 
+ * - [moveUsedThisTurn]: How much movement we have used this turn so far.  This is stored as
  *   fixed-point, base 30, in 9 bits.
- * - turns: The number of turns used so far. Tiles reachable on the current turn have turns=0. We
+ * - [turns]: The number of turns used so far. Tiles reachable on the current turn have turns=0. We
  *   assume a maximum of 64 turns for pathing. If the AStar calculation hits this limit when
  *   calculating a tile, it simply returns the route to this tile. Which is a surprisingly
  *   reasonable approximation, in an unreasonable scenario. This requires 6 bits.
- * - underestimatedTotal: How much movement it would take to reach the target from the current tile,
- *   if all remaining tiles to the target are railroads.  We store this as as base-30 fixed point, 
+ * - [underestimatedTotal][PrioritizedNode.underestimatedTotal]: How much movement it would take to reach the target from the current tile,
+ *   if all remaining tiles to the target are railroads.  We store this as base-30 fixed point,
  *   with a maximum value of 819.15 movement used (25.55*64). This takes 14 bits. This is ONLY
- *   used by PrioritizedNode. This is never zero, which guarantees that an initialized 
+ *   used by PrioritizedNode. This is never zero, which guarantees that an initialized
  *   PrioritizedNode is never zero... except for the start node in one edge case.
- * - parentClockDir: The clock-direction index (2-12) of the parent tile, relative to this tile. We
+ * - [parentClockDir]: The clock-direction index (2-12) of the parent tile, relative to this tile. We
  *   use 14 to represent "no parent tile" (such as for the root node). Since the values are always
- *   even, we do not store the last bit, so this only takes 3 bits. This is never zero, which 
+ *   even, we do not store the last bit, so this only takes 3 bits. This is never zero, which
  *   guarantees that an initialized RouteNode is never zero.
- * - canMoveTo: True if the unit can end turn on the tile, or it's multiple turns away.
- * - padding: In a RouteNode, the other remaining 12 bits of underestimatedTotal just hold zeroes, 
+ * - [canMoveTo]: True if the unit can end turn on the tile, or it's multiple turns away.
+ * - `padding`: In a RouteNode, the other remaining 12 bits of underestimatedTotal just hold zeroes,
  *   for now.
- * - damagingTiles: How many tiles that cause end-turn damage have been crossed to reach this tile.
+ * - [damagingTiles]: How many tiles that cause end-turn damage have been crossed to reach this tile.
  *   This is the absolute highest priority field, so it goes in the most significant bits. So very
  *   long routes that do not take damage are prioritized over shorter routes that take damage,
  *   emulating prior behavior, while also allowing cache reuse.  We only store up to 3 damaging
  *   tiles, so this takes 2 bits.
- * - sign bit: Zero.  We *could* use it for values, but then we'd have to handle negative values
+ * - `sign bit`: Zero.  We *could* use it for values, but then we'd have to handle negative values
  *   in the comparison, which might involve negation and other complexity when reading other
  *   fields. Far safer and eaiser and faster to just keep it zero.
- * 
+ *
  * Tiles that cannot be pathed to at all store the maximum value in all fields except
  * zeroBasedIndex.
  */
@@ -99,17 +99,16 @@ value class RouteNode(val bits: Long=0L) {
         parentTile: Tile,
         moveTo: Boolean,
         damagingTiles: Int,
-    ):
-        this(
-            toTileIdxBits(tile) or
-                toRelationshipLevelBits(relationshipLevel) or
-                toPbmMoveThisTurnBits(pauseBeforeMountainMove) or
-                toMoveThisTurnBits(moveThisTurn) or
-                toTurnsBits(turns) or
-                toParentClockDirBits(tile, parentTile) or
-                toMoveToBits(moveTo) or
-                toDamagingTilesBits(damagingTiles)
-        ) {
+    ) : this(
+        toTileIdxBits(tile) or
+            toRelationshipLevelBits(relationshipLevel) or
+            toPbmMoveThisTurnBits(pauseBeforeMountainMove) or
+            toMoveThisTurnBits(moveThisTurn) or
+            toTurnsBits(turns) or
+            toParentClockDirBits(tile, parentTile) or
+            toMoveToBits(moveTo) or
+            toDamagingTilesBits(damagingTiles)
+    ) {
         require(tile.zeroBasedIndex < tile.tileMap.tileList.size) { "tileList ${tile.zeroBasedIndex} exceeds max ${tile.tileMap.tileList.size}" }
         require(tile.tileMap.tileList.size <= TILE_IDX_LO_MASK) { "tileList ${tile.tileMap.tileList.size} exceeds max $TILE_IDX_LO_MASK" }
         require(pauseBeforeMountainMove >= 0) { "pauseBeforeMountainMoveThisTurn $pbmMoveThisTurn must be positive" }
@@ -127,7 +126,7 @@ value class RouteNode(val bits: Long=0L) {
     @Readonly
     fun tile(tileMap: TileMap): Tile = tileMap.tileList[tileIdx]
 
-    val relationshipLevelBits: Long get() {require(initialized); return ((bits shr RELATIONSHIP_LEVEL_OFFSET) and RELATIONSHIP_LEVEL_LO_MASK) }
+    private val relationshipLevelBits: Long get() {require(initialized); return ((bits shr RELATIONSHIP_LEVEL_OFFSET) and RELATIONSHIP_LEVEL_LO_MASK) }
     val relationshipLevel: RelationshipLevel get() = RelationshipLevel.entries[MAX_RELATIONSHIP_LEVEL - relationshipLevelBits.toInt()]
 
     val pbmMoveThisTurn: FixedPointMovement get() {
@@ -152,7 +151,7 @@ value class RouteNode(val bits: Long=0L) {
         if (idx == NO_PARENT_TILE_VALUE) return tile(tileMap)
         return tileMap.getClockPositionNeighborTile(tile(tileMap), idx)!!
     }
-    
+
     val canMoveTo: Boolean get() { require(initialized); return (bits and MOVE_TO_HI_MASK) == MOVE_TO_HI_MASK}
 
     val damagingTiles: Int get() { require(initialized); return ((bits shr DAMAGE_TILES_OFFSET) and DAMAGE_TILES_LO_MASK).toInt() }
@@ -160,15 +159,15 @@ value class RouteNode(val bits: Long=0L) {
     // parentClockDir can never be 0, so all zeroes means uninitialized
     val initialized: Boolean get() = bits != 0L
 
-    val isNoPathingNode: Boolean get() = pbmMoveThisTurn.bits == PBM_MOVE_THIS_TURN_LO_MASK.toInt()
+    internal val isNoPathingNode: Boolean get() = pbmMoveThisTurn.bits == PBM_MOVE_THIS_TURN_LO_MASK.toInt()
 
     @Readonly
     override fun toString() = "RouteNode[tile=$tileIdx, turns=$turns, moveUsedThisTurn=$moveUsedThisTurn]"
     @Readonly
-    fun toString(tileMap: TileMap) = "RouteNode[tile=${tile(tileMap)} turns=$turns, moveThisTurn=$moveUsedThisTurn]"
+    fun toString(tileMap: TileMap) = "RouteNode[tile=${tile(tileMap)}, turns=$turns, moveThisTurn=$moveUsedThisTurn]"
 
     companion object {
-        // bits 0-19 (20b = 1048576tiles) are the zeroBasedIndex of this tile (radius 500, or approx 1170x896) 
+        // bits 0-19 (20b = 1048576tiles) are the zeroBasedIndex of this tile (radius 500, or approx 1170x896)
         internal const val TILE_IDX_OFFSET = 0
         internal const val TILE_IDX_BIT_COUNT = 20
         internal const val TILE_IDX_LO_MASK = (0x1L shl TILE_IDX_BIT_COUNT) - 1L
@@ -196,7 +195,7 @@ value class RouteNode(val bits: Long=0L) {
         private const val TURNS_LO_MASK = (0x1L shl TURNS_BIT_COUNT) - 1L
         const val MAX_TURNS = TURNS_LO_MASK.toInt()
         const val MAX_VALID_TURNS = MAX_TURNS - 1
-        // [PrioritizedNode] bits 47-60 (14b) are the underestimated total movement from the initial tile toward the target. 
+        // [PrioritizedNode] bits 47-60 (14b) are the underestimated total movement from the initial tile toward the target.
         internal const val UNDERESTIMATED_TOTAL_OFFSET = TURNS_OFFSET + TURNS_BIT_COUNT
         internal const val UNDERESTIMATED_TOTAL_BIT_COUNT = 14
         internal const val UNDERESTIMATED_TOTAL_LO_MASK = (0x1L shl  UNDERESTIMATED_TOTAL_BIT_COUNT) - 1L
@@ -208,7 +207,7 @@ value class RouteNode(val bits: Long=0L) {
         private const val PARENT_TILE_LO_MASK = (0x1L shl PARENT_TILE_BIT_COUNT) - 1L
         private const val NO_PARENT_TILE_BITS = 7L
         private const val NO_PARENT_TILE_VALUE = 14
-        // [RouteNode] bit 50 (1b = 2values) tracks if we can we can "move to" a tile.
+        // [RouteNode] bit 50 (1b = 2values) tracks if we can "move to" a tile.
         // Aka either we can path through it, or it contains an enemy.
         private const val MOVE_TO_OFFSET = PARENT_TILE_OFFSET + PARENT_TILE_BIT_COUNT
         private const val MOVE_TO_BIT_COUNT = 1
@@ -220,7 +219,6 @@ value class RouteNode(val bits: Long=0L) {
         private const val DAMAGE_TILES_BIT_COUNT = 2
         private const val DAMAGE_TILES_LO_MASK = (0x1L shl DAMAGE_TILES_BIT_COUNT) -1L
         internal const val MAX_DAMAGING_TILES = DAMAGE_TILES_LO_MASK.toInt()
-
 
         @Readonly
         private fun toParentClockDirBits(tile: Tile, parentTile: Tile): Long
@@ -306,7 +304,7 @@ value class FixedPointMovement private constructor(val bits: Int) {
 
         @Pure fun fpmFromFixedPointBits(bits: Int) = FixedPointMovement(bits)
         @Pure fun fpmFromMovement(move: Int) = FixedPointMovement((move * MOVE_SPEED_BASE))
-        @Pure fun fpmFromMovement(move: Float): FixedPointMovement { // rounding HALF_UP 
+        @Pure fun fpmFromMovement(move: Float): FixedPointMovement { // rounding HALF_UP
             val plusOneBit = (move * (MOVE_SPEED_BASE * 2)).toInt()
             return FixedPointMovement((plusOneBit shr 1) + (plusOneBit and 1))
         }
@@ -320,57 +318,50 @@ data class PathingMapCacheKey(
     val startingPoint: HexCoord,
     val moveRemaining: FixedPointMovement,
     val fullMove: FixedPointMovement,
-)
+) {
+    override fun toString() = "$startingPoint/$moveRemaining/$fullMove"
+}
 
+/**
+ *  @property key The key for this cache. If the key no longer matches, then the cache is invalid
+ *  @property nodesNeedingNeighbors Frontier list of the tiles to be checked.
+ *            In exceptional cases, a node already calculated may be left here, and recalculated again later.
+ *            Bitset used to minimize memory allocations
+ *  @property addedNeighborNodes A BitSet to track which tiles have already been checked.
+ *            This helps avoid redundant calculations and ensures each tile is processed only once.
+ *            Bitset used to minimize memory allocations
+ *  @property routeNodes A map where each tile reached during the search points to its parent tile.
+ *            This map is used to reconstruct the path once the destination is reached.
+ *            Theoretically, this can be replaced with three separate arrays for each field, eliminating
+ *            the separate allocations per-node, but it's unclear if the performance is worth the complexity.
+ */
 @InternalState
 internal class PathingMapCache private constructor(
-    /**
-     * The key for this cache. If the key no longer matches, then the cache is invalid
-     */
     internal val key: PathingMapCacheKey,
-
-    /**
-     * Frontier list of the tiles to be checked.
-     *
-     * In exceptional cases, a node already calculated may be left here, and recalculated again
-     * later.
-     *
-     * Bitset used to minimize memory allocations
-     */
     internal val nodesNeedingNeighbors: BitSet,
-    /**
-     * A BitSet to track which tiles have already been checked.
-     * This helps avoid redundant calculations and ensures each tile is processed only once.
-     *
-     * Bitset used to minimize memory allocations
-     */
     internal val addedNeighborNodes: BitSet,
-    /**
-     * A map where each tile reached during the search points to its parent tile.
-     * This map is used to reconstruct the path once the destination is reached.
-     *
-     * Theoretically, this can be replaced with three separate arrays for each field, eliminiating
-     * the separate allocations per-node, but it's unclear if the performance is worth the
-     * complexity.
-     */
     internal val routeNodes: LongArray,  // Actually Array<RouteNode>
 ) {
     internal val tilesSameTurn: PathsToTilesWithinTurn = PathsToTilesWithinTurn()
-        
+
+    /** Creates an empty [PathingMapCache], using [tileMap] only for allocating the arrays to the proper size */
     constructor(key: PathingMapCacheKey, tileMap: TileMap) : this(
         key,
         BitSet(tileMap.tileList.size),
         BitSet(tileMap.tileList.size),
         LongArray(tileMap.tileList.size)
     )
-    
+
+    @Readonly
     fun isCacheValid(latestKey: PathingMapCacheKey) = key == latestKey
-    
-    /*
+
+    /**
      * Returns a mutable fork for pathfinding
-     * 
-     * This uses the same routeNodes, but copies of the frontier bitsets. It does not set tilesSameTurn.
+     *
+     * This uses the same [routeNodes], but copies of the frontier bitsets. It does not set [tilesSameTurn].
+     * @see mergePathfindingFork
      */
+    @Readonly
     fun forkForPathfinding(): PathingMapCache {
         synchronized(addedNeighborNodes) {
             val codesNeedingNeighborsCopy: BitSet = nodesNeedingNeighbors.clone() as BitSet
@@ -378,9 +369,14 @@ internal class PathingMapCache private constructor(
             return PathingMapCache(key, codesNeedingNeighborsCopy, addedNeighborNodesCopy, routeNodes)
         }
     }
-    
+
+    /**
+     * Merges a fork created with [forkForPathfinding], modifying [addedNeighborNodes]
+     * and [nodesNeedingNeighbors]. Also mutates `update.nodesNeedingNeighbors`, meaning the fork
+     * should be discarded.
+     */
     fun mergePathfindingFork(update: PathingMapCache) {
-        require(key == update.key && routeNodes === routeNodes)
+        require(key == update.key && routeNodes === update.routeNodes)
         // now merge the pathfinder's tilesChecked and tilesToCheck back into the shared PathingData
         // again using a synchronized block not just for thread-safety, but also to ensure atomicity
         synchronized(addedNeighborNodes) {
@@ -390,7 +386,7 @@ internal class PathingMapCache private constructor(
             nodesNeedingNeighbors.andNot(update.addedNeighborNodes)
 
             // For tiles that were queued but not yet calculated, add them to nodesNeedingNeighbors.
-            // When a tile incurs taking damage, a later tile can replace it's data with a less
+            // When a tile incurs taking damage, a later tile can replace its data with a less
             // damaging route. In edge cases, this can cause a tile to be queued a second time.
             // Since tiles can be queued multiple times, they can be both queued (at higher damage)
             // and already calculated (at lower damage). We have to skip over tiles already calculated
@@ -414,7 +410,7 @@ internal class PathingMapCache private constructor(
         val width = tileMap.tileMatrix.size
         val xs = BitSet(width)
         val ys = BitSet(height)
-        routeTiles.forEach { 
+        routeTiles.forEach {
             xs.set(it.position.x - tileMap.leftX)
             ys.set(height -it.position.y + tileMap.bottomY) // invert the ys to easily iterate from positive to negative
         }
@@ -466,5 +462,5 @@ internal class PathingMapCache private constructor(
         }
     }
 
-    override fun toString() = "${javaClass.simpleName}[key=${key.startingPoint}/${key.moveRemaining}/${key.fullMove} nodesNeedingNeighbors=${nodesNeedingNeighbors.cardinality()} addedNeighborNodes=${addedNeighborNodes.cardinality()} routeNodes=${routeNodes.size} tilesSameTurn=${tilesSameTurn.size}"
+    override fun toString() = "${javaClass.simpleName}[key=$key nodesNeedingNeighbors=${nodesNeedingNeighbors.cardinality()} addedNeighborNodes=${addedNeighborNodes.cardinality()} routeNodes=${routeNodes.size} tilesSameTurn=${tilesSameTurn.size}]"
 }


### PR DESCRIPTION
Done while analyzing #15165 - pure comments, Kdoc usability and whitespace lint, except:
- Obvious oversight `routeNodes === routeNodes` which was always true
- Some missing debug string punctuation

@Ambeco:
- did I get the additional Kdoc right?
- Should `VERBOSE_PATHFINDING_LOGS` be modifiable in-game on the Debug page - or rather somehow be better documented how to use it meaningfully?