### PR TITLE
Fix uniques for losing hp missing full combat context

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -371,10 +371,11 @@ object Battle {
     }
 
     internal fun takeDamage(attacker: ICombatant, defender: ICombatant): DamageDealt {
-        val attackContext = GameContext(attacker, defender, defender.getTile(), CombatAction.Attack)
+        val attackerContext = GameContext(attacker, defender, defender.getTile(), CombatAction.Attack)
+        val defenderContext = GameContext(defender, attacker, defender.getTile(), CombatAction.Defend)
         var potentialDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender)
         var potentialDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender)
-        val rng = attackContext.stateBasedRandom("Battle.takeDamage")
+        val rng = attackerContext.stateBasedRandom("Battle.takeDamage")
 
         val attackerHealthBefore = attacker.getHealth()
         val defenderHealthBefore = defender.getHealth()
@@ -403,26 +404,60 @@ object Battle {
         val defenderDamageDealt = attackerHealthBefore - attacker.getHealth()
         val attackerDamageDealt = defenderHealthBefore - defender.getHealth()
 
-        if (attacker is MapUnitCombatant)
-            for (unique in attacker.unit.getTriggeredUniques(UniqueType.TriggerUponLosingHealth)
-                    { it.params[0].toInt() <= defenderDamageDealt }) {
-                val unit = if (unique.params[0] == Constants.targetUnit && defender is MapUnitCombatant)
-                    defender.unit
-                else attacker.unit
-                UniqueTriggerActivation.triggerUnique(unique, unit, triggerNotificationText = "due to losing [$defenderDamageDealt] HP")
-            }
-
-        if (defender is MapUnitCombatant)
-            for (unique in defender.unit.getTriggeredUniques(UniqueType.TriggerUponLosingHealth)
-                    { it.params[0].toInt() <= attackerDamageDealt }) {
-                val unit = if (unique.params[0] == Constants.targetUnit && attacker is MapUnitCombatant)
-                attacker.unit
-                else defender.unit
-                UniqueTriggerActivation.triggerUnique(unique, unit, triggerNotificationText = "due to losing [$attackerDamageDealt] HP")
-            }
+        triggerLosingHPUniques(attacker, attackerContext, attackerDamageDealt, defender, defenderContext, defenderDamageDealt)
 
         plunderFromDamage(attacker, defender, attackerDamageDealt)
         return DamageDealt(attackerDamageDealt, defenderDamageDealt)
+    }
+
+    private fun triggerLosingHPUniques(
+        attacker: ICombatant,
+        attackerContext: GameContext,
+        attackerDamageDealt: Int,
+        defender: ICombatant,
+        defenderContext: GameContext,
+        defenderDamageDealt: Int
+    ) {
+        fun triggerUnique(
+            combatant: ICombatant,
+            unique: Unique,
+            action: CombatAction
+        ) {
+            val triggerText =
+                if (action == CombatAction.Attack) "due to losing [$defenderDamageDealt] HP"
+                else "due to losing [$attackerDamageDealt] HP"
+            when (combatant) {
+                is MapUnitCombatant -> UniqueTriggerActivation.triggerUnique(
+                    unique,
+                    combatant.unit,
+                    triggerNotificationText = triggerText
+                )
+
+                is CityCombatant -> UniqueTriggerActivation.triggerUnique(
+                    unique,
+                    combatant.city,
+                    triggerNotificationText = triggerText
+                )
+            }
+        }
+
+        for (unique in attacker.getTriggeredUniques(
+            UniqueType.TriggerUponLosingHealth,
+            attackerContext
+        )
+        { it.params[0].toInt() <= defenderDamageDealt }) {
+            val combatant = if (unique.params[0] == Constants.targetUnit) defender else attacker
+            triggerUnique(combatant, unique, CombatAction.Attack)
+        }
+
+        for (unique in defender.getTriggeredUniques(
+            UniqueType.TriggerUponLosingHealth,
+            defenderContext
+        )
+        { it.params[0].toInt() <= attackerDamageDealt }) {
+            val combatant = if (unique.params[0] == Constants.targetUnit) attacker else defender
+            triggerUnique(combatant, unique, CombatAction.Defend)
+        }
     }
 
     private fun plunderFromDamage(

--- a/core/src/com/unciv/logic/battle/CityCombatant.kt
+++ b/core/src/com/unciv/logic/battle/CityCombatant.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.unique.GameContext
+import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.ui.components.extensions.toPercent

--- a/core/src/com/unciv/logic/battle/CityCombatant.kt
+++ b/core/src/com/unciv/logic/battle/CityCombatant.kt
@@ -76,6 +76,7 @@ class CityCombatant(val city: City) : ICombatant {
         return strength.roundToInt()
     }
 
+    @Readonly
     override fun getTriggeredUniques(
         trigger: UniqueType,
         gameContext: GameContext,

--- a/core/src/com/unciv/logic/battle/CityCombatant.kt
+++ b/core/src/com/unciv/logic/battle/CityCombatant.kt
@@ -76,5 +76,13 @@ class CityCombatant(val city: City) : ICombatant {
         return strength.roundToInt()
     }
 
+    override fun getTriggeredUniques(
+        trigger: UniqueType,
+        gameContext: GameContext,
+        triggerFilter: (Unique) -> Boolean
+    ): Sequence<Unique> {
+        return city.getTriggeredUniques(trigger, gameContext, triggerFilter)
+    }
+
     override fun toString() = city.name // for debug
 }

--- a/core/src/com/unciv/logic/battle/ICombatant.kt
+++ b/core/src/com/unciv/logic/battle/ICombatant.kt
@@ -3,6 +3,9 @@ package com.unciv.logic.battle
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UncivSound
+import com.unciv.models.ruleset.unique.GameContext
+import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.UnitType
 import yairm210.purity.annotations.Readonly
 

--- a/core/src/com/unciv/logic/battle/ICombatant.kt
+++ b/core/src/com/unciv/logic/battle/ICombatant.kt
@@ -47,6 +47,12 @@ interface ICombatant {
     }
     @Readonly fun isCity(): Boolean = this is CityCombatant
     @Readonly fun isCivilian() = this is MapUnitCombatant && this.unit.isCivilian()
+    
+    @Readonly fun getTriggeredUniques(
+        trigger: UniqueType,
+        gameContext: GameContext,
+        triggerFilter: (Unique) -> Boolean = { true }
+    ): Sequence<Unique>
 
     fun getNotificationDisplay(leadingText: String = ""): String = ""
 }

