### PR TITLE
Catch load from custom location exceptions

### DIFF
--- a/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
@@ -136,20 +136,31 @@ class LoadGameScreen : LoadOrSaveScreen() {
 
     private fun Table.addLoadFromCustomLocationButton() {
         val loadFromCustomLocationButton = loadFromCustomLocation.toTextButton()
-        loadFromCustomLocationButton.onClick {
+        loadFromCustomLocationButton.onActivation {
             errorLabel.isVisible = false
             loadFromCustomLocationButton.setText(Constants.loading.tr())
             loadFromCustomLocationButton.disable()
+            fun revertButton() {
+                loadFromCustomLocationButton.setText(loadFromCustomLocation.tr())
+                loadFromCustomLocationButton.enable()
+            }
             Concurrency.run(loadFromCustomLocation) {
                 game.files.loadGameFromCustomLocation(
-                    {
-                        Concurrency.run { game.loadGame(it, callFromLoadScreen = true) }
+                    onLoaded = { loadedGame ->
+                        Concurrency.run {
+                            try {
+                                game.loadGame(loadedGame, callFromLoadScreen = true)
+                            } catch (ex: Exception) {
+                                launchOnGLThread { handleLoadGameException(ex, "Could not load game from custom location!") }
+                            } finally {
+                                launchOnGLThread { revertButton() }
+                            }
+                        }
                     },
-                    {
-                        if (it !is PlatformSaverLoader.Cancelled)
-                            handleLoadGameException(it, "Could not load game from custom location!")
-                        loadFromCustomLocationButton.setText(loadFromCustomLocation.tr())
-                        loadFromCustomLocationButton.enable()
+                    onError = { ex ->
+                        if (ex !is PlatformSaverLoader.Cancelled)
+                            handleLoadGameException(ex, "Could not load game from custom location!")
+                        revertButton()
                     }
                 )
             }


### PR DESCRIPTION
### Steps to reproduce
- Get one of the saves in #15226
- Try to load it via "Load from custom location"
- See `CrashScreen` with cause **`UncivShowableException`**

### Before
<img width="1507" height="897" title="BOOM" src="https://github.com/user-attachments/assets/cbf838f9-9252-403d-a0eb-dfd3edd1b8a2" />

### After
<img width="1507" height="897" title="AAAH" src="https://github.com/user-attachments/assets/118913b3-9ca8-4a34-8a2b-f873381c4a36" />
