### PR TITLE
Allow pixel unit art option and modded extraImages for units to coexist

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -493,6 +493,10 @@ open class RulesetValidator protected constructor(
 
         if (unit.isMilitary && unit.strength == 0)  // Should only match ranged units with 0 strength
             lines.add("${unit.name} is a military unit but has no assigned strength!", sourceObject = unit)
+
+        val pixelUnitTexturePattern = Regex("TileSets/[^/]+/Units/${unit.name}")
+        if (unit.civilopediaText.any { it.extraImage.matches(pixelUnitTexturePattern) })
+            lines.add("Unit ${unit.name} includes the unit's UnitSet art in civilopediaText, which is superseded by the \"Size of Unitset art in Civilopedia\" option", RulesetErrorSeverity.WarningOptionsOnly, unit)
     }
 
     protected open fun addUnitTypeErrors(lines: RulesetErrorList) {

--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -215,7 +215,8 @@ object BaseUnitDescriptions {
      */
     // Note: By popular request (this is a simple variant of one of the ideas in #10175)
     private fun ArrayList<FormattedLine>.addPixelUnitImage(baseUnit: BaseUnit) {
-        if (baseUnit.civilopediaText.any { it.extraImage.isNotEmpty() }) return
+        val pixelUnitTexturePattern = Regex("TileSets/[^/]+/Units/${baseUnit.name}")
+        if (baseUnit.civilopediaText.any { it.extraImage.matches(pixelUnitTexturePattern) }) return
         val settings = GUI.getSettings()
         if (settings.unitSet.isNullOrEmpty() || settings.pediaUnitArtSize < 1f) return
         val imageName = "TileSets/${settings.unitSet}/Units/${baseUnit.name}"
@@ -225,7 +226,6 @@ object BaseUnitDescriptions {
     }
 
     @Suppress("RemoveExplicitTypeArguments")  // for faster IDE - inferring sequence types can be slow
-    
     fun UnitType.getUnitTypeCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         @Readonly
         fun getDomainLines() = sequence<FormattedLine> {


### PR DESCRIPTION
Fixes #15201 
- Adds mod check warning when a mod still does its own pulling in of sprites
- But also skips the auto-sprites only for such units, not for any units having _any_ extraImage.

Can be tested with [Rivers of Lava](https://github.com/SpacedOutChicken/Rivers-of-Lava) (Hi @SpacedOutChicken sorry to poke the wasp nest) - always unit sprites sized by the mod, option ignored, no duplicate sprite. As for a combo, didn't do a test mod...