### PR TITLE
Fix RekMod Moai can be built on water tiles with a resource

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -204,7 +204,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     @Readonly fun isCapital(): Boolean = cityConstructions.builtBuildingUniqueMap.hasUnique(UniqueType.IndicatesCapital, state)
     @Readonly fun isCoastal(): Boolean = centerTile.isAdjacentToCoast()
     @Readonly fun isNaval(): Boolean = centerTile.isWater || isCoastal()
-    
+
     @Readonly fun getBombardRange(): Int = civ.gameInfo.ruleset.modOptions.constants.baseCityBombardRange
     @Readonly fun getWorkRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityWorkRange
     @Readonly fun getExpandRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityExpandRange
@@ -218,7 +218,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         val mediumTypes = civ.cache.citiesConnectedToCapitalToMediums[this] ?: return false
         return connectionTypePredicate(mediumTypes)
     }
-    
+
     @Readonly
     fun getLandAttackPath(destination: City, maxTurns: Int = PathingMap.MAX_VALID_TURNS): List<Tile>? {
         @LocalState val pathingCache = landAttackPathing.getOrPut(destination.civ, {PathingMap.createLandAttackPathingMap(civ, centerTile, destination.civ)})

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -571,7 +571,7 @@ class Tile : IsPartOfGameInfoSerialization {
             "All", "all" -> return true
             "Water" -> return isWater
             "Land" -> return isLand
-            Constants.coastal -> return _isAdjacentToCoast
+            Constants.coastal -> return isAdjacentToCoast()
             Constants.river -> return isAdjacentToRiver()
             "Unowned" -> return getOwner() == null
             "your" -> return observingCiv != null && getOwner() == observingCiv
@@ -615,7 +615,7 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
 
-    @Readonly fun isAdjacentToCoast() = _isAdjacentToCoast
+    @Readonly fun isAdjacentToCoast() = isLand && _isAdjacentToCoast
 
     @Readonly fun getViewableTilesList(distance: Int): List<Tile> = tileMap.getViewableTiles(position, distance)
     @Deprecated(message = "forEachTileInDistance is faster. If not viable, then this can still be used",

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -424,7 +424,7 @@ class Tile : IsPartOfGameInfoSerialization {
         return civInfo.isAtWarWith(tileOwner)
     }
 
-    @Readonly fun isRoughTerrain() = allTerrains.any { it.isRough}
+    @Readonly fun isRoughTerrain() = allTerrains.any { it.isRough }
 
     @Transient
     internal var stateThisTile: GameContext = GameContext.EmptyState
@@ -591,10 +591,10 @@ class Tile : IsPartOfGameInfoSerialization {
             resource -> observingCiv == null || observingCiv.canSeeResource(tileResource)
 
             else -> {
-                val owner = getOwner()
                 if (allTerrains.any { it.matchesFilter(filter, stateThisTile, false) }) return true
-                if (owner != null && owner.matchesFilter(filter, stateThisTile, false)) return true
 
+                val owner = getOwner()
+                if (owner != null && owner.matchesFilter(filter, stateThisTile, false)) return true
 
                 // Checks 'luxury resource', 'strategic resource' and 'bonus resource' - only those that are visible of course
                 // not using canSeeResource as observingCiv is often not passed in,

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -581,7 +581,7 @@ class Tile : IsPartOfGameInfoSerialization {
             "resource" -> return observingCiv != null && observingCiv.canSeeResource(tileResource)
             "Water resource" -> return isWater && observingCiv != null && observingCiv.canSeeResource(tileResource)
             "Featureless" -> return terrainFeatures.isEmpty()
-            "Open terrain" -> return allTerrains.all { !it.isRough} // special case - if *one* terrain is open, we don't care, we need *all*
+            "Open terrain" -> return allTerrains.all { !it.isRough } // special case - if *one* terrain is open, we don't care, we need *all*
             Constants.freshWaterFilter ->
                 return isAdjacentTo(Constants.freshWater, observingCiv)
         }

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.managers.ImprovementFunctions
 import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.models.ruleset.tile.TerrainType
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
@@ -146,10 +147,34 @@ class TileImprovementFunctions(val tile: Tile) {
                     && tile.isAdjacentTo(Constants.freshWater) -> true
 
             // I don't particularly like this check, but it is required to build mines on non-hill resources
-            resourceIsVisible && tile.tileResource!!.isImprovedBy(improvement.name) -> true
+            resourceIsVisible && tile.tileResource!!.isImprovedBy(improvement.name)
+                && extendedDomainCheck(improvement) -> true
             // No reason this improvement should be built here, so can't build it
             else -> false
         }
+    }
+
+    /** Helper for the "build mines on non-hill resources" branch above:
+     *  Verifies not to allow land improvements on water and vice versa.
+     */
+    @Readonly
+    private fun extendedDomainCheck(improvement: TileImprovement): Boolean {
+        // Don't check when there's no terrain and CanOnlyImproveResource is the only reason allowing the improvement
+        if (improvement.terrainsCanBeBuiltOn.isEmpty()) return true
+        // Resolve all terrainsCanBeBuiltOn entries to a TerrainType, using `occursOn` for TerrainFeatures
+        val allowedTypes = mutableSetOf<TerrainType>()
+        for (canBuildOn in improvement.terrainsCanBeBuiltOn) {
+            val type = TerrainType.entries.firstOrNull { it.name == canBuildOn }
+            if (type != null) allowedTypes += type
+            val terrain = tile.ruleset.terrains[canBuildOn] ?: continue
+            allowedTypes += terrain.type
+            for (occursOn in terrain.occursOn) {
+                val baseTerrain = tile.ruleset.terrains[occursOn] ?: continue
+                allowedTypes += baseTerrain.type
+            }
+        }
+        return tile.isLand && TerrainType.Land in allowedTypes ||
+            tile.isWater && TerrainType.Water in allowedTypes
     }
 
     fun setImprovement(

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -13,6 +13,7 @@ import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stats
+import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.LocalState
 import yairm210.purity.annotations.Readonly
 
@@ -158,7 +159,8 @@ class TileImprovementFunctions(val tile: Tile) {
      *  Verifies not to allow land improvements on water and vice versa.
      */
     @Readonly
-    private fun extendedDomainCheck(improvement: TileImprovement): Boolean {
+    @VisibleForTesting
+    fun extendedDomainCheck(improvement: TileImprovement): Boolean {
         // Don't check when there's no terrain and CanOnlyImproveResource is the only reason allowing the improvement
         if (improvement.terrainsCanBeBuiltOn.isEmpty()) return true
         // Resolve all terrainsCanBeBuiltOn entries to a TerrainType, using `occursOn` for TerrainFeatures

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -199,7 +199,7 @@ class Terrain : RulesetStatsObject() {
             "Rough terrain" -> isRough
             "Natural Wonder" -> type == TerrainType.NaturalWonder
             "Terrain Feature" -> type == TerrainType.TerrainFeature
-            else -> when(filter){ // non-constants
+            else -> when(filter) { // non-constants
                 name -> true
                 type.name -> true
                 else -> false

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -195,6 +195,7 @@ class Terrain : RulesetStatsObject() {
         return when (filter) {
             "all", "All" -> true
             "Terrain" -> true
+            Constants.impassable -> impassable
             "Open terrain" -> !isRough
             "Rough terrain" -> isRough
             "Natural Wonder" -> type == TerrainType.NaturalWonder

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -320,7 +320,7 @@ enum class UniqueParameterType(
             Constants.coastal, Constants.river, "Open terrain", "Rough terrain", "Water resource",
             "resource", "Foreign Land", "Foreign", "Friendly Land", "Friendly", "Enemy Land", "Enemy", "your", "Unowned",
             "Featureless", Constants.freshWaterFilter, "non-fresh water", "Natural Wonder",
-            "Impassable", "Land", "Water"
+            Constants.impassable, "Land", "Water"
         ) + ResourceType.entries.map { it.name + " resource" } + Constants.all
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = getErrorSeverityForFilter(parameterText, ruleset)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -319,7 +319,7 @@ enum class UniqueParameterType(
             "Terrain",
             Constants.coastal, Constants.river, "Open terrain", "Rough terrain", "Water resource",
             "resource", "Foreign Land", "Foreign", "Friendly Land", "Friendly", "Enemy Land", "Enemy", "your", "Unowned",
-            "Featureless", Constants.freshWaterFilter, "non-fresh water", "Natural Wonder",
+            "Terrain Feature", "Featureless", Constants.freshWaterFilter, "non-fresh water", "Natural Wonder",
             Constants.impassable, "Land", "Water"
         ) + ResourceType.entries.map { it.name + " resource" } + Constants.all
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -654,7 +654,11 @@ enum class UniqueType(
 
     FreshWater(Constants.freshWater, UniqueTarget.Terrain),
     RoughTerrain("Rough terrain", UniqueTarget.Terrain),
-    CoastalWater("Coastal Water", UniqueTarget.Terrain),
+    CoastalWater("Coastal Water", UniqueTarget.Terrain, docDescription =
+        "Marks water tiles as Coast - all other water tiles count as Ocean. These distinctions are relevant e.g. for map generator or the ability to navigate here.\n" +
+        "Note that terrain filters do not recognize this distinction, filtering for \"Coast\" or \"Ocean\" will only look for a terrain of that name.\n" +
+        "Also note that for compatibility reasons, terrains named \"Coast\" are assuned to have this Unique even if it's missing. This may be removed in a future version.\n" +
+        "A tile marked this way marks adjacent land tiles as \"Coastal\", so they fulfill the terrain filter, and cities built there can build ships, Harbor, etc."),
 
     ExcludedFromMapEditor("Excluded from map editor", UniqueTarget.Terrain, UniqueTarget.Improvement, UniqueTarget.Resource, UniqueTarget.Nation, flags = UniqueFlag.setOfHiddenToUsers),
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -312,28 +312,27 @@ Allowed values:
     - A [nationFilter](#nationfilter) matching the tile owner
 - Or the filter is a constant string choosing a derived test:
     - `All`, `all`
-    - `Terrain`
+    - `Terrain` (same as "all" in this context, can help making uniques more readable)
     - `Water`, `Land`
-    - `Coastal` (at least one direct neighbor is a coast)
+    - `Coastal` (_Land_ with least one direct neighbor being a coast - see ["Coastal Water"](uniques.md#terrain-uniques) unique)
     - `River` (as in all 'river on tile' contexts, it means 'adjacent to a river on at least one side')
-    - `Open terrain`, `Rough terrain` (note all terrain not having the rough unique is counted as open)
-    - `Friendly Land`, `Friendly` - land belonging to you, or other civs with open borders to you
-    - `Foreign Land` - any land that isn't friendly land
-    - `Enemy Land`, `Enemy` - any land belonging to a civ you are at war with
-    - `your` - land belonging to you
-    - `Unowned` - land that is not owned by any civ
+    - `Open terrain`, `Rough terrain` (note all terrain not having the ["Rough terrain"](uniques.md#terrain-uniques) unique is counted as open)
     - `Water resource`, `Strategic resource`, `Luxury resource`, `Bonus resource`, `resource`
     - `Natural Wonder` (as opposed to above which means testing for a specific Natural Wonder by name, this tests for any of them)
-    - `Featureless`
-    - `Fresh Water`
+    - `Terrain Feature` (having any terrain feature)
+    - `Featureless` (having no terrain feature)
+    - `Fresh Water` ("River" filter, or adjacent to a tile with the "Fresh water" unique, like Oasis. Note the important case distinction: with "w" the filter will match the Oasis by matching the Unique, with "W" it will not match the Oasis but its neighboring tiles)
     - `non-fresh water`
-    - `Impassible`
+    - `Impassable`
+    - `Friendly Land`, `Friendly` - terrain (despite the name this includes water tiles) belonging to you, or other civs with open borders to you
+    - `Foreign Land` - any terrain that isn't friendly terrain
+    - `Enemy Land`, `Enemy` - any terrain belonging to a civ you are at war with
+    - `your` - terrain belonging to you
+    - `Unowned` - terrain that is not owned by any civ
 
 Please note all of these are _case-sensitive_.
 
 Note: Resource filters depend on whether a viewing civ is known in the context where the filter runs. Water and specific tests require a viewing civ, and if the resource needs a tech to be visible, that tech to be researched by the viewing civ. The other resource category tests can succeed without a known viewing civ only for resources not requiring any tech. So - test your mod!
-
-So for instance, the unique "[stats] from [tileFilter] tiles [cityFilter]" can match several cases:
 
 ## tileFilter
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2807,6 +2807,14 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Terrain
 
 ??? example  "Coastal Water"
+	Marks water tiles as Coast - all other water tiles count as Ocean. These distinctions are relevant e.g. for map generator or the ability to navigate here.
+
+	Note that terrain filters do not recognize this distinction, filtering for "Coast" or "Ocean" will only look for a terrain of that name.
+
+	Also note that for compatibility reasons, terrains named "Coast" are assuned to have this Unique even if it's missing. This may be removed in a future version.
+
+	A tile marked this way marks adjacent land tiles as "Coastal", so they fulfill the terrain filter, and cities built there can build ships, Harbor, etc.
+
 	Applicable to: Terrain
 
 ??? example  "Excluded from map editor"

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -1,17 +1,23 @@
 //  Taken from https://github.com/TomGrill/gdx-testing
 package com.unciv.logic.map
 
+import com.unciv.Constants
 import com.unciv.logic.city.City
 import com.unciv.logic.city.City.Companion.NO_ID
 import com.unciv.logic.city.City.Companion.pseudoRandomId
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.RoadStatus
+import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.tile.TerrainType
+import com.unciv.models.ruleset.tile.TileImprovement
+import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stats
 import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestCase
 import com.unciv.testing.TestGame
+import com.unciv.testing.runTestParcours
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -72,26 +78,58 @@ class TileImprovementConstructionTests {
 
     @Test
     fun allResourceImprovementsCanBeBuilt() {
+        testResourceImprovements("Improvements improving a resource can be built on that resource as long as the domain matches -", wrongDomain = false)
+    }
 
-        for (improvement in testGame.ruleset.tileImprovements.values) {
-            val tile = tileMap[1,1]
-            tile.tileResource = testGame.ruleset.tileResources.values
-                .firstOrNull { it.isImprovedBy(improvement.name) }
-            if (tile.tileResource == null) continue
-            // If this improvement requires additional conditions to be true,
-            // its too complex to handle all of them, so just skip it and hope its fine
-            if (improvement.hasUnique(UniqueType.CanOnlyBeBuiltOnTile, GameContext.IgnoreConditionals)) continue
+    @Test
+    fun resourceImprovementsOnWrongDomainCannotBeBuilt() {
+        testResourceImprovements("Improvements improving a resource cannot be built on that resource when the domain does not match -", wrongDomain = true)
+    }
 
+    private fun testResourceImprovements(title: String, wrongDomain: Boolean) {
+        val landTile = tileMap[1,1]
+        val coastTile = tileMap[1,2]
+        coastTile.baseTerrain = Constants.coast
+        coastTile.setTransients()
+        coastTile.setOwningCity(city) // Yes ownership is tested
+
+        val items: Array<TestCase<Pair<TileImprovement, TileResource>, Boolean>> =
+            testGame.ruleset.tileImprovements.values
+            .flatMap { improvement ->
+                // Test all combinations - e.g. both Oil well and Offshore Platform for Oil
+                testGame.ruleset.tileResources.values
+                    .filter { it.isImprovedBy(improvement.name) }
+                    .map { improvement to it }
+            }
+            .map { TestCase(it, !wrongDomain) }
+            .toTypedArray()
+
+        fun testImprovement(improvement: TileImprovement, tileResource: TileResource, tile: Tile): Boolean {
+            tile.tileResource = tileResource
             tile.setTransients()
-            val canBeBuilt = tile.improvementFunctions.canBuildImprovement(improvement, civInfo.state)
-            Assert.assertTrue(improvement.name, canBeBuilt)
+            return tile.improvementFunctions.canBuildImprovement(improvement, civInfo.state)
         }
+        fun testImprovement(improvement: TileImprovement, tileResource: TileResource): Boolean {
+            // This relies on our builtin rulesets not using more complex filter in these uniques
+            val landOK = landTile.improvementFunctions.extendedDomainCheck(improvement) &&
+                improvement.getMatchingUniques(UniqueType.CanOnlyBeBuiltOnTile).all { it.params[0] == "Land" } &&
+                improvement.getMatchingUniques(UniqueType.CannotBuildOnTile).none { it.params[0] == "Land" }
+            val coastOK = coastTile.improvementFunctions.extendedDomainCheck(improvement) &&
+                improvement.getMatchingUniques(UniqueType.CanOnlyBeBuiltOnTile).all { it.params[0] == "Water" } &&
+                improvement.getMatchingUniques(UniqueType.CannotBuildOnTile).none { it.params[0] == "Water" }
+            if (wrongDomain && landOK && coastOK) return false // Can't test wrong domain as the improvement has CanOnlyImproveResource which always ignores domain
+            if (landOK != wrongDomain && !testImprovement(improvement, tileResource, landTile)) return false
+            if (coastOK != wrongDomain && !testImprovement(improvement, tileResource, coastTile)) return false
+            return true
+        }
+
+        runTestParcours(title, *items) { testImprovement(it.first, it.second) }
     }
 
     @Test
     fun coastalImprovementsCanBeBuilt() {
         val coastTile = tileMap[1,2]
-        coastTile.baseTerrain = "Coast"
+        coastTile.baseTerrain = Constants.coast
         coastTile.setTransients()
 
         val coastalTile = tileMap[1,1]


### PR DESCRIPTION
My take on #15171.

One _could_ offload the burden on the modders, but from the RekMod json Moai definition I find it absolutely unintuitive. It says Moai must be built on Land, but then the "Improves [Bonus] resource in this tile" trumps it? 🤷 

Note: I noticed the "Friendly Land" filter will apply to Water contradicting its name, and one or two related ones. Not treated here.