### PR TITLE
Visually indicate failed MP upload

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1247,6 +1247,7 @@ from the ruins =
 
 # World Screen UI
 
+Retry Upload = 
 Working... = 
 Waiting for other players... = 
 Waiting for [civName]... = 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -97,6 +97,10 @@ class WorldScreen(
     /** Indicates it's the player's ([viewingCiv]) turn */
     var isPlayersTurn = viewingCiv.isCurrentPlayer()
         internal set     // only this class is allowed to make changes
+    
+    /** Indicates that a game failed to upload, and needs to be uploaded */
+    var failedUpload = false
+        internal set
 
     /** Selected civilization, used in spectator and replay mode, equals viewingCiv in ordinary games */
     var selectedCiv = viewingCiv
@@ -645,7 +649,7 @@ class WorldScreen(
                         }
                     }
 
-                    this@WorldScreen.isPlayersTurn = true // Since we couldn't push the new game clone, then it's like we never clicked the "next turn" button
+                    this@WorldScreen.failedUpload = true // Since we couldn't push the new game clone, then we need to try again
                     this@WorldScreen.shouldUpdate = true
                     return@runOnNonDaemonThreadPool
                 }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -100,7 +100,7 @@ class WorldScreen(
     
     /** Indicates that a game failed to upload, and needs to be uploaded */
     var failedUpload = false
-        internal set
+        private set
 
     /** Selected civilization, used in spectator and replay mode, equals viewingCiv in ordinary games */
     var selectedCiv = viewingCiv

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnAction.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnAction.kt
@@ -27,6 +27,12 @@ enum class NextTurnAction(protected val text: String, val color: Color) {
         override val icon get() = null
         override fun isChoice(worldScreen: WorldScreen) = false
     },
+    RetryUpload("Retry Upload", Color.RED) {
+        override fun isChoice(worldScreen: WorldScreen) =
+            worldScreen.failedUpload
+        override fun action(worldScreen: WorldScreen) =
+            worldScreen.nextTurn()
+    },
     AutoPlay("AutoPlay", Color.WHITE) {
         override fun isChoice(worldScreen: WorldScreen) =
             worldScreen.autoPlay.isAutoPlaying()

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -52,8 +52,7 @@ class NextTurnButton(
         }
 
         isEnabled = nextTurnAction.getText(worldScreen) == "AutoPlay"
-            || worldScreen.failedUpload
-            || (worldScreen.isPlayersTurn && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
+            || ((worldScreen.isPlayersTurn || worldScreen.failedUpload) && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
         if (isEnabled) {
             addTooltip(KeyboardBinding.NextTurn)
         } else {

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -52,7 +52,7 @@ class NextTurnButton(
         }
 
         isEnabled = nextTurnAction.getText(worldScreen) == "AutoPlay" ||
-            (!worldScreen.hasOpenPopups() && worldScreen.isPlayersTurn && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
+            (!worldScreen.hasOpenPopups() && (worldScreen.isPlayersTurn || worldScreen.failedUpload) && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
         if (isEnabled) {
             addTooltip(KeyboardBinding.NextTurn)
         } else {

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -51,8 +51,9 @@ class NextTurnButton(
             }
         }
 
-        isEnabled = nextTurnAction.getText(worldScreen) == "AutoPlay" ||
-            (!worldScreen.hasOpenPopups() && (worldScreen.isPlayersTurn || worldScreen.failedUpload) && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
+        isEnabled = nextTurnAction.getText(worldScreen) == "AutoPlay"
+            || worldScreen.failedUpload
+            || (worldScreen.isPlayersTurn && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning())
         if (isEnabled) {
             addTooltip(KeyboardBinding.NextTurn)
         } else {


### PR DESCRIPTION
This PR improves how we handle failed MP uploads (discovered while working on #15210). Instead of returning to the default 'Next Turn' button after an error, the button text now distinctively reflects the upload failure.

I chose a RED font to visually emphasize the issue, but the exact styling and naming are open to refinement.

<img width="406" height="178" alt="retry" src="https://github.com/user-attachments/assets/473d8bbe-29bf-4340-8b2f-41b3992b8fca" />
