### PR TITLE
Allow CitiesAreRazedXTimesFaster on units

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -145,9 +145,13 @@ class CityTurnManager(val city: City) {
         city.cityConstructions.endTurn(stats)
         city.expansion.nextTurn(stats.culture)
         if (city.isBeingRazed) {
-            val removedPopulation =
-                    1 + city.civ.getMatchingUniques(UniqueType.CitiesAreRazedXTimesFaster)
-                        .sumOf { it.params[0].toInt() - 1 }
+            val neighborUnits = city.getCenterTile()
+                .let { it.neighbors + it }
+                .flatMap { it.getUnits() }
+                .filter { it.civ == city.civ }
+            val razeUniques = city.civ.getMatchingUniques(UniqueType.CitiesAreRazedXTimesFaster) +
+                neighborUnits.flatMap { it.getMatchingUniques(UniqueType.CitiesAreRazedXTimesFaster) }
+            val removedPopulation = 1 + razeUniques.sumOf { it.params[0].toInt() - 1 }
 
             if (city.population.population <= removedPopulation) {
                 city.espionage.removeAllPresentSpies(SpyFleeReason.Other)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -297,7 +297,8 @@ enum class UniqueType(
     MayBuyConstructionsInPuppets("May buy items in puppet cities", UniqueTarget.Global),
     MayNotAnnexCities("May not annex cities", UniqueTarget.Global),
     BorrowsCityNames("\"Borrows\" city names from other civilizations in the game", UniqueTarget.Global),
-    CitiesAreRazedXTimesFaster("Cities are razed [amount] times as fast", UniqueTarget.Global),
+    CitiesAreRazedXTimesFaster("Cities are razed [amount] times as fast", UniqueTarget.Global, UniqueTarget.Unit,
+        docDescription = "When applied to a unit, it works when the unit belongs to the same civ and is present in the razing city or a neighbor tile"),
 
     TechBoostWhenScientificBuildingsBuiltInCapital("Receive a tech boost when scientific buildings/wonders are built in capital", UniqueTarget.Global),
     ResearchableMultipleTimes("Can be continually researched", UniqueTarget.Tech),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1036,9 +1036,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Global
 
 ??? example  "Cities are razed [amount] times as fast"
+	When applied to a unit, it works when the unit belongs to the same civ and is present in the razing city or a neighbor tile
+
 	Example: "Cities are razed [3] times as fast"
 
-	Applicable to: Global
+	Applicable to: Global, Unit
 
 ??? example  "Receive a tech boost when scientific buildings/wonders are built in capital"
 	Applicable to: Global
@@ -1980,6 +1982,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	This unique's effect can be modified with &lt;(modified by game speed)&gt;
 
 	Applicable to: Building, Unit, Improvement
+
+??? example  "Cities are razed [amount] times as fast"
+	When applied to a unit, it works when the unit belongs to the same civ and is present in the razing city or a neighbor tile
+
+	Example: "Cities are razed [3] times as fast"
+
+	Applicable to: Global, Unit
 
 ??? example  "Unbuildable"
 	Blocks from being built, possibly by conditional. However it can still appear in the menu and be bought with other means such as Gold or Faith


### PR DESCRIPTION
sic.

Works as designed, though I'm not entirely happy with it - 
- the original Unique suggests multiplicative stacking when it's actually a weird additive stacking
- the original Unique is lacking when it comes to slowing down a raze without stopping it
- the original Unique grows cities with negative amount
- I limit the candidate units hard-coded, because I don't know whether the same limitation could be done with conditionals
- the mechanics for a unit influencing razing could be something entirely different