### PR TITLE
Turn combatant classes into inline classes

### DIFF
--- a/core/src/com/unciv/logic/battle/CityCombatant.kt
+++ b/core/src/com/unciv/logic/battle/CityCombatant.kt
@@ -14,7 +14,8 @@ import yairm210.purity.annotations.Readonly
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
-class CityCombatant(val city: City) : ICombatant {
+@JvmInline
+value class CityCombatant(val city: City) : ICombatant {
     override fun getMaxHealth(): Int {
         return city.getMaxHealth()
     }

--- a/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
+++ b/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
@@ -10,7 +10,8 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.UnitType
 import yairm210.purity.annotations.Readonly
 
-class MapUnitCombatant(val unit: MapUnit) : ICombatant {
+@JvmInline
+value class MapUnitCombatant(val unit: MapUnit) : ICombatant {
     override fun getHealth(): Int = unit.health
     override fun getMaxHealth() = 100
     override fun getCivInfo(): Civilization = unit.civ
@@ -69,11 +70,5 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
     fun hasUnique(uniqueType: UniqueType, conditionalState: GameContext? = null): Boolean =
         if (conditionalState == null) unit.hasUnique(uniqueType)
         else unit.hasUnique(uniqueType, conditionalState)
-    
-    @Readonly
-    override fun hashCode() = unit.hashCode()
-    @Readonly
-    override fun equals(other: Any?) = other is MapUnitCombatant && other.unit == unit
-
 
 }


### PR DESCRIPTION
Currently, we constantly end up constructing new combatant objects any time we refer to a unit or a city as a combatant. This typically doesn't make much sense. The two combatant classes aren't really full classes as much as they are wrappers for functionally. The ideal thing is likely to instead cache the combatant object with their respective unit or city instead or else just map MapUnit and City directly inherit ICombatant


Or...

We can make the combatant types into inline classes. We more or less meet all the criteria for value classes anyways. These are logic only classes, the only override of ``equals`` and ``hashcode`` are exactly the same as how Kotlin defines them, and these classes derive almost everything from the singular value we pass into the constructor. This seems like an obvious improvement in my eyes.......... Except that we almost always pass stuff into stuff that wants an ICombatant, which forces boxing of the value type. Oh well. I'm pretty sure this is still inherently an improvement and therefore still worth doing regardless, but the other ideas of just caching the potential boxed version or having the underlying type just directly inheriting ICombatant is probably more impactful