### PR TITLE
Prettify the city-state diplomacy page when a CS has _many_ protectors

### DIFF
--- a/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
@@ -147,7 +147,10 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
                     newProtectors.add(protector.civName.tr())
             }
             val protectorString = "{Protected by}: " + newProtectors.joinToString(", ")
-            diplomacyTable.add(protectorString.toLabel()).row()
+            diplomacyTable.add(protectorString.toLabel().apply {
+                wrap = true
+                setAlignment(Align.center)
+            }).width(diplomacyScreen.rightSideLabelWidth()).row()
         }
 
         val atWar = otherCiv.isAtWarWith(viewingCiv)

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -73,12 +73,13 @@ class DiplomacyScreen(
         background = skinStrings.getUiBackground("DiplomacyScreen/RightSide", tintColor = highlightColor)
     }
 
+    private val splitPane = SplitPaneCenteringLeftSide()
+
     private val closeButton = getCloseButton(closeButtonSize) { game.popScreen() }
 
     internal fun isNotPlayersTurn() = !GUI.isAllowedChangeState()
 
     init {
-        val splitPane = SplitPaneCenteringLeftSide()
         // In cramped conditions, start the left side with enough width for nation icon and padding, but allow it to get squeezed until just the icon fits.
         // (and SplitPane will squeeze even beyond the minWidth our left side supplies - when the right side has a conflicting minWidth, then both get squeezed).
         splitPane.splitAmount = 0.2f.coerceAtLeast(leftSideScroll.prefWidth / stage.width)
@@ -400,7 +401,15 @@ class DiplomacyScreen(
      *  _Caller is responsible to not exceed this **including its own padding**_
      */
     // Note breaking the rule above will squeeze the leftSideScroll to the left - cumulatively.
-    internal fun getTradeColumnsWidth() = (stage.width * 0.8f - 3f) / 2  // 3 for SplitPane handle
+    internal fun getTradeColumnsWidth() = rightSideWidth() / 2
+
+    /** Recommended Cell width for wrappable Labels spanning the right side, e.g. city-state protectors */
+    internal fun rightSideLabelWidth() = rightSideWidth() - 40f
+
+    private fun rightSideWidth(): Float {
+        splitPane.validate() // Ensure rightSideTable is sized
+        return rightSideTable.width
+    }
 
     override fun resize(width: Int, height: Int) {
         super.resize(width, height)


### PR DESCRIPTION
<details><summary>screamshots</summary>

##Before
<img width="903" height="478" alt="image" src="https://github.com/user-attachments/assets/bc87157f-c26a-4122-b0b2-66299ef689a0" />

##After
<img width="903" height="478" alt="image" src="https://github.com/user-attachments/assets/0d96164c-0a40-4238-a811-24dd84d87914" />

No, really, I just ordered a huge world with 3-max random number of civs, and somehow everybody was ultra friendly, except the rednex of course. That long example evolved, it wasn't faked.

</details>