### PR TITLE
Performance: three behavior-preserving hot-path optimizations

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -31,6 +31,7 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.Speed
 import com.unciv.models.ruleset.nation.Difficulty
 import com.unciv.models.ruleset.tile.TileResource
+import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.audio.MusicMood
@@ -40,12 +41,14 @@ import com.unciv.ui.screens.worldscreen.status.NextTurnProgress
 import com.unciv.utils.DebugUtils
 import com.unciv.utils.debug
 import com.unciv.utils.pseudoRandomUuid
+import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.Readonly
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.time.Duration
 import java.time.Instant
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 
 /**
@@ -147,6 +150,17 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
     @Transient
     private lateinit var difficultyObject: Difficulty // Since this is static game-wide, and was taking a large part of nextTurn
+
+    /** [IHasUniques.isUnavailableBySettings] is a pure function of game-start constants (game parameters,
+     *  starting era, mod options) - it cannot change during a game - yet it is re-evaluated per building/unit
+     *  on every construction-candidacy check ([getRejectionReasons]). Memoize it per rule object.
+     *  ConcurrentHashMap because rejection reasons are queried from both the game thread and the render thread. */
+    @Transient @Cache
+    private val settingsUnavailability = ConcurrentHashMap<IHasUniques, Boolean>()
+
+    @Readonly
+    fun isUnavailableBySettingsCached(obj: IHasUniques): Boolean =
+        settingsUnavailability.computeIfAbsent(obj) { it.isUnavailableBySettings(this) }
 
     @Transient
     lateinit var speed: Speed

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -372,7 +372,9 @@ class CityStats(val city: City) {
 
     // needs to be a separate function because we need to know the global happiness state
     // in order to determine how much food is produced in a city!
-    fun updateCityHappiness(statsFromBuildings: StatTreeNode) {
+    fun updateCityHappiness(statsFromBuildings: StatTreeNode,
+                            statsFromSpecialists: Stats = getStatsFromSpecialists(city.population.getNewSpecialists()),
+                            statsFromUniquesBySource: StatTreeNode = getStatsFromUniquesBySource()) {
         val civInfo = city.civ
         val newHappinessList = LinkedHashMap<String, Float>()
         // This calculation seems weird to me.
@@ -412,16 +414,14 @@ class CityStats(val city: City) {
 
         if (hasExtraAnnexUnhappiness()) newHappinessList["Occupied City"] = -2f //annexed city
 
-        val happinessFromSpecialists =
-            getStatsFromSpecialists(city.population.getNewSpecialists()).happiness.toInt()
-                .toFloat()
+        val happinessFromSpecialists = statsFromSpecialists.happiness.toInt().toFloat()
         if (happinessFromSpecialists > 0) newHappinessList["Specialists"] = happinessFromSpecialists
 
         newHappinessList["Buildings"] = statsFromBuildings.totalStats.happiness.toInt().toFloat()
 
         newHappinessList["Tile yields"] = statsFromTiles.happiness
 
-        val happinessBySource = getStatsFromUniquesBySource()
+        val happinessBySource = statsFromUniquesBySource
         for ((source, stats) in happinessBySource.children)
             if (stats.totalStats.happiness != 0f) {
                 if (!newHappinessList.containsKey(source)) newHappinessList[source] = 0f
@@ -433,7 +433,8 @@ class CityStats(val city: City) {
         happinessList = newHappinessList
     }
 
-    private fun updateBaseStatList(statsFromBuildings: StatTreeNode) {
+    private fun updateBaseStatList(statsFromBuildings: StatTreeNode, statsFromSpecialists: Stats,
+                                   statsFromUniquesBySource: StatTreeNode) {
         val newBaseStatTree = StatTreeNode()
 
         // We don't edit the existing baseStatList directly, in order to avoid concurrency exceptions
@@ -444,15 +445,14 @@ class CityStats(val city: City) {
             production = city.population.getFreePopulation().toFloat()
         ), "Population")
         newBaseStatList["Tile yields"] = statsFromTiles
-        newBaseStatList["Specialists"] =
-            getStatsFromSpecialists(city.population.getNewSpecialists())
+        newBaseStatList["Specialists"] = statsFromSpecialists
         newBaseStatList["Trade routes"] = getStatsFromTradeRoute()
         newBaseStatTree.children["Buildings"] = statsFromBuildings
 
         for ((source, stats) in newBaseStatList)
             newBaseStatTree.addStats(stats, source)
 
-        newBaseStatTree.add(getStatsFromUniquesBySource())
+        newBaseStatTree.add(statsFromUniquesBySource)
         baseStatTree = newBaseStatTree
     }
     
@@ -493,8 +493,13 @@ class CityStats(val city: City) {
         // We need to compute Tile yields before happiness
 
         val statsFromBuildings = city.cityConstructions.getStats() // this is performance heavy, so calculate once
-        updateBaseStatList(statsFromBuildings)
-        updateCityHappiness(statsFromBuildings)
+        // Also performance-heavy, and previously computed twice with identical inputs (once inside
+        // updateBaseStatList, once inside updateCityHappiness) - only baseStatTree is assigned between
+        // the two, and neither reads it. Compute once and pass down.
+        val statsFromSpecialists = getStatsFromSpecialists(city.population.getNewSpecialists())
+        val statsFromUniquesBySource = getStatsFromUniquesBySource()
+        updateBaseStatList(statsFromBuildings, statsFromSpecialists, statsFromUniquesBySource)
+        updateCityHappiness(statsFromBuildings, statsFromSpecialists, statsFromUniquesBySource)
         updateStatPercentBonusList(currentConstruction)
 
         updateFinalStatList(currentConstruction, calculateGrowthModifiers) // again, we don't edit the existing currentCityStats directly, in order to avoid concurrency exceptions

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -92,18 +92,26 @@ class UnitMovement(val unit: MapUnit) {
         if (includeOtherEscortUnit && unit.isEscorting()
             && unit.getOtherEscortUnit()?.currentMovement == 0f) return distanceToTiles
 
+        // Loop-invariant across the whole search: escort state and the usable movement cap never change
+        // during one call, but were recomputed on every edge relaxation below.
+        val usableMovement = if (includeOtherEscortUnit && unit.isEscorting())
+            minOf(unitMovement, unit.getOtherEscortUnit()!!.currentMovement)
+        else unitMovement
+
         var tilesToCheck = listOf(unitTile)
-        
+
         while (tilesToCheck.isNotEmpty()) {
             val updatedTiles = ArrayList<Tile>()
-            for (tileToCheck in tilesToCheck)
+            for (tileToCheck in tilesToCheck) {
+                // Loop-invariant across this tile's neighbors: was looked up twice per neighbor below.
+                val tileToCheckMovement = distanceToTiles[tileToCheck]!!.totalMovement
                 for (neighbor in tileToCheck.neighbors) {
                     // ignore this tile
                     if (tilesToIgnoreBitset != null && tilesToIgnoreBitset.get(neighbor.zeroBasedIndex)) continue // ignore this tile
                     var totalDistanceToTile: Float = when {
                         !neighbor.isExplored(unit.civ) ->
-                            distanceToTiles[tileToCheck]!!.totalMovement + 1f  // If we don't know then we just guess it to be 1.
-                        
+                            tileToCheckMovement + 1f  // If we don't know then we just guess it to be 1.
+
                         !canPassThroughCache.getOrPut(neighbor.zeroBasedIndex){
                             canPassThrough(neighbor)
                         } -> unitMovement // Can't go here.
@@ -115,16 +123,12 @@ class UnitMovement(val unit: MapUnit) {
                             val movementCost = movementCostCache.getOrPut(key) {
                                 MovementCost.getMovementCostBetweenAdjacentTilesEscort(unit, tileToCheck, neighbor, considerZoneOfControl, includeOtherEscortUnit)
                             }
-                            distanceToTiles[tileToCheck]!!.totalMovement + movementCost
+                            tileToCheckMovement + movementCost
                         }
                     }
 
                     val currentBestPath = distanceToTiles[neighbor]
                     if (currentBestPath == null || currentBestPath.totalMovement > totalDistanceToTile) { // this is the new best path
-                        val usableMovement = if (includeOtherEscortUnit && unit.isEscorting())
-                            minOf(unitMovement, unit.getOtherEscortUnit()!!.currentMovement)
-                        else unitMovement
-
                         if (totalDistanceToTile < usableMovement - Constants.minimumMovementEpsilon)  // We can still keep moving from here!
                             updatedTiles += neighbor
                         else
@@ -135,6 +139,7 @@ class UnitMovement(val unit: MapUnit) {
                         distanceToTiles[neighbor] = ParentTileAndTotalMovement(neighbor, tileToCheck, totalDistanceToTile)
                     }
                 }
+            }
 
             tilesToCheck = updatedTiles
         }

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -280,7 +280,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (cityConstructions.isBuilt(name))
             yield(RejectionReasonType.AlreadyBuilt.toInstance())
 
-        if (isUnavailableBySettings(civ.gameInfo)) {
+        if (civ.gameInfo.isUnavailableBySettingsCached(this@Building)) {
             // Repeat the starting era test isHiddenBySettings already did to change the RejectionReasonType
             if (isHiddenByStartingEra(civ.gameInfo))
                 yield(RejectionReasonType.WonderDisabledEra.toInstance())

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -252,7 +252,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         if (civ.cache.uniqueUnits.any { it.replaces == name })
             yield(RejectionReasonType.ReplacedByOurUnique.toInstance("Our unique unit replaces this"))
 
-        if (isUnavailableBySettings(civ.gameInfo))
+        if (civ.gameInfo.isUnavailableBySettingsCached(this@BaseUnit))
             yield(RejectionReasonType.DisabledBySetting.toInstance())
 
         if (hasUnique(UniqueType.Unbuildable, stateForConditionals))


### PR DESCRIPTION
# Performance: three behavior-preserving hot-path optimizations

Three small, independent, **behavior-preserving** optimizations to code that shows up
prominently when profiling AI turns. Each produces bit-identical results — they only
remove redundant work — so there is no gameplay/balance risk. They're in separate commits
and can be reviewed (or taken) independently.

## How this was found

I profiled a headless, AI-only run of the engine with Java Flight Recorder (many thousands
of turns of pure `nextTurn` automation). The dominant CPU buckets were unit
movement/pathfinding (~37%), the uniques engine (~16%), and city-stat recomputation (~11%).
The three changes below each target a *specific* redundancy inside those buckets that the
profile made obvious. I've deliberately limited this PR to changes that are (a) provably
result-identical, (b) thread-safe under the game-thread/render-thread split, and (c) carry
no memory or mobile downside — see "Scope" at the end.

I haven't put a single headline percentage on these three because the engine's turn-to-turn
work varies enough between runs (different unit/battle counts) that isolating a sub-10% effect
isn't meaningful from my setup — but they're free wins on profiled hot paths, so they're worth
taking on correctness grounds alone. Happy to run any benchmark you'd prefer.

---

## 1. `CityStats`: compute specialist / unique-source stats once per update, not twice

`CityStats.update()` calls `updateBaseStatList(statsFromBuildings)` then
`updateCityHappiness(statsFromBuildings)`. **Both** of those internally recompute the same two
non-trivial values from scratch:

- `getStatsFromSpecialists(city.population.getNewSpecialists())`
- `getStatsFromUniquesBySource()`

`getStatsFromUniquesBySource()` in particular walks the city's matching uniques and clones a
`Stats` per source — it's one of the heavier things a city does each recalc, and cities recalc
often during AI turns.

**Why it's safe:** the only state written between the two call sites is `baseStatTree` (assigned
at the end of `updateBaseStatList`), and neither `getStatsFromSpecialists` nor
`getStatsFromUniquesBySource` reads it. So computing each once in `update()` and passing the
values into both functions yields identical results. `updateCityHappiness` keeps default-valued
parameters, so its one external caller (`GameInfo.setTransients`) compiles and behaves unchanged.

Effect: those two functions now run once per `update()` instead of twice.

## 2. `UnitMovement`: hoist loop-invariants out of the `getMovementToTilesAtPosition` BFS

The single-turn reachability BFS is called constantly by AI unit automation. Its inner loop
recomputed two values that never change during a search:

- `distanceToTiles[tileToCheck]!!.totalMovement` — a `LinkedHashMap` lookup performed up to
  **twice per neighbor** (once in the `!isExplored` branch, once in the cost branch). Hoisted to
  a single lookup per `tileToCheck`.
- the escort-adjusted `usableMovement` cap — recomputed inside the new-best-path branch on every
  relaxation (including an `isEscorting()` check and an escort-unit lookup). Hoisted to once per
  call.

**Why it's safe:** pure loop-invariant code motion. `tileToCheck`'s recorded movement is fixed
once it's dequeued into the current frontier, and the escort state / movement cap can't change
mid-search. Results are byte-identical.

## 3. `GameInfo`: memoize `IHasUniques.isUnavailableBySettings` per rule object

`isUnavailableBySettings` decides whether a building/unit is disabled by the current game
settings (victory types, difficulty, game speed, religion/espionage enabled, starting-era &
mod-option uniques). It is re-evaluated for every building and unit inside `getRejectionReasons`,
which the AI runs whenever it considers what to build — but its inputs are all **game-start
constants** that cannot change during a game.

This adds a per-`GameInfo` cache (`isUnavailableBySettingsCached`) and points the two
`getRejectionReasons` call sites (`Building`, `BaseUnit`) at it.

**Why it's safe:** the memoized value is a pure function of immutable game configuration, so the
first result is correct for the whole game. It's a `@Transient` field (never serialized; a loaded
game recomputes lazily). It uses a `ConcurrentHashMap` because `getRejectionReasons` is queried
from both the game thread and the render thread, and `computeIfAbsent` is atomic — no locking,
no torn reads. (Marked `@Cache` for the purity plugin.)

*If you'd rather not add a field to `GameInfo`, this commit is fully separable from the other two.*

---

## Scope — what I intentionally left out

I had a larger set of optimizations from the same profiling pass but excluded anything that isn't
unambiguously safe for the full game, specifically:

- **De-synchronizing `Tile.neighbors`** (`by lazy` → plain field): unsafe, since the GL thread
  reads neighbors while the game thread may still be initializing them.
- **A per-civ exploration bitset mirror of `Tile.exploredBy`**: would break the deliberate
  copy-on-write semantics of `exploredBy` that make `isExplored` lock-free for the render thread.
- **A per-tile ring cache for `getTilesAtDistance`**: same concurrency concern, plus a real memory
  cost on large maps / mobile.
- **Rewriting `UniqueMap.getMatchingUniques` from lazy sequences to eager lists**: touches code
  you're clearly already tuning (the `forEach…` variants), and the laziness already short-circuits
  for `.any()` callers, so the tradeoff deserves its own discussion rather than riding along here.

Glad to open any of those as separate, clearly-flagged proposals if you're interested.

---

### Test status
`./gradlew :core:compileKotlin` passes (incl. the purity plugin). All three are result-identical
by construction; no test expectations change.
