### PR TITLE
[Lint] specify return type for automation functions

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -22,7 +22,7 @@ object CivilianUnitAutomation {
         && !unit.hasUnique(UniqueType.AddInCapital)
         && unit.civ.units.getCivUnits().any { it.hasUnique(UniqueType.AddInCapital) }
 
-    fun automateCivilianUnit(unit: MapUnit, dangerousTiles: HashSet<Tile>) = timeThis<Unit>("automateCivilianUnit") {
+    fun automateCivilianUnit(unit: MapUnit, dangerousTiles: HashSet<Tile>): Unit = timeThis("automateCivilianUnit") {
         // To allow "found city" actions that can only trigger a limited number of times
         
         // Slightly modified getUsableUnitActionUniques() to allow for settlers with *conditional* settling uniques

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -75,7 +75,7 @@ class WorkerAutomation(
     /**
      * Automate one Worker - decide what to do and where, move, start or continue work.
      */
-    fun automateWorkerAction(unit: MapUnit, dangerousTiles: HashSet<Tile>) = timeThis<Unit>("automateWorkerAction") {
+    fun automateWorkerAction(unit: MapUnit, dangerousTiles: HashSet<Tile>): Unit = timeThis("automateWorkerAction") {
         val currentTile = unit.getTile()
         val currentTileIsCreatesOneImprovementMarker = currentTile.isMarkedForCreatesOneImprovement()
         // Must be called before any getPriority checks to guarantee the local road cache is processed


### PR DESCRIPTION
Another Return in function without an explicit type. No, the type of the generic in ``timeThis`` doesn't count. Actually, the codebase is usually good about actually specifying it elsewhere, as I think these are the only cases of it causing this problem. Just had these 2 slip through the cracks

~~Tbh, I don't really like that ``timeThis`` is ran in effectively in the release version and isn't just a debug feature. But since I'm assuming this is pretty minor on performance, I'm not going to say anything about it~~