### PR TITLE
Update docker workflow-action versions

### DIFF
--- a/.github/workflows/dockerPublish.yml
+++ b/.github/workflows/dockerPublish.yml
@@ -40,13 +40,13 @@ jobs:
 
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6.2
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/dockerPublish.yml
+++ b/.github/workflows/dockerPublish.yml
@@ -56,7 +56,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6.2
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -64,7 +64,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Might fix the latest docker workflow failures??

Other workflows might be affected soon - I see:
- actions/stale@v9 flagged for the stale issue thing
- eps1lon/actions-label-merge-conflict@releases/2.x. for Conflict marking
- peter-murray/setup-detekt@v3 for detekt

... logged as being tied to node.js 20.