### PR TITLE
Freeze Demographics rankings to turn-start snapshots

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -30,6 +30,9 @@ class TurnManager(val civInfo: Civilization) {
 
         civInfo.threatManager.clear()
         if (civInfo.isMajorCiv() && civInfo.isAlive()) {
+            // Force uses a transient cache that is not invalidated on combat losses during
+            // other civs' turns; clear it so the turn-start demographics/charts snapshot is accurate.
+            civInfo.resetMilitaryMightCache()
             civInfo.statsHistory.recordRankingStats(civInfo)
         }
 

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
@@ -2,11 +2,13 @@ package com.unciv.ui.screens.victoryscreen
 
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.Constants
+import com.unciv.logic.civilization.Civilization
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.worldscreen.WorldScreen
 import kotlin.math.roundToInt
+import yairm210.purity.annotations.Readonly
 
 class VictoryScreenDemographics(
     worldScreen: WorldScreen
@@ -30,8 +32,10 @@ class VictoryScreenDemographics(
             add(rankLabel.name.toLabel())
 
             for (category in RankingType.entries) {
+                // Use turn-start snapshots so mid-turn army/economy changes cannot be used to
+                // probe Best/Worst values of other civilizations (see linked issue).
                 val aliveMajorCivsSorted = majorCivs.filter { it.isAlive() || it == playerCiv }
-                    .map { VictoryScreen.CivWithStat(it, category) }
+                    .map { VictoryScreen.CivWithStat(it, it.getStatForDemographics(category)) }
                     .sortedByDescending { it.value }
 
                 fun addRankCivGroup(civEntry: VictoryScreen.CivWithStat) {
@@ -48,6 +52,17 @@ class VictoryScreenDemographics(
                 }
             }
         }
+    }
+
+    /**
+     * Ranking value frozen at that civilization's last turn-start recording in [Civilization.statsHistory].
+     * Falls back to a live value only when no history exists yet (e.g. very early game).
+     */
+    @Readonly
+    private fun Civilization.getStatForDemographics(category: RankingType): Int {
+        val history = statsHistory
+        val snapshot = history[gameInfo.turns] ?: history.maxByOrNull { it.key }?.value
+        return snapshot?.get(category) ?: getStatForRanking(category)
     }
 
     private fun buildDemographicsHeaders() {


### PR DESCRIPTION
## Summary

Fixes Demographics mid-turn information leak by reading ranking values from each civ's **turn-start** `statsHistory` snapshot instead of live `getStatForRanking()`.

Also resets the military might cache before `recordRankingStats()` so Force in that snapshot is not stale after combat on other players' turns.

Closes #15237

## Motivation

`Best` / `Worst` expose exact values of the leading / trailing civ. A player who is currently #1 can temporarily drop their live stats, refresh Demographics, and learn the former #2's exact value. Freezing to turn-start stats blocks that probe without removing the Civ5-style layout.

## Alternatives considered

Not implemented here; listed for discussion:

1. **If you are Best/Worst, do not reveal the next civ's value** — when the viewing player is #1, `Best` shows only their own entry. Smallest UI change; does not address seeing #1's exact value while you are #2.
2. **Tighter Demographics when `showDemographics` is on** — only Rank + Value + Average (no Best/Worst, or no foreign exact numbers). Preserves vanilla Demographics elsewhere; suits competitive games that already use that option instead of full Rankings.

## Test plan

- [ ] Mid-game with Demographics visible: note Force Best/Value at turn start
- [ ] Disband enough units to fall behind another civ in live Force
- [ ] Reopen Demographics: Rank/Value/Best still match turn-start snapshot (you still appear as Best if you were Best at turn start)
- [ ] End turn / start next turn: Demographics updates to the new snapshot
- [ ] Charts / `statsHistory` still record as before
- [ ] Very early game with empty history still shows values (live fallback)
