### PR TITLE
Don't wipe city-state relations on liberation; Civ5 liberator influence

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -31,6 +31,11 @@ import kotlin.random.Random
 
 /** Helper class for containing 200 lines of "how to move cities between civs" */
 class CityConquestFunctions(val city: City) {
+    companion object {
+        const val MINOR_FRIENDSHIP_AT_WAR = -60f
+        const val MINOR_LIBERATION_FRIENDSHIP = 105f
+    }
+
     private val tileBasedRandom = Random(city.getCenterTile().position.hashCode())
 
     @Readonly
@@ -203,22 +208,6 @@ class CityConquestFunctions(val city: City) {
         }
 
         val foundingCiv = city.foundingCivObject!!
-        if (foundingCiv.isDefeated()) { // resurrected civ
-            for (diploManager in foundingCiv.diplomacy.values) {
-                if (diploManager.diplomaticStatus == DiplomaticStatus.War)
-                    diploManager.makePeace()
-
-                // Clear all diplomatic flags and modifiers to prevent asymmetry after resurrection
-                // The defeated civ's flags were frozen while other civs' flags continued to expire
-                // Perhaps some of this needs more dedicated treatment but it's a pretty rare case anyway
-                //   so I think starting from scratch is a good way to go 
-                diploManager.flagsCountdown.clear()
-                diploManager.otherCivDiplomacy().flagsCountdown.clear()
-                diploManager.diplomaticModifiers.clear()
-                diploManager.otherCivDiplomacy().diplomaticModifiers.clear()
-            }
-        }
-
         val oldCiv = city.civ
 
         diplomaticRepercussionsForLiberatingCity(conqueringCiv, oldCiv)
@@ -262,6 +251,22 @@ class CityConquestFunctions(val city: City) {
         val respectForLiberatingOurCity = 10f + percentageOfCivPopulationInThatCity.roundToInt()
 
         if (foundingCiv.isMajorCiv()) {
+            if (foundingCiv.isDefeated()) { // resurrected civ
+                for (diploManager in foundingCiv.diplomacy.values) {
+                    if (diploManager.diplomaticStatus == DiplomaticStatus.War)
+                        diploManager.makePeace()
+
+                    // Clear all diplomatic flags and modifiers to prevent asymmetry after resurrection
+                    // The defeated civ's flags were frozen while other civs' flags continued to expire
+                    // Perhaps some of this needs more dedicated treatment but it's a pretty rare case anyway
+                    //   so I think starting from scratch is a good way to go 
+                    diploManager.flagsCountdown.clear()
+                    diploManager.otherCivDiplomacy().flagsCountdown.clear()
+                    diploManager.diplomaticModifiers.clear()
+                    diploManager.otherCivDiplomacy().diplomaticModifiers.clear()
+                }
+            }
+
             // In order to get "plus points" in Diplomacy, you have to establish diplomatic relations if you haven't yet
             foundingCiv.getDiplomacyManagerOrMeet(conqueringCiv)
                 .addModifier(DiplomaticModifiers.CapturedOurCities, respectForLiberatingOurCity)
@@ -269,8 +274,17 @@ class CityConquestFunctions(val city: City) {
             openBordersTrade.currentTrade.ourOffers.add(TradeOffer(Constants.openBorders, TradeOfferType.Agreement, speed = conqueringCiv.gameInfo.speed))
             openBordersTrade.acceptTrade(false)
         } else {
-            foundingCiv.getDiplomacyManagerOrMeet(conqueringCiv).setInfluence(90f)
             // Liberating a city state gives a large amount of influence, and peace
+            // as per discussion in #15226 
+            val maxOtherInfluence = foundingCiv.diplomacy.values
+                .filter { it.otherCiv != conqueringCiv && it.otherCiv.isMajorCiv() && it.otherCiv.isAlive() }
+                .fold(MINOR_FRIENDSHIP_AT_WAR) { a, b -> a.coerceAtLeast(b.getInfluence()) }
+            val diplomacy = foundingCiv.getDiplomacyManagerOrMeet(conqueringCiv)
+            val liberatorOldInfluence = diplomacy.getInfluence()
+            val liberatorNewInfluence = maxOtherInfluence.coerceAtLeast(liberatorOldInfluence)
+                .plus(MINOR_LIBERATION_FRIENDSHIP)
+                .coerceAtLeast(60f)  // TODO that should be a const val, hardcoded in several places
+            diplomacy.setInfluence(liberatorNewInfluence)
             if (foundingCiv.isAtWarWith(conqueringCiv)) {
                 val tradeLogic = TradeLogic(foundingCiv, conqueringCiv)
                 tradeLogic.currentTrade.ourOffers.add(TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, speed = conqueringCiv.gameInfo.speed))

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -37,14 +37,14 @@ class CityConquestFunctions(val city: City) {
     private fun getGoldForCapturingCity(conqueringCiv: Civilization): Int {
         val baseGold = 20 + 10 * city.population.population + tileBasedRandom.nextInt(40)
         val turnModifier = max(0, min(50, city.civ.gameInfo.turns - city.turnAcquired)) / 50f
-        
+
         var cityModifier = 1f
-        for (unique in city.getMatchingUniques(UniqueType.GoldFromCapturingCity, city.state)) {
+        city.forEachMatchingUnique(UniqueType.GoldFromCapturingCity, city.state) { unique ->
             cityModifier *= unique.params[0].toPercent()
         }
 
         var conqueringCivModifier = 1f
-        for (unique in conqueringCiv.getMatchingUniques(UniqueType.GoldFromEncampmentsAndCities, conqueringCiv.state)) {
+        conqueringCiv.forEachMatchingUnique(UniqueType.GoldFromEncampmentsAndCities, conqueringCiv.state) { unique ->
             conqueringCivModifier *= unique.params[0].toPercent()
         }
 
@@ -155,7 +155,7 @@ class CityConquestFunctions(val city: City) {
         makePuppet()
         city.cityStats.update()
     }
-    
+
     private fun makePuppet(){
         city.isPuppet = true
         // The city could be producing something that puppets shouldn't, like units
@@ -258,19 +258,19 @@ class CityConquestFunctions(val city: City) {
     private fun diplomaticRepercussionsForLiberatingCity(conqueringCiv: Civilization, conqueredCiv: Civilization) {
         val foundingCiv = city.foundingCivObject!!
         val percentageOfCivPopulationInThatCity = city.population.population *
-                100f / (foundingCiv.cities.sumOf { it.population.population } + city.population.population)
+            100f / (foundingCiv.cities.sumOf { it.population.population } + city.population.population)
         val respectForLiberatingOurCity = 10f + percentageOfCivPopulationInThatCity.roundToInt()
 
         if (foundingCiv.isMajorCiv()) {
             // In order to get "plus points" in Diplomacy, you have to establish diplomatic relations if you haven't yet
             foundingCiv.getDiplomacyManagerOrMeet(conqueringCiv)
-                    .addModifier(DiplomaticModifiers.CapturedOurCities, respectForLiberatingOurCity)
+                .addModifier(DiplomaticModifiers.CapturedOurCities, respectForLiberatingOurCity)
             val openBordersTrade = TradeLogic(foundingCiv, conqueringCiv)
             openBordersTrade.currentTrade.ourOffers.add(TradeOffer(Constants.openBorders, TradeOfferType.Agreement, speed = conqueringCiv.gameInfo.speed))
             openBordersTrade.acceptTrade(false)
         } else {
-            //Liberating a city state gives a large amount of influence, and peace
             foundingCiv.getDiplomacyManagerOrMeet(conqueringCiv).setInfluence(90f)
+            // Liberating a city state gives a large amount of influence, and peace
             if (foundingCiv.isAtWarWith(conqueringCiv)) {
                 val tradeLogic = TradeLogic(foundingCiv, conqueringCiv)
                 tradeLogic.currentTrade.ourOffers.add(TradeOffer(Constants.peaceTreaty, TradeOfferType.Treaty, speed = conqueringCiv.gameInfo.speed))
@@ -282,7 +282,7 @@ class CityConquestFunctions(val city: City) {
         val otherCivsRespectForLiberating = (respectForLiberatingOurCity / 10).roundToInt().toFloat()
         for (thirdPartyCiv in conqueringCiv.getKnownCivs().filter { it.isMajorCiv() && it != conqueredCiv }) {
             thirdPartyCiv.getDiplomacyManager(conqueringCiv)!!
-                    .addModifier(DiplomaticModifiers.LiberatedCity, otherCivsRespectForLiberating) // Cool, keep at at! =D
+                .addModifier(DiplomaticModifiers.LiberatedCity, otherCivsRespectForLiberating) // Cool, keep at it! =D
         }
     }
 
@@ -353,7 +353,7 @@ class CityConquestFunctions(val city: City) {
         city.getTiles().forEach { tile ->
             tile.history.recordTakeOwnership(tile)
         }
-        
+
         city.resetDisabledConstructions()
 
         newCiv.cache.updateOurTiles()

--- a/tests/src/com/unciv/logic/civilization/diplomacy/DiplomacyManagerTests.kt
+++ b/tests/src/com/unciv/logic/civilization/diplomacy/DiplomacyManagerTests.kt
@@ -382,4 +382,46 @@ class DiplomacyManagerTests {
         assertEquals(expectedSciencePerTurnCivA * turns, b.tech.scienceFromResearchAgreements)
     }
 
+    @Test
+    fun `liberating city-state keeps third-party influence and applies Civ5 liberator formula`() {
+        // given — CS with varied influence; capture then liberate (resurrection)
+        val cityState = addCiv(cityStateType = "Militaristic")
+        val liberator = addCiv()
+        val conqueror = addCiv()
+        val ally = addCiv()
+        val rival = addCiv()
+
+        meet(liberator, cityState)
+        meet(conqueror, cityState)
+        meet(ally, cityState)
+        meet(rival, cityState)
+        meet(liberator, conqueror)
+        meet(liberator, ally)
+        meet(liberator, rival)
+
+        testGame.gameInfo.currentPlayerCiv = addCiv()
+        testGame.gameInfo.currentPlayer = testGame.gameInfo.currentPlayerCiv.civID
+
+        val csCity = testGame.addCity(cityState, testGame.getTile(HexCoord.Zero), initialPopulation = 2)
+        cityState.getDiplomacyManager(ally)!!.setInfluence(93f)
+        cityState.getDiplomacyManager(rival)!!.setInfluence(-20f)
+        cityState.getDiplomacyManager(liberator)!!.setInfluence(19f)
+
+        csCity.puppetCity(conqueror)
+        assertTrue(cityState.isDefeated())
+        assertEquals(93f, cityState.getDiplomacyManager(ally)!!.getInfluence(), 0.01f)
+        assertEquals(-20f, cityState.getDiplomacyManager(rival)!!.getInfluence(), 0.01f)
+
+        // when
+        csCity.liberateCity(liberator)
+
+        // then — third parties unchanged (no full diplo wipe); liberator gets Civ5-style bonus
+        assertFalse(cityState.isDefeated())
+        assertEquals(cityState, csCity.civ)
+        assertEquals(93f, cityState.getDiplomacyManager(ally)!!.getInfluence(), 0.01f)
+        assertEquals(-20f, cityState.getDiplomacyManager(rival)!!.getInfluence(), 0.01f)
+        // max(max(-60, 93, -20), 19) + 105 = 93 + 105 = 198
+        assertEquals(198f, cityState.getDiplomacyManager(liberator)!!.getInfluence(), 0.01f)
+    }
+
 }


### PR DESCRIPTION
## Motivation

Fixes #15226: liberating a defeated City-State was wiping **all** diplomacy (same path as major-civ resurrection), then applying a flat `setInfluence(90f)` for the liberator. Third-party influence/modifiers were lost.

Based on experiments by @SomeTroglodyte — see discussion on #15226 and his branch `LiberateCityStateRelations`.

## Summary

- Scope the full diplomacy wipe (flags/modifiers/peace) to **major** civ resurrection only — city-states keep prior third-party relations when liberated.
- Replace flat `setInfluence(90f)` for CS liberation with the Civ5 BNW liberator formula from `DoLiberationByMajor`:
  - `maxOther = max(-60, influence of other alive majors)`
  - liberator = `max(maxOther, liberatorOld) + 105`, floored at allies threshold (`60`)
- No conqueror-team → `-60` (Unciv has no teams).

## Testing

- [ ] Liberate a CS that had varied influence with several majors: third parties preserved (ally/enemy standings not wiped).
- [ ] Liberator influence rises per formula (at least ally threshold; never below prior + bonus vs max other).
- [ ] Liberating / resurrecting a **major** civ still clears frozen diplo flags/modifiers as before.
- [ ] Production saves from #15226 (Harappa T121→T122) if available: Inca liberator + retained Belgium/etc. standings.
