### PR TITLE
Button to check a Mod directly from the Mod manager screen

### DIFF
--- a/android/assets/Skin.json
+++ b/android/assets/Skin.json
@@ -137,6 +137,12 @@
             "b": 0,
             "a": 0
         }
+        "mods-scroll-bg": {
+            "r": 0.4,
+            "g": 0.4,
+            "b": 0.4,
+            "a": 0.25
+        }
     },
     "com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable": {
         "button-c": {
@@ -258,6 +264,14 @@
         "white": {
             "name": "Rectangle",
             "color": "white"
+        },
+        "mods-scroll-bg-c": {
+            "name": "Scrollbar",
+            "color": "mods-scroll-bg"
+        },
+        "mods-scroll-knob-c": {
+            "name": "Scrollbar",
+            "color": "highlight"
         }
     },
     "com.badlogic.gdx.scenes.scene2d.ui.Button$ButtonStyle": {
@@ -302,6 +316,11 @@
         },
         "select-box-scroll": {
             "background": "select-box-scroll-bg-c",
+            "hScrollKnob": "scrollbar-c",
+            "vScrollKnob": "scrollbar-c"
+        },
+        "mods-scroll": {
+            "vScroll": "mods-scroll-bg-c",
             "hScrollKnob": "scrollbar-c",
             "vScrollKnob": "scrollbar-c"
         }

--- a/core/src/com/unciv/ui/popups/options/AboutTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AboutTab.kt
@@ -6,16 +6,31 @@ import com.unciv.UncivGame
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
 
-fun aboutTab(): Table {
-    // The changelog has no patches, and anchors per release tag omit the dots
-    val versionAnchor = Regex("""\.|-patch\d+$""").replace(UncivGame.VERSION.text, "")
-    val lines = sequence {
-        yield(FormattedLine(extraImage = "banner", imageSize = 240f, centered = true))
-        yield(FormattedLine())
-        yield(FormattedLine("{Version}: ${UncivGame.VERSION.toNiceString()}", link = "${Constants.uncivRepoURL}blob/master/changelog.md#$versionAnchor"))
-        yield(FormattedLine("See online Readme", link = "${Constants.uncivRepoURL}blob/master/README.md#unciv---foss-civ-v-for-androiddesktop"))
-        yield(FormattedLine("Visit repository", link = Constants.uncivRepoURL))
-        yield(FormattedLine("Visit the wiki", link = Constants.wikiURL))
+internal class AboutTab(
+    optionsPopup: OptionsPopup
+): OptionsPopupTab(optionsPopup) {
+    init {
+        renderTo(this)
     }
-    return MarkupRenderer.render(lines.asIterable()).pad(20f)
+
+    companion object {
+        /** Get "About" content in a separate Table without the [OptionsPopupTab] contract */
+        // MainMenuscreen adds this to a Popup - one Table wrapper could be saved by using renderTo(Popup.innerTable), but that would be longer code
+        fun asTable() = Table().apply { renderTo(this) }
+
+        private fun renderTo(table: Table) {
+            table.pad(20f)
+            // The changelog has no patches, and anchors per release tag omit the dots
+            val versionAnchor = Regex("""\.|-patch\d+$""").replace(UncivGame.VERSION.text, "")
+            val lines = sequence {
+                yield(FormattedLine(extraImage = "banner", imageSize = 240f, centered = true))
+                yield(FormattedLine())
+                yield(FormattedLine("{Version}: ${UncivGame.VERSION.toNiceString()}", link = "${Constants.uncivRepoURL}blob/master/changelog.md#$versionAnchor"))
+                yield(FormattedLine("See online Readme", link = "${Constants.uncivRepoURL}blob/master/README.md#unciv---foss-civ-v-for-androiddesktop"))
+                yield(FormattedLine("Visit repository", link = Constants.uncivRepoURL))
+                yield(FormattedLine("Visit the wiki", link = Constants.wikiURL))
+            }
+            MarkupRenderer.renderTo(table, lines.asIterable())
+        }
+    }
 }

--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -97,6 +97,10 @@ internal class ModCheckTab(
         add(modCheckResultTable)
     }
 
+    override fun subSelect(select: String?) {
+        searchModsTextField.text = select
+    }
+
     private fun runAction() {
         if (modCheckFirstRun) runModChecker()
         else runModChecker(modCheckBaseSelect!!.selected.value)
@@ -133,7 +137,9 @@ internal class ModCheckTab(
 
         val openedExpanderTitles = modResultTables
             .filterIsInstance<ExpanderTab>()
-            .filter { it.isOpen }.map { it.title }.toSet()
+            .filter { it.isOpen }.mapTo(mutableSetOf()) { it.title }
+        if (searchModsTextField.text in RulesetCache.keys)
+            openedExpanderTitles.add(searchModsTextField.text)
 
         modCheckResultTable.clear()
         modResultTables.clear()

--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -42,8 +42,8 @@ private const val MOD_CHECK_WITHOUT_BASE = "-none-"
 private const val MOD_CHECK_DYNAMIC_BASE = "-declared requirements-"
 
 internal class ModCheckTab(
-    val screen: BaseScreen
-) : Table(), TabbedPager.IPageExtensions {
+    optionsPopup: OptionsPopup,
+) : OptionsPopupTab(optionsPopup) {
     private val fixedContent = Table()
 
     // marker for automatic first run on selecting the tab
@@ -268,11 +268,11 @@ internal class ModCheckTab(
             openUniqueBuilderButton.onClick { openUniqueBuilder(combinedRuleset) }
             it.add(openUniqueBuilderButton).row()
 
-            if (severity != RulesetErrorSeverity.OK && mod.folderLocation != null) {
+            if (game.screen != null && severity != RulesetErrorSeverity.OK && mod.folderLocation != null) {
                 val replaceableUniques = UniqueAutoUpdater.getDeprecatedReplaceableUniques(mod, combinedRuleset)
                 if (replaceableUniques.isNotEmpty())
                     it.add("Autoupdate mod uniques".toTextButton()
-                        .onClick { autoUpdateUniques(screen, mod, replaceableUniques) }).row()
+                        .onClick { autoUpdateUniques(game.screen!!, mod, replaceableUniques) }).row()
             }
             for (line in modLinks) {
                 val label = Label(line.text, BaseScreen.skin)

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -18,7 +18,8 @@ class OptionsPopup(
     screen: BaseScreen,
     private val selectPage: OptionsPopupPages = defaultPage,
     withDebug: Boolean = false,
-    private val onClose: () -> Unit = {}
+    private val onClose: () -> Unit = {},
+    private val subSelect: String? = null
 ) : Popup(screen.stage, /** [TabbedPager] handles scrolling */ scrollable = Scrollability.None), OptionsPopupHelpers {
 
     val game = screen.game
@@ -84,6 +85,8 @@ class OptionsPopup(
     override fun setVisible(visible: Boolean) {
         super.setVisible(visible)
         if (!visible) return
-        if (tabs.activePage < 0) tabs.selectPage(selectPage)
+        if (tabs.activePage >= 0) return
+        pageIndex[selectPage]?.subSelect(subSelect)
+        tabs.selectPage(selectPage.ordinal)
     }
 }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -1,15 +1,9 @@
 package com.unciv.ui.popups.options
 
-import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
-import com.unciv.GUI
-import com.unciv.models.metadata.BaseRuleset
-import com.unciv.models.ruleset.RulesetCache
-import com.unciv.ui.components.extensions.areSecretKeysPressed
 import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.extensions.getCloseButton
 import com.unciv.ui.components.widgets.TabbedPager
-import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
@@ -22,7 +16,7 @@ import com.unciv.ui.screens.worldscreen.WorldScreen
 //region Fields
 class OptionsPopup(
     screen: BaseScreen,
-    private val selectPage: Int = defaultPage,
+    private val selectPage: OptionsPopupPages = defaultPage,
     withDebug: Boolean = false,
     private val onClose: () -> Unit = {}
 ) : Popup(screen.stage, /** [TabbedPager] handles scrolling */ scrollable = Scrollability.None), OptionsPopupHelpers {
@@ -30,14 +24,15 @@ class OptionsPopup(
     val game = screen.game
     val settings = screen.game.settings
     val tabs: TabbedPager
-    override val activePage get() = tabs.activePage
+    private val pageIndex = HashMap<OptionsPopupPages, OptionsPopupTab>()
+    override val activePage get() = OptionsPopupPages[tabs.activePage]
     override val rightWidgetMinWidth: Float
-    private val tabMinWidth: Float
+    internal val tabMinWidth: Float
 
     //endregion
 
     companion object {
-        const val defaultPage = 2  // Gameplay
+        val defaultPage = OptionsPopupPages.Gameplay
     }
 
     init {
@@ -64,62 +59,11 @@ class OptionsPopup(
         )
         add(tabs).pad(0f).grow().row()
 
-        tabs.addPage(
-            "About",
-            aboutTab(),
-            ImageGetter.getExternalImage("Icons/Unciv128.png"), 24f
-        )
-        tabs.addPage(
-            "Display",
-            DisplayTab(this),
-            ImageGetter.getImage("UnitPromotionIcons/Scouting"), 24f
-        )
-        tabs.addPage(
-            "Gameplay",
-            GameplayTab(this),
-            ImageGetter.getImage("OtherIcons/Options"), 24f
-        )
-        tabs.addPage(
-            "Automation",
-            AutomationTab(this),
-            ImageGetter.getImage("OtherIcons/NationSwap"), 24f
-        )
-        tabs.addPage(
-            "Language",
-            LanguageTab(this),
-            ImageGetter.getImage("FlagIcons/${settings.language}"), 24f
-        )
-        tabs.addPage(
-            "Sound",
-            SoundTab(this),
-            ImageGetter.getImage("OtherIcons/Speaker"), 24f
-        )
-        tabs.addPage(
-            "Multiplayer",
-            MultiplayerTab(this),
-            ImageGetter.getImage("OtherIcons/Multiplayer"), 24f
-        )
-
-        if (GUI.keyboardAvailable) {
-            tabs.addPage(
-                "Keys",
-                KeyBindingsTab(this, tabMinWidth - 40f),  // 40 = padding
-                ImageGetter.getImage("OtherIcons/Keyboard"), 24f
-            )
-        }
-
-        tabs.addPage(
-            "Advanced",
-            AdvancedTab(this),
-            ImageGetter.getImage("OtherIcons/Settings"), 24f
-        )
-
-        if (RulesetCache.size > BaseRuleset.entries.size) {
-            val content = ModCheckTab(screen)
-            tabs.addPage("Locate mod errors", content, ImageGetter.getImage("OtherIcons/Mods"), 24f)
-        }
-        if (withDebug || Gdx.input.areSecretKeysPressed()) {
-            tabs.addPage("Debug", DebugTab(this), ImageGetter.getImage("OtherIcons/SecretOptions"), 24f)
+        for (page in OptionsPopupPages.entries) {
+            if (!page.visible(withDebug)) continue
+            val content = page.getContent(this)
+            tabs.addPage(page.label, content, page.getIcon(settings.language), 24f)
+            pageIndex[page] = content
         }
 
         tabs.decorateHeader(getCloseButton { close() })

--- a/core/src/com/unciv/ui/popups/options/OptionsPopupHelpers.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopupHelpers.kt
@@ -60,8 +60,8 @@ internal interface OptionsPopupHelpers {
      */
     val rightWidgetMinWidth: Float
 
-    /** Access the active page number of the TabbedPager in [OptionsPopup] */
-    val activePage: Int
+    /** Access the active page of the TabbedPager in [OptionsPopup] */
+    val activePage: OptionsPopupPages
 
 
     /**

--- a/core/src/com/unciv/ui/popups/options/OptionsPopupPages.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopupPages.kt
@@ -1,0 +1,44 @@
+package com.unciv.ui.popups.options
+
+import com.badlogic.gdx.Gdx
+import com.unciv.GUI
+import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.ui.components.extensions.areSecretKeysPressed
+import com.unciv.ui.images.ImageGetter
+
+enum class OptionsPopupPages(
+    val label: String,
+    internal val iconPath: String,
+    internal val getContent: OptionsPopup.() -> OptionsPopupTab
+) {
+    About("About", "Icons/Unciv128.png", { AboutTab(this) }),
+    Display("Display", "UnitPromotionIcons/Scouting", { DisplayTab(this) }),
+    Gameplay("Gameplay", "OtherIcons/Options", { GameplayTab(this) }),
+    Automation("Automation", "OtherIcons/NationSwap", { AutomationTab(this) }),
+    Language("Language", "FlagIcons/", { LanguageTab(this) }) {
+        override fun getIcon(language: String) = ImageGetter.getImage(iconPath + language)
+    },
+    Sound("Sound", "OtherIcons/Speaker", { SoundTab(this) }),
+    Multiplayer("Multiplayer", "OtherIcons/Multiplayer", { MultiplayerTab(this) }),
+    Keys("Keys", "OtherIcons/Keyboard", { KeyBindingsTab(this, tabMinWidth - 40f) }) {   // 40 = padding
+        override fun visible(withDebug: Boolean) = GUI.keyboardAvailable
+    },
+    Advanced("Advanced", "OtherIcons/Settings", { AdvancedTab(this) }),
+    ModCheck("Locate mod errors", "OtherIcons/Mods", { ModCheckTab(this) }) {
+        override fun visible(withDebug: Boolean) = RulesetCache.size > BaseRuleset.entries.size
+    },
+    Debug("Debug", "OtherIcons/SecretOptions", { DebugTab(this) }) {
+        override fun visible(withDebug: Boolean) = withDebug || Gdx.input.areSecretKeysPressed()
+    },
+    ;
+
+    internal open fun visible(withDebug: Boolean) = true
+    internal open fun getIcon(language: String) =
+        if (iconPath.endsWith(".png")) ImageGetter.getExternalImage(iconPath)
+        else ImageGetter.getImage(iconPath)
+
+    companion object {
+        operator fun get(ordinal: Int) = entries.first { it.ordinal == ordinal }
+    }
+}

--- a/core/src/com/unciv/ui/popups/options/OptionsPopupTab.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopupTab.kt
@@ -40,4 +40,6 @@ internal abstract class OptionsPopupTab(
     override fun activated(index: Int, caption: String, pager: TabbedPager) {
         if (!isInitialized) lateInitialize()
     }
+
+    open fun subSelect(select: String?) {}
 }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopupTab.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopupTab.kt
@@ -17,14 +17,14 @@ internal abstract class OptionsPopupTab(
     internal val optionsPopup: OptionsPopup,
 ) : Table(skin), TabbedPager.IPageExtensions, OptionsPopupHelpers {
     override val rightWidgetMinWidth by optionsPopup::rightWidgetMinWidth
-    override val activePage get() = optionsPopup.tabs.activePage
+    override val activePage get() = OptionsPopupPages[optionsPopup.tabs.activePage]
 
     val settings by optionsPopup::settings
     val game by optionsPopup::game
 
     fun selectPage(name: String) = optionsPopup.tabs.selectPage(name)
     fun replacePage(factory: (OptionsPopup) -> OptionsPopupTab) =
-        optionsPopup.tabs.replacePage(activePage, factory(optionsPopup))
+        optionsPopup.tabs.replacePage(activePage.ordinal, factory(optionsPopup))
 
     private var isInitialized = false
 

--- a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
@@ -34,6 +34,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.activePopup
 import com.unciv.ui.popups.options.OptionsPopup
+import com.unciv.ui.popups.options.OptionsPopupPages
 import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
 import com.unciv.ui.screens.worldscreen.WorldScreen
@@ -178,7 +179,7 @@ abstract class BaseScreen : Screen {
     /** @return `true` if the screen is narrower than 4:3 landscape */
     fun isNarrowerThan4to3() = stage.isNarrowerThan4to3()
 
-    open fun openOptionsPopup(startingPage: Int = OptionsPopup.defaultPage, withDebug: Boolean = false, onClose: () -> Unit = {}) {
+    open fun openOptionsPopup(startingPage: OptionsPopupPages = OptionsPopup.defaultPage, withDebug: Boolean = false, onClose: () -> Unit = {}) {
         OptionsPopup(this, startingPage, withDebug, onClose).open(force = true)
     }
 

--- a/core/src/com/unciv/ui/screens/civilopediascreen/MarkupRenderer.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/MarkupRenderer.kt
@@ -38,6 +38,24 @@ object MarkupRenderer {
     ): Table {
         val skin = BaseScreen.skin
         val table = Table(skin).apply { defaults().pad(padding).align(Align.left) }
+        renderTo(table, lines, labelWidth, iconDisplay, linkAction)
+        return table
+    }
+
+    /**
+     *  Render [formatted][FormattedLine] [content][lines] into an existing [table].
+     *
+     *  @param labelWidth       Available width needed for wrapping labels and [centered][FormattedLine.centered] attribute.
+     *  @param iconDisplay      Flag to omit link or all images (but not linking itself if linkAction is supplied)
+     *  @param linkAction       Delegate to call for internal links. Leave null to suppress linking.
+     */
+    fun renderTo(
+        table: Table,
+        lines: Iterable<FormattedLine>,
+        labelWidth: Float = 0f,
+        iconDisplay: FormattedLine.IconDisplay = FormattedLine.IconDisplay.All,
+        linkAction: ((id: String) -> Unit)? = null
+    ) {
         for (line in lines) {
             if (line.isEmpty()) {
                 table.add().padTop(emptyLineHeight).row()
@@ -66,6 +84,6 @@ object MarkupRenderer {
             else
                 table.add(actor).width(labelWidth).align(line.align).row()
         }
-        return table.apply { pack() }
+        table.pack()
     }
 }

--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -45,7 +45,7 @@ import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.popups.closeAllPopups
 import com.unciv.ui.popups.hasOpenPopups
-import com.unciv.ui.popups.options.aboutTab
+import com.unciv.ui.popups.options.AboutTab
 import com.unciv.ui.popups.popups
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
@@ -246,7 +246,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
         versionTable.touchable = Touchable.enabled
         versionTable.onClick {
             val popup = Popup(stage)
-            popup.add(aboutTab()).row()
+            popup.add(AboutTab.asTable()).row()
             popup.addCloseButton()
             popup.open()
         }

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -20,6 +20,7 @@ import com.unciv.logic.github.GithubAPI
 import com.unciv.logic.github.GithubAPI.downloadAndExtract
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.addSeparator
@@ -517,6 +518,8 @@ class ModManagementScreen private constructor(
                         ToastPopup(msg, this@ModManagementScreen, 4000L)
                     }
 
+                    if (RulesetCache[repoName]?.modOptions?.hasUnique(UniqueType.ModIsAudioVisualOnly) == true)
+                        game.settings.visualMods.add(repoName)
                     updateInstalledModUIData(repoName)
                     refreshInstalledModTable()
                     lastSelectedButton?.let { syncOnlineSelected(repoName, it) }

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -80,6 +80,12 @@ class ModManagementScreen private constructor(
         fun cleanModName(modName: String): String = modName.replace("   ", " - ")
     }
 
+    private class ModsScrollPane(widget: Actor?) : AutoScrollPane(widget, skin, "mods-scroll") {
+        init {
+            setupFadeScrollBars(3f, 3f) // Let them fade away, but more slowly than default (1, 1)
+        }
+    }
+
     // Since we're `RecreateOnResize`, preserve the portrait/landscape mode for our lifetime
     private val isPortrait: Boolean
 
@@ -90,13 +96,13 @@ class ModManagementScreen private constructor(
 
     // Left column (in landscape, portrait stacks them within expanders)
     private val installedModsTable = Table().apply { defaults().pad(10f) }
-    private val scrollInstalledMods = AutoScrollPane(installedModsTable)
+    private val scrollInstalledMods = ModsScrollPane(installedModsTable)
     // Center column
     private val onlineModsTable = Table().apply { defaults().pad(10f) }
-    private val scrollOnlineMods = AutoScrollPane(onlineModsTable)
+    private val scrollOnlineMods = ModsScrollPane(onlineModsTable)
     // Right column
     private val modActionTable = ModInfoAndActionPane()
-    private val scrollActionTable = AutoScrollPane(modActionTable)
+    private val scrollActionTable = ModsScrollPane(modActionTable)
     // Manager providing the Widget floating top right in landscape mode, stacked expander in portrait
     private val optionsManager = ModManagementOptions(this)
 

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -43,6 +43,8 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.ToastPopup
+import com.unciv.ui.popups.options.OptionsPopup
+import com.unciv.ui.popups.options.OptionsPopupPages
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
@@ -607,6 +609,12 @@ class ModManagementScreen private constructor(
             if (optionsManager.sortInstalled == SortType.Status)
                 refreshInstalledModTable()
         }
+
+        val checkModButton = "Check [${cleanModName(modInfo.name)}]".toTextButton()
+        checkModButton.onClick {
+            OptionsPopup(this, OptionsPopupPages.ModCheck, subSelect = mod.name).open()
+        }
+        modActionTable.add(checkModButton).row()
 
         val updateModButton = modActionTable.addUpdateModButton(modInfo) ?: return
         updateModButton.onClick {

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -35,6 +35,7 @@ import com.unciv.ui.popups.AuthPopup
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.popups.hasOpenPopups
+import com.unciv.ui.popups.options.OptionsPopupPages
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.cityscreen.CityScreen
 import com.unciv.ui.screens.devconsole.DevConsolePopup
@@ -225,7 +226,7 @@ class WorldScreen(
     override fun getCivilopediaRuleset() = gameInfo.ruleset
 
     // Handle disabling and re-enabling WASD listener while Options are open
-    override fun openOptionsPopup(startingPage: Int, withDebug: Boolean, onClose: () -> Unit) {
+    override fun openOptionsPopup(startingPage: OptionsPopupPages, withDebug: Boolean, onClose: () -> Unit) {
         val oldListener = stage.root.listeners.filterIsInstance<KeyboardPanningListener>().firstOrNull()
         if (oldListener != null) {
             stage.removeListener(oldListener)


### PR DESCRIPTION
### Motivation
I was hunting the elusive "ModManagementScreen duplicates entries in the center column" bug (#14927), and I thought I had a repro - but then I implemented feature one to better see what's going on, and lost it. So somehow I ended up implementing feature two, which was an idea in #14950, and while testing got another tiny idea from a mod description - the Civ3 music one by @RobLoach I think - which would **now** not need to be manually "PAV"-selected after download.

### Demo clip
<details>

A bit jumpy, and would be clearer had peek not lost the ability to render the mouse pointer, but the first two thirds were intended to show how the scrollbars are visible and usable by dragging...

https://github.com/user-attachments/assets/42f4d5a5-0c78-4f39-bf59-3e0f9fbbeaef

</details>

### Features
- ModManagementScreen's ScrollPanes have their ScrollBars repaired and reskinned, plus longer fade times
- ModManagementScreen has a "Check this mod" button
- Freshly downloaded mods that are marked as "permanent audiovisual only" automatically get marked as PAV - otherwise, why would you download it? Maybe controversial, if so, we can revert?

### Technical details
(NOT in order of importance)
- Finally, all Tabs in the Options popup have a common contract, no exceptions
- Cleaner "select page" interface via enum
- Reason: Allow asking OptionsPopup to check a specific mod
- Simplification leads to: Modchecker shows more than the "selected" mod, but the "selected" one is the only one started expanded. Example: "Deciv Redux" selects a few mods more than just that one, because I didn't invent a new selection system but reused the filter.