### PR TITLE
Fix inverted force-resign bank update

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -456,7 +456,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             val turnStart: Instant  = Instant.ofEpochMilli(currentTurnStartTime)
             val timeUsed = Duration.between(turnStart, Instant.now()).toMinutes().toInt()
             val timeRegained = if (shouldGainTime) gameParameters.minutesRecoveredPerTurn else 0
-            val rawNewTime = player.playerMinutesBeforeForceResign + timeUsed - timeRegained
+            val rawNewTime = player.playerMinutesBeforeForceResign - timeUsed + timeRegained
             val maxNewTime = gameParameters.minutesUntilForceResign
             player.playerMinutesBeforeForceResign = rawNewTime.coerceIn(0, maxNewTime)
     }


### PR DESCRIPTION
There is a [setting for how much time a player should recover](https://github.com/yairm210/Unciv/blob/d2374a85b0d00900b046d2ba9954f6f32914151c/core/src/com/unciv/models/metadata/GameParameters.kt#L62) when they end their turn, so they are less likely to be force-resigned.

The actual logic does the opposite: recover time is subtracted from the player's bank. As a result, players are punished for quick turns and rewarded for slow ones. Fast players risk being force-resigned, while slow players can take their time. I suggest reversing this so recover time is added and time spent is subtracted.

So when the current turn is longer than that player’s remaining bank, he [can be forced to resign](https://github.com/yairm210/Unciv/blob/d2374a85b0d00900b046d2ba9954f6f32914151c/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerScreen.kt#L447)

