### PR TITLE
Document exact license of HexaRealm and Fantasy Hex

### DIFF
--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -9,9 +9,6 @@ The works listed in this document fall under various licenses. Here’s a list o
 * CC BY 4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
 * CC BY-SA 4.0 [Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)
 * Public domain: The work has been released into the public domain.
-* Unknown license: Unfortunately, the license this work was released under got lost to history.
-
-Please note that having an unknown license is incompatible with free software.
 
 ## Icon Credits
 
@@ -200,7 +197,7 @@ By Basil:
 
 ### HexaRealm
 
-Unless otherwise specified, Tile improvements and units, as well as the terrains and improvements for HexaRealm tileset, are made by The Bucketeer / @GeneralWadaling and are licenced under an unknown Creative Commons license (we only know it has version 3.0, but we don’t know *which* license specifically).
+Unless otherwise specified, tile improvements and units, as well as the terrains and improvements for HexaRealm tileset, are made by The Bucketeer / @GeneralWadaling and are licenced under CC BY-SA 3.0.
 
 
 HexaRealm tileset images by legacymtgsalvationuser69544 [here](https://github.com/legacymtgsalvationuser69544/Edges-Tileset):

--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -24,7 +24,7 @@ Flag Icons made by [Freepik](https://www.flaticon.com/authors/freepik) from [www
 
 New Unciv logo made by u-ndefined on Discord
 
-Base tile icons for the "Fantasy Hex" tileset belong to CuddlyClover @ https://cuddlyclover.itch.io/fantasy-hex-tiles with a few additions by various contributors
+The base tile icons for the "Fantasy Hex" tileset were created CuddlyClover at <https://cuddlyclover.itch.io/fantasy-hex-tiles> with a few additions by various contributors, licensed CC BY 4.0.
 
 Promotional trailer for Steam and other storefronts made by [letstalkaboutdune](https://github.com/letstalkaboutdune)
 


### PR DESCRIPTION
The goal of this PR is to update the `Credits.md` file to further clarify incomplete or missing license info to make sure this game can correctly claim to be fully free software. Hopefully this will be the last PR of this sort.

It documents the license of HexaRealm as CC BY-SA 3.0, based on information at <https://github.com/yairm210/Unciv/pull/15183#issuecomment-5001720611>.
It documents the license of Fantasy Hex as CC BY 4.0, as defined at <https://cuddlyclover.itch.io/fantasy-hex-tiles> (click on "More information" to reveal original license).

Another question: What is the licensing of this?:

> New Unciv logo made by u-ndefined on Discord

I assume the license for that would be CC BY 3.0 since the logo is based on the Stat icons, which are mostly CC BY 3.0). Correct?

(Off-topic:  Maybe it would help a lot in future to write down a "default content license" (probably CC BY or CC BY SA simply those are the most used free licenses in the project right now) that all future contributors must agree to when contributing. Otherwise problems like this will just keep happening. Or does that already exist and I did not see it? Anyway, not relevant for this PR)

(Off-topic 2: If you wonder why I have been annoying you so much with this license stuff lately: The answer is LibreGameWiki, which only accepts articles for fully libre games, and Unciv is currently rejected. My goal is to change that.)

----

Thanks, @GeneralWadaling.