### PR TITLE
Politics overview "Ball of Yarn" makeover

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
@@ -1,15 +1,17 @@
 package com.unciv.ui.screens.overviewscreen
 
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.Touchable
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
+import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.diplomacy.DiplomacyManager
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
@@ -17,12 +19,16 @@ import com.unciv.logic.map.HexMath
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.extensions.getContrastRatio
+import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.input.ClickableCircle
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.ShadowedLabel
+import com.unciv.ui.images.IconCircleGroup
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.AnimatedMenuPopup
+import com.unciv.ui.screens.basescreen.BaseScreen
+import kotlin.collections.set
 
 /** This is the 'spider net'-like polygon showing one line per civ-civ relation
  *  @param undefeatedCivs Civs to display - note the viewing player is always included, so it's possible the name is off and there's a dead civ included.
@@ -32,11 +38,197 @@ class GlobalPoliticsDiagramGroup(
     undefeatedCivs: List<Civilization>,
     freeSize: Float
 ): Group() {
+    @Suppress("ConstPropertyName")
+    companion object {
+        const val iconSize = 30f
+        const val iconCircleSize = 42f
+        const val selectedIconCircleAlpha = .5f
+        const val deselectedIconAlpha = .5f
+        const val lineWidth = 2f
+        const val legendLineWidth = 3f  // a little thicker than the actual diagram
+        const val legendLowContrastWidth = 4f
+        const val legendLineLength = 120f
+    }
+
+    /** Wrapper around [RelationshipLevel], adding War, DefensivePact, and a Z-Order property */
+    private sealed class Relation {
+        abstract val ordinal: Int
+        abstract val label: String
+        abstract val color: Color
+        abstract val zOrder: Int
+
+        object War : Relation() {
+            override val ordinal = 0
+            override val label = "War"
+            override val color: Color = Color.RED
+            override val zOrder = 100
+        }
+        private class Wrapped(level: RelationshipLevel) : Relation() {
+            override val ordinal = level.ordinal + 1
+            override val label = level.name
+            override val color: Color = level.color
+            override val zOrder = getZOrder(level)
+        }
+        object DefensivePact : Relation() {
+            override val ordinal = 99
+            override val label = Constants.defensivePact
+            override val color: Color = Color.PURPLE
+            override val zOrder = 99
+        }
+
+        companion object {
+            private val relationshipLevels: Array<Relation> = RelationshipLevel.entries.map { Wrapped(it) }.toTypedArray()
+
+            operator fun get(level: RelationshipLevel) = relationshipLevels[level.ordinal]
+
+            val entries = listOf(
+                War,
+                *relationshipLevels,
+                DefensivePact,
+            )
+
+            private fun getZOrder(level: RelationshipLevel) = when(level) {
+                RelationshipLevel.Unforgivable -> 7
+                RelationshipLevel.Enemy -> 5
+                RelationshipLevel.Afraid -> 4
+                RelationshipLevel.Competitor -> 2
+                RelationshipLevel.Neutral -> 0
+                RelationshipLevel.Favorable -> 1
+                RelationshipLevel.Friend -> 3
+                RelationshipLevel.Ally -> 6
+            }
+        }
+
+        // These are for cleaner Set support - would likely work without
+        override fun hashCode() = ordinal.hashCode()
+        override fun equals(other: Any?) = other is Relation && ordinal == other.ordinal
+    }
+
+    /** Wrapper for either civ Nation Portrait (with selection circle) or a relationship line */
+    private sealed class WidgetEntry {
+        abstract val widget: Actor
+        abstract val zOrder: Int
+        abstract fun isRelationSelected(selection: Set<Relation>): Boolean
+        abstract fun isCivSelected(selection: Set<Civilization>): Boolean
+        abstract fun setSelected(selected: Boolean)
+        fun setSelected(selectedCivs: Set<Civilization>, selectedRelations: Set<Relation>) =
+            setSelected(isCivSelected(selectedCivs) && isRelationSelected(selectedRelations))
+
+        class Icon(val icon: IconCircleGroup, val civ: Civilization) : WidgetEntry() {
+            override val widget get() = icon
+            override val zOrder = 200
+            override fun isRelationSelected(selection: Set<Relation>) = true
+            override fun isCivSelected(selection: Set<Civilization>) = civ in selection
+            override fun setSelected(selected: Boolean) {
+                icon.circle.color.a = if (selected) selectedIconCircleAlpha else 0f
+                icon.actor.color.a = if (selected) 1f else deselectedIconAlpha
+            }
+            val x get() = widget.x + widget.width / 2
+            val y get() = widget.y + widget.height / 2
+        }
+
+        class Line(val line: Image, val relation: Relation, val civ1: Civilization, val civ2: Civilization) : WidgetEntry() {
+            override val widget get() = line
+            override val zOrder = relation.zOrder
+            override fun isRelationSelected(selection: Set<Relation>) = relation in selection
+            override fun isCivSelected(selection: Set<Civilization>) = civ1 in selection && civ2 in selection
+            override fun setSelected(selected: Boolean) {
+                widget.isVisible = selected
+            }
+        }
+    }
+
+    private class WidgetIndex(
+        undefeatedCivs: List<Civilization>,
+        freeSize: Float,
+        val toggleSelection: (Civilization) -> Unit
+    ) {
+        // Not used after init, kept as property for convenience
+        val civCount = undefeatedCivs.size
+        /** Nation Portraits */
+        val civWidgets = LinkedHashMap<Civilization, WidgetEntry.Icon>(civCount)
+        /** Tracks which civ have any lines. Dead _and_ isolated civs should not react to icon clicks. */
+        val hasLines = HashSet<Civilization>(civCount)
+        /** All portraits and lines, each line only once */
+        val all = ArrayList<WidgetEntry>((civCount * (civCount + 1)) / 2)
+
+        init {
+            // icons - not etheir center coordinates are used for the line creation
+            for ((index, civ) in undefeatedCivs.withIndex())
+                addCivIcon(index, civ, freeSize)
+
+            // lines
+            for ((fromIndex, civ) in undefeatedCivs.withIndex()) {
+                if (civ.isDefeated()) continue // if you're dead, icon but no lines (One more turn mode after losing)
+                val civWidget = civWidgets[civ]!! // !! is covered because every item in undefeatedCivs is guaranteed to be in the map by the "icons" loop
+                for (toIndex in 0 until fromIndex) {
+                    val otherCiv = undefeatedCivs[toIndex]
+                    // Note: toIndex < fromIndex, so we're getting a relation _from_ a city-state _to_ a major civ, not vice versa (so we see "Afraid"),
+                    // and major-major or cs-cs relations should be symmetrical
+                    if (otherCiv.isDefeated()) continue
+                    val diplomacy = civ.diplomacy[otherCiv.civID] ?: continue // Skip line if the civs don't know each other
+                    val otherCivWidget = civWidgets[otherCiv]!! // !! is covered same as above
+                    addLine(civ, otherCiv, civWidget, otherCivWidget, diplomacy.getRelation())
+                }
+            }
+
+            all.sortBy { it.zOrder }
+        }
+
+        fun DiplomacyManager.getRelation() = when {
+            diplomaticStatus == DiplomaticStatus.War ->
+                Relation.War
+            diplomaticStatus == DiplomaticStatus.DefensivePact && !(civInfo.isCityState || otherCiv.isCityState) ->
+                Relation.DefensivePact
+            civInfo.isHuman() && otherCiv.isHuman() && hasModifier(DiplomaticModifiers.DeclarationOfFriendship) ->
+                Relation[RelationshipLevel.Friend]
+            (civInfo.isCityState && civInfo.allyCiv == otherCiv) || (otherCiv.isCityState && otherCiv.allyCiv == civInfo) ->
+                Relation[RelationshipLevel.Ally]
+            else ->
+                Relation[relationshipLevel()]
+        }
+
+        fun addCivIcon(index: Int, civ: Civilization, freeSize: Float) {
+            val civGroup = ImageGetter.getNationPortrait(civ.nation, iconSize)
+                .surroundWithCircle(iconCircleSize, false, Color.CLEAR_WHITE) // Not CLEAR, we simply control alpha later for some gray.
+
+            val vector = HexMath.getVectorForAngle(2 * Math.PI.toFloat() * index / civCount)
+            civGroup.setPosition(freeSize / 2, freeSize / 2, Align.center)
+            civGroup.moveBy(vector.x * freeSize / 2.25f, vector.y * freeSize / 2.25f)
+            civGroup.touchable = Touchable.enabled
+            civGroup.onClick { toggleSelection(civ) }
+            civGroup.addTooltip(civ.civName, tipAlign = Align.left, hideIcons = true)
+
+            val entry = WidgetEntry.Icon(civGroup, civ)
+            civWidgets[civ] = entry
+            all += entry
+        }
+
+        fun addLine(civ: Civilization, otherCiv: Civilization, civWidget: WidgetEntry.Icon, otherCivWidget: WidgetEntry.Icon, relation: Relation) {
+            val statusLine = ImageGetter.getLine(
+                startX = civWidget.x,
+                startY = civWidget.y,
+                endX = otherCivWidget.x,
+                endY = otherCivWidget.y,
+                width = lineWidth
+            )
+            statusLine.color = relation.color
+            val entry = WidgetEntry.Line(statusLine, relation, civ, otherCiv)
+            hasLines += civ
+            hasLines += otherCiv
+            all += entry
+        }
+    }
+
+    private val index = WidgetIndex(undefeatedCivs, freeSize, ::toggleSelection)
+    private val selectedCivs = mutableSetOf<Civilization>()
+    private val selectedRelations = mutableSetOf<Relation>()
+
     init {
         setSize(freeSize, freeSize)
 
         // An Image Actor does not respect alpha for its hit area, it's always square, but we want a clickable _circle_
-        // Radius to show legend should be no larger than freeSize / 2.25f - 15f (see below), let's make it a little smaller
+        // Radius to show legend should be no larger than freeSize / 2.25f - 15f (see above), let's make it a little smaller
         val clickableArea = ClickableCircle(freeSize / 1.25f - 25f)
         clickableArea.onActivation {
             DiagramLegendPopup(stage, this)
@@ -44,131 +236,72 @@ class GlobalPoliticsDiagramGroup(
         clickableArea.center(this)
         addActor(clickableArea)
 
-        val civGroups = HashMap<String, Actor>()
-        val civLines = HashMap<String, MutableSet<Actor>>()
-        val civCount = undefeatedCivs.count()
+        for (entry in index.all)
+            addActor(entry.widget)
 
-        for ((i, civ) in undefeatedCivs.withIndex()) {
-            val civGroup = ImageGetter.getNationPortrait(civ.nation, 30f)
-
-            val vector = HexMath.getVectorForAngle(2 * Math.PI.toFloat() * i / civCount)
-            civGroup.center(this)
-            civGroup.moveBy(vector.x * freeSize / 2.25f, vector.y * freeSize / 2.25f)
-            civGroup.touchable = Touchable.enabled
-            civGroup.onClick {
-                onCivClicked(civLines, civ.civName)
-            }
-            civGroup.addTooltip(civ.civName, tipAlign = Align.bottomLeft)
-
-            civGroups[civ.civName] = civGroup
-            addActor(civGroup)
-        }
-
-        for (civ in undefeatedCivs) {
-            if (civ.isDefeated()) continue // if you're dead, icon but no lines (One more turn mode after losing)
-            for (diplomacy in civ.diplomacy.values) {
-                val otherCiv = diplomacy.otherCiv
-                if (otherCiv !in undefeatedCivs || otherCiv.isDefeated()) continue
-                val civGroup = civGroups[civ.civName]!!
-                val otherCivGroup = civGroups[diplomacy.otherCiv.civName]!!
-
-                val statusLine = ImageGetter.getLine(
-                    startX = civGroup.x + civGroup.width / 2,
-                    startY = civGroup.y + civGroup.height / 2,
-                    endX = otherCivGroup.x + otherCivGroup.width / 2,
-                    endY = otherCivGroup.y + otherCivGroup.height / 2,
-                    width = 2f
-                )
-
-                statusLine.color = if (diplomacy.diplomaticStatus == DiplomaticStatus.War) Color.RED
-                // Color defensive pact for major civs only
-                else if (diplomacy.diplomaticStatus == DiplomaticStatus.DefensivePact
-                    && !(civ.isCityState || otherCiv.isCityState)) Color.PURPLE
-                else if (civ.isHuman() && otherCiv.isHuman() && diplomacy.hasModifier(DiplomaticModifiers.DeclarationOfFriendship))
-                    RelationshipLevel.Friend.color
-                // Test for alliance with city state
-                else if ((civ.isCityState && civ.allyCiv == diplomacy.otherCiv)
-                    || (otherCiv.isCityState && otherCiv.allyCiv == civ)) RelationshipLevel.Ally.color
-                // Else the color depends on opinion between major civs, OR city state relationship with major civ
-                else diplomacy.relationshipLevel().color
-
-                if (!civLines.containsKey(civ.civName)) civLines[civ.civName] = mutableSetOf()
-                civLines[civ.civName]!!.add(statusLine)
-
-                addActorAt(0, statusLine)
-            }
-        }
+        selectedCivs.addAll(undefeatedCivs)
+        selectedRelations.addAll(Relation.entries)
     }
 
-    private fun onCivClicked(civLines: HashMap<String, MutableSet<Actor>>, name: String) {
-        // ignore the clicks on "dead" civilizations, and remember the selected one
-        val selectedLines = civLines[name] ?: return
+    private fun toggleSelection(civ: Civilization) {
+        // ignore the clicks on "dead" civilizations
+        if (civ !in index.hasLines) return
 
-        // let's check whether lines of all civs are visible (except selected one)
-        var atLeastOneLineVisible = false
-        var allAreLinesInvisible = true
-        for (lines in civLines.values) {
-            // skip the civilization selected by user, and civilizations with no lines
-            if (lines == selectedLines || lines.isEmpty()) continue
-
-            val visibility = lines.first().isVisible
-            atLeastOneLineVisible = atLeastOneLineVisible || visibility
-            allAreLinesInvisible = allAreLinesInvisible && visibility
-
-            // check whether both visible and invisible lines are present
-            if (atLeastOneLineVisible && !allAreLinesInvisible) {
-                // invert visibility of the selected civ's lines
-                selectedLines.forEach { it.isVisible = !it.isVisible }
-                return
-            }
-        }
-
-        if (selectedLines.first().isVisible) {
-            // invert visibility of all lines except selected one
-            civLines.filter { it.key != name }
-                .forEach { it.value.forEach { line -> line.isVisible = !line.isVisible } }
-        } else {
-            // it happens only when all are visible except selected one
-            // invert visibility of the selected civ's lines
-            selectedLines.forEach { it.isVisible = !it.isVisible }
-        }
+        if (civ in selectedCivs) selectedCivs.remove(civ) else selectedCivs.add(civ)
+        if (selectedCivs.size < 2) selectedCivs.addAll(index.civWidgets.keys)
+        updateVisibility()
     }
 
-    private class DiagramLegendPopup(stage: Stage, diagram: Actor) : AnimatedMenuPopup(stage, diagram, Align.center) {
-        init {
-            touchable = Touchable.enabled
-            onActivation { close() }
-        }
+    private fun toggleSelection(relation: Relation) {
+        if (relation in selectedRelations) selectedRelations.remove(relation) else selectedRelations.add(relation)
+        if (selectedRelations.isEmpty()) selectedRelations.addAll(Relation.entries)
+        updateVisibility()
+    }
 
-        companion object {
-            const val lineWidth = 3f  // a little thicker than the actual diagram
-            const val lowContrastWidth = 4f
-            const val lineLength = 120f
-        }
+    private fun updateVisibility() {
+        for (entry in index.all)
+            entry.setSelected(selectedCivs, selectedRelations)
+    }
+
+    private inner class DiagramLegendPopup(stage: Stage, diagram: Actor) : AnimatedMenuPopup(stage, diagram, Align.center) {
+        val checkBoxes = mutableMapOf<Relation, CheckBox>()
 
         override fun createContentTable(): Table {
             val legend = Table()
             legend.background = ImageGetter.getDrawable("OtherIcons/Politics-diagram-bg")
-            legend.add(ShadowedLabel("Diagram line colors", Constants.headingFontSize)).colspan(2).row()
-            //todo Rethink hardcoding together with the statusLine.color one in GlobalPoliticsDiagramGroup
-            legend.addLegendRow("War", Color.RED)
-            for (level in RelationshipLevel.entries) {
-                legend.addLegendRow(level.name, level.color)
+            legend.add(ShadowedLabel("Diagram line colors", Constants.headingFontSize)).colspan(3).row()
+            for (relation in Relation.entries) {
+                legend.addLegendRow(relation)
             }
-            legend.addLegendRow(Constants.defensivePact, Color.PURPLE)
             return super.createContentTable()!!.apply {
                 add(legend).grow()
             }
         }
 
-        fun Table.addLegendRow(text: String, color: Color) {
+        fun updateCheckBoxes() {
+            // Checked stati are only out of sync if toggleSelection replaced the empty selection with all entries
+            if (checkBoxes.all { it.value.isChecked == it.key in selectedRelations }) return
+            checkBoxes.values.forEach { it.isChecked = true }
+        }
+
+        fun Table.addLegendRow(relation: Relation) {
+            val checkBox = CheckBox(null, BaseScreen.skin)
+            checkBox.isChecked = relation in selectedRelations
+            checkBox.onClick {
+                toggleSelection(relation)
+                updateCheckBoxes()
+            }
+            checkBoxes[relation] = checkBox
+            add(checkBox)
+
             // empiric hack to equalize the "visual impact" a little. Afraid is worst at contrast 1.4, Enemy has 9.8
-            val contrast = getContrastRatio(Color.DARK_GRAY, color).toFloat()
-            val width = lineWidth + (lowContrastWidth - lineWidth) / contrast.coerceAtLeast(1f)
-            val line = ImageGetter.getLine(0f, width / 2, lineLength, width / 2, width)
-            line.color = color
-            add(line).size(lineLength, width).padTop(5f)
-            add(ShadowedLabel(text)).padLeft(5f).padTop(10f).row()
+            val contrast = getContrastRatio(Color.DARK_GRAY, relation.color).toFloat()
+            val width = legendLineWidth + (legendLowContrastWidth - legendLineWidth) / contrast.coerceAtLeast(1f)
+            val line = ImageGetter.getLine(0f, width / 2, legendLineLength, width / 2, width)
+            line.color = relation.color
+            add(line).size(legendLineLength, width).padTop(5f)
+
+            add(ShadowedLabel(relation.label)).padLeft(5f).padTop(10f).row()
         }
     }
 }


### PR DESCRIPTION
You really need a huge world with many civs to appreciate  this.

<details><summary>visual demo</summary>

https://github.com/user-attachments/assets/b25b4201-60b7-4292-a1ce-37d3bbe60216

</details>

For code review, it may be easier to view the resulting file not the diff.

### Features:
- Understandable deterministic effect of civ (de)selection
- Visible civ selected/deselected state
- Z-Order of lines is by relationship, ordered by relevance, so "War" is always on top and "Neutral" on bottom
- Relation states can be (de)selected to reduce clutter
- Selection snaps back to "all civs" when reduced to 1 selected civ (which would leave no lines at all)
- Selection snaps back to "all relationship levels" when reduced to 0

### Non-features, open to suggestion:
- Persistence of selections, neither when flipping "city-states", nor re-entering overview
- I disagree with "Ally" for CS and "Ally" as extreme favorable between major civs being lumped together
- Relation to "relevance" for Z-Order is subjective, open to suggestions - e.g. draw "Afraid" on top of "Ally" instead of vice versa?