--- a/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
+++ b/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
@@ -65,15 +65,23 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
     fun getMatchingUniques(uniqueType: UniqueType, gameContext: GameContext, checkCivUniques: Boolean): Sequence<Unique> =
         unit.getMatchingUniques(uniqueType, gameContext, checkCivUniques)
 
+    override fun getTriggeredUniques(
+        trigger: UniqueType,
+        gameContext: GameContext,
+        triggerFilter: (Unique) -> Boolean
+    ): Sequence<Unique> {
+        return unit.getTriggeredUniques(trigger, gameContext, triggerFilter)
+    }
+
     @Readonly
     fun hasUnique(uniqueType: UniqueType, conditionalState: GameContext? = null): Boolean =
         if (conditionalState == null) unit.hasUnique(uniqueType)
         else unit.hasUnique(uniqueType, conditionalState)
     
-    @Readonly
+/*    @Readonly
     override fun hashCode() = unit.hashCode()
     @Readonly
     override fun equals(other: Any?) = other is MapUnitCombatant && other.unit == unit
-
+*/
 
 }

--- a/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
+++ b/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
@@ -65,6 +65,7 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
     fun getMatchingUniques(uniqueType: UniqueType, gameContext: GameContext, checkCivUniques: Boolean): Sequence<Unique> =
         unit.getMatchingUniques(uniqueType, gameContext, checkCivUniques)
 
+    @Readonly
     override fun getTriggeredUniques(
         trigger: UniqueType,
         gameContext: GameContext,
@@ -78,10 +79,10 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
         if (conditionalState == null) unit.hasUnique(uniqueType)
         else unit.hasUnique(uniqueType, conditionalState)
     
-/*    @Readonly
+    @Readonly
     override fun hashCode() = unit.hashCode()
     @Readonly
     override fun equals(other: Any?) = other is MapUnitCombatant && other.unit == unit
-*/
+
 
 }


### PR DESCRIPTION
Closes #15054

See #15054 for primary discussion. Current uniques uses the default context for ``unit.getTriggeredUniques`` which is only ``unit.state`` as opposed to the full combat context

----------------
The changes to ICombantant are a plant for a future PR. Currently, many uniques such as this only fundamentally does not need the restriction to only be usable on units. More importantly, currently, there are some major unintuitiveness regarding "this unit" and "target unit" as it is currently designed. Previously, this unique could in fact trigger when attacking a city, but when doing so, it would treat "target unit" as "this unit", which is extremely unintuitive and would require a ``<vs [Non-city] units>``. And if they need the conditional regardless, there's no point in the weird definition. Yes, you could restrict things to only triggering when the attacker and the defender is a mapUnit, but again, I'm not really convinced that such a restriction really makes sense


(Funny note: ``vs [units]`` doesn't work. Maybe it should. And ``<vs [all] units>`` actually still include cities when it shouldn't)