### PR TITLE
perf: improve fps in technology picker screen by adding culling

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -2,7 +2,6 @@ package com.unciv.ui.screens.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.Batch
-import com.badlogic.gdx.math.Rectangle
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Label
@@ -57,21 +56,8 @@ class TechPickerScreen(
      *  leaving us the juicy small tech tree right in the center.
      */
     private val techTable = object : Table(){
-        private val childCullingArea = Rectangle()
-
         override fun draw(batch: Batch?, parentAlpha: Float) {
-            val parentTable = parent as? Table
-            val parentCulling = parentTable?.cullingArea
-            if (parentCulling == null) {
-                cullingArea = null
-            } else {
-                val cell = parentTable.getCell(this)
-                val offsetX = cell?.actorX ?: 0f
-                val offsetY = cell?.actorY ?: 0f
-                childCullingArea.set(parentCulling.x - offsetX, parentCulling.y - offsetY,
-                    parentCulling.width, parentCulling.height)
-                cullingArea = childCullingArea
-            }
+            cullingArea = topTable.cullingArea
             super.draw(batch, parentAlpha)
         }
     }

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -2,10 +2,12 @@ package com.unciv.ui.screens.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.Batch
+import com.badlogic.gdx.math.Rectangle
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.GUI
@@ -43,8 +45,8 @@ class TechPickerScreen(
     private var selectedTech: Technology? = null
     private var civTech: TechManager = civInfo.tech
     private var tempTechsToResearch: ArrayList<String>
-    private var lines = NonTransformGroup()
-    private var orderIndicators = NonTransformGroup()
+    private var lines = NonTransformGroup().apply { touchable = Touchable.disabled }
+    private var orderIndicators = NonTransformGroup().apply { touchable = Touchable.disabled }
     private var eraLabels = ArrayList<Label>()
 
     /** We need this to be a separate table, and NOT the topTable, because *inhales*
@@ -55,7 +57,23 @@ class TechPickerScreen(
      *  leaving us the juicy small tech tree right in the center.
      */
     private val techTable = object : Table(){
-        override fun draw(batch: Batch?, parentAlpha: Float) = super.draw(batch, parentAlpha)
+        private val childCullingArea = Rectangle()
+
+        override fun draw(batch: Batch?, parentAlpha: Float) {
+            val parentTable = parent as? Table
+            val parentCulling = parentTable?.cullingArea
+            if (parentCulling == null) {
+                cullingArea = null
+            } else {
+                val cell = parentTable.getCell(this)
+                val offsetX = cell?.actorX ?: 0f
+                val offsetY = cell?.actorY ?: 0f
+                childCullingArea.set(parentCulling.x - offsetX, parentCulling.y - offsetY,
+                    parentCulling.width, parentCulling.height)
+                cullingArea = childCullingArea
+            }
+            super.draw(batch, parentAlpha)
+        }
     }
 
     // All these are to counter performance problems when updating buttons for all techs.
@@ -351,6 +369,8 @@ class TechPickerScreen(
 
         lines.children.filter { it.color == currentTechColor && it.color != Color.WHITE.cpy() }
             .forEach { it.toFront() }
+
+        lines.setSize(techTable.width, techTable.height)
     }
 
     private fun addOrderIndicators() {
@@ -370,6 +390,7 @@ class TechPickerScreen(
             }
         }
         orderIndicators.toFront()
+        orderIndicators.setSize(techTable.width, techTable.height)
     }
 
     private fun selectTechnology(tech: Technology?, queue: Boolean = false, center: Boolean = false, switchFromWorldScreen: Boolean = true) {


### PR DESCRIPTION
I did this pull request because my brother complained about low fps in technology screen on his low-end phone.

Current (stable) implementation of tech picker redraws every tech button every frame, including the ones scrolled off screen.
Although technically `ScrollPane` already computes a correct `cullingArea`, it sets it only on its direct widget `topTable`, so culling gets no-opped because `Group.drawChildren` culls only direct children against that rectangle.
This commit moves the culling rectangle one level down - `techTable.draw()` copies `cullingArea` of `topTable` into its own so small (centered) mod trees cull.

Few notes about PR
- Why I am reading the offset from the `Cell` and not `this.x/this.y`
In `Group`, `drawChildren` bakes the scroll offset into each child's x/y for the duration of the `draw()` call. 
Reading `this.x/y` makes the cull window drift with the scroll so content of the window disappears.
  
- Why `setSize` on `lines` / `orderIndicators`
They hold absolutely-positioned children and report a 0x0 bounding box, so culling would drop each group wholesale the instant it scrolled past the origin. 
Sizing them to span the table keeps them drawn (their children have no culling area of their own).
I also have set `Touchable.disabled` for them - they cover the whole tree, so without it they would intercept clicks meant for the buttons under them.

After this change fps improved from 15 to 78 (measured via SurfaceFlinger timestamps).
Small trees are centered and don't scroll so everything stays inside the window.
Large/modded trees cull more, so they benefit even more. When `ScrollPane` sets no culling area, the code falls back to `cullingArea = null` (draw everything, in other words previous behavior).

---------------------------------
Although I tested this in real game and a few edge cases, please test and review this thoroughly because I am a little bit bad at Kotlin lol
I didn't bother searching through commit/PRs/issues history to see if this was dealed before, so I would like to have some information if this would given a thought before
@yairm210 @SomeTroglodyte
- shwwwa