### PR TITLE
feat(i18n): complete missing Spanish translations for diplomacy, chat and UI

### DIFF
--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -144,12 +144,9 @@ Cancel = Cancelar
 
 Diplomacy = Diplomacia
 War = Guerra
- # Requires translation!
-DECLARATION OF WAR = 
- # Requires translation!
-DECLARATION OF FRIENDSHIP = 
- # Requires translation!
-DENOUNCEMENT = 
+DECLARATION OF WAR = DECLARACIÓN DE GUERRA
+DECLARATION OF FRIENDSHIP = DECLARACIÓN DE AMISTAD
+DENOUNCEMENT = DENUNCIA
 Peace = Paz
 Research Agreement = Acuerdo de Investigación
 Declare war = Declarar la guerra
@@ -178,10 +175,8 @@ Indeed! = ¡Por supuesto!
 Denounce [civName]? = ¿Denunciar a [civName]? 
 Denounce ([numberOfTurns] turns) = Denunciar ([numberOfTurns] ⏳turnos)
 We will remember this. = Recordaremos esto.
- # Requires translation!
-You have violated our bond of trust. This is intolerable! = 
- # Requires translation!
-You are a scourge upon this earth. I denounce you! = 
+You have violated our bond of trust. This is intolerable! = Has violado nuestro vínculo de confianza. ¡Esto es intolerable!
+You are a scourge upon this earth. I denounce you! = Eres una plaga sobre esta tierra. ¡Te denuncio!
 
 [civName] has declared war on [targetCivName]! = ¡[civName] ha declarado la guerra a [targetCivName]!
 # Join War
@@ -297,16 +292,11 @@ Hostile = Hostil
 Irrational = Irracional
 Personality = Personalidad
 Influence = Influencia
- # Requires translation!
-[leader]'s personality = 
- # Requires translation!
-Neutral personality = 
- # Requires translation!
-Preferred victory type: [victoryType] = 
- # Requires translation!
-Policy priorities: = 
- # Requires translation!
-Biases: = 
+[leader]'s personality = Personalidad de [leader]
+Neutral personality = Personalidad neutral
+Preferred victory type: [victoryType] = Tipo de victoria preferida: [victoryType]
+Policy priorities: = Prioridades de políticas:
+Biases: = Tendencias:
 
 Ally: [civilization] with [amount] Influence = Aliado: [civilization] con [amount] de Influencia
 Unknown civilization = Civilización Desconocida
@@ -445,16 +435,11 @@ Raging Barbarians = Bárbaros Furiosos
 No Ancient Ruins = Sin Ruinas Antiguas
 No Natural Wonders = Sin Maravillas Naturales
 Allow anyone to spectate = Permitir a cualquiera observar
- # Requires translation!
-Show Civilization Stats = 
- # Requires translation!
-Show Rankings = 
- # Requires translation!
-Show Demographics = 
- # Requires translation!
-Show Charts = 
- # Requires translation!
-Restrict to own civilization = 
+Show Civilization Stats = Mostrar estadísticas de la civilización
+Show Rankings = Mostrar clasificaciones
+Show Demographics = Mostrar demografía
+Show Charts = Mostrar gráficos
+Restrict to own civilization = Restringir a la propia civilización
 Victory Conditions = Condiciones de Victoria
 Scientific = Científica
 Domination = Dominación
@@ -495,8 +480,7 @@ Resource richness = Recursos
 Vegetation richness = Vegetación
 Rare features richness = Características raras
 Max Coast extension = Extensión de Costa
- # Requires translation!
-Biome size = 
+Biome size = Tamaño de bioma
 Water level = Nivel del agua
 
 Online Multiplayer = Multijugador en Línea
@@ -506,17 +490,14 @@ Don't show again = No mostrar de nuevo
 
 World Size = Tamaño
 Enabled World Sizes = Tamaños
- # Requires translation!
-Micro = 
+Micro = Micro
 Tiny = Diminuto
 Small = Pequeño
 Medium = Mediano
 Large = Grande
 Huge = Enorme
- # Requires translation!
-FullHD = 
- # Requires translation!
-QuadHD = 
+FullHD = FullHD
+QuadHD = QuadHD
 World wrap requires a minimum width of 32 tiles = El mapa envolvente requiere un ancho mínimo de 32 casillas
 The provided map dimensions were too small = Las dimensiones del mapa son muy pequeñas
 The provided map dimensions were too big = Las dimensiones del mapa son muy grandes
@@ -540,12 +521,9 @@ Epic = Épica
 Marathon = Maratón
 
 Starting Era = Era Inicial
- # Requires translation!
-any era = 
- # Requires translation!
-pre-[era] = 
- # Requires translation!
-post-[era] = 
+any era = cualquier era
+pre-[era] = pre-[era]
+post-[era] = post-[era]
 It looks like we can't make a map with the parameters you requested! = ¡Parece que no se puede crear un mapa con los parámetros especificados!
 Maybe you put too many players into too small a map? = ¿Quizá haya demasiados jugadores para un mapa tan pequeño?
 No human players selected! = ¡No se han seleccionado jugadores humanos!
@@ -755,28 +733,19 @@ You are not allowed to spectate! = ¡No tienes permitido observar!
 Couldn't download the latest game state! = ¡No se pudo descargar el último estado de la partida!
 
 ## Chat
- # Requires translation!
-Chat = 
- # Requires translation!
-System = 
- # Requires translation!
-Server = 
+Chat = Chat
+System = Sistema
+Server = Servidor
 # Unknown = is under Overview screens
  # Requires translation!
 one time = 
- # Requires translation!
-Welcome to Chat! = 
- # Requires translation!
-Successfully connected to WebSocket server! = 
- # Requires translation!
-Authentication issue detected! You have to set a password to use Chat. = 
- # Requires translation!
-Type something... = 
+Welcome to Chat! = ¡Bienvenido al chat!
+Successfully connected to WebSocket server! = ¡Conectado exitosamente al servidor WebSocket!
+Authentication issue detected! You have to set a password to use Chat. = ¡Problema de autenticación detectado! Debes establecer una contraseña para usar el chat.
+Type something... = Escribe algo...
 
- # Requires translation!
-Error: [error] = 
- # Requires translation!
-WebSocket connection closed. Cause: [cause] = 
+Error: [error] = Error: [error]
+WebSocket connection closed. Cause: [cause] = Conexión de WebSocket cerrada. Causa: [cause]
 
 
 ## Resign button
@@ -788,19 +757,14 @@ You can only resign if it's your turn = Solo puedes rendirte si es tu turno
 ## Force resign button
 Force current player to resign = Forzar al jugador actual a rendirse
 Are you sure you want to force the current player ([civName]) to resign? = ¿Estás seguro de que deseas forzar al jugador actual ([civName]) a rendirse?
- # Requires translation!
-[civName] was forcibly resigned by [responsible] and is now controlled by AI = 
+[civName] was forcibly resigned by [responsible] and is now controlled by AI = [civName] fue obligado a rendirse por [responsible] y ahora es controlado por la IA
 
 Skip turn of current player = Saltarse el turno del jugador que le toca
 Are you sure you want to skip the turn of [civName]? = ¿Estás seguro de que deseas forzar al jugador actual ([civName]) a pasar su turno?
- # Requires translation!
-[civName] skipped their own turn = 
- # Requires translation!
-[civName]'s turn was skipped by [responsible] = 
- # Requires translation!
-Could not skip turn - current player is [actualCivName], not [expectedCivName] = 
- # Requires translation!
-The game was out of sync with the server = 
+[civName] skipped their own turn = [civName] pasó su propio turno
+[civName]'s turn was skipped by [responsible] = El turno de [civName] fue pasado por [responsible]
+Could not skip turn - current player is [actualCivName], not [expectedCivName] = No se pudo pasar el turno: el jugador actual es [actualCivName], no [expectedCivName]
+The game was out of sync with the server = La partida no estaba sincronizada con el servidor
 
 Last refresh: [duration] ago = Última recarga hace: [duration]
 Current Turn: [civName] since [duration] ago = ⏳Turno actual: [civName] hace [duration]
@@ -881,8 +845,7 @@ Options = Opciones
 ## About tab
 About = Acerca
 Version = Versión
- # Requires translation!
-[version] (Build [number]) = 
+[version] (Build [number]) = [version] (Compilación [number])
 See online Readme = Ver "Léeme" en línea
 Visit repository = Visitar repositorio
 Visit the wiki = Visita la wiki
@@ -927,8 +890,7 @@ Reset tutorials = Reiniciar tutoriales
 Do you want to reset completed tutorials? = ¿Quiere reiniciar los tutoriales completados?
 Reset = Reiniciar
 
- # Requires translation!
-Show long-press indicators = 
+Show long-press indicators = Mostrar indicadores de pulsación larga
 Show zoom buttons in world screen = Mostrar Botones para Zoom del Mapa
 Experimental = Experimental
 Animate Unit movement button = Animar el botón de movimiento de unidad
@@ -960,16 +922,14 @@ Gameplay = Jugabilidad
 Check for idle units = Verificar Unidades inactivas
 'Next unit' button cycles idle units = El botón de 'Siguiente unidad' activa y desactiva las unidades inactivas
 Auto Unit Cycle = Ciclo Aut. de Unidades
- # Requires translation!
-Alternate Unit cycle order = 
+Alternate Unit cycle order = Orden alternativo de ciclo de unidades
 Show Small Skip/Cycle Unit Button = Mostrar pequeño botón de salto/ciclo unidad 
 Move units with a single tap = Mover Unidades con un solo toque
 Move units with a long tap = Mover unidades con toque prolongado
 Auto-assign city production = Construcción Automática en las Ciudades
 Auto-build roads = Construir carreteras autom.
 Automated workers replace improvements = Los Trabajadores aut. Reemplazan Mejoras
- # Requires translation!
-Stop automated workers from removing vegetation terrain = 
+Stop automated workers from removing vegetation terrain = Evitar que los trabajadores automatizados eliminen terreno de vegetación
 Automated units move on turn start = Unidades Automatizadas se mueven al principio del Turno
 Automated units can upgrade = Unidades automatizadas se mejoran solas
 Automated units choose promotions = Unidades automatizadas escogen sus promociones
@@ -997,10 +957,8 @@ Music = Música
 Currently playing: [title] = Reproduciendo actualmente: [title]
 Download music = Descargar música
 Downloading... = Descargando...
- # Requires translation!
-Extracting... = 
- # Requires translation!
-Finishing... = 
+Extracting... = Extrayendo...
+Finishing... = Finalizando...
 Could not download music! = ¡No se pudo descargar la música!
 —Paused— = —Pausado—
 —Default— = —Defecto—
@@ -1009,13 +967,10 @@ Could not download music! = ¡No se pudo descargar la música!
 ## Advanced tab
 Advanced = Avanzado
 Number of autosave files stored = Número de archivos de guardado automático almacenados
- # Requires translation!
-Autosave turns must be larger than 0! = 
- # Requires translation!
-Autosave turns over 200 may take a lot of space on your device. = 
+Autosave turns must be larger than 0! = ¡Los turnos de autoguardado deben ser mayores que 0!
+Autosave turns over 200 may take a lot of space on your device. = Los turnos de autoguardado superiores a 200 pueden ocupar mucho espacio en tu dispositivo.
 Turns between autosaves = ⏳Turnos entre autoguardados
- # Requires translation!
-Enter = 
+Enter = Intro
 
 Screen orientation = Orientación de Pantalla
 Landscape (fixed) = Horizontal (fijo)
@@ -1026,27 +981,19 @@ Hide system status and navigation bars = Ocultar estatus de sistema y barra de n
 Font family = Tipos de Fuente
 Font size multiplier = Escala de la Fuente
 Default Font = Fuente predeterminada
- # Requires translation!
-Long press delay = 
- # Requires translation!
-Double tap interval = 
- # Requires translation!
-Test area = 
- # Requires translation!
-Single tap = 
- # Requires translation!
-Right-click = 
- # Requires translation!
-Double-click = 
- # Requires translation!
-Long press = 
+Long press delay = Retraso de pulsación larga
+Double tap interval = Intervalo de doble toque
+Test area = Área de prueba
+Single tap = Un toque
+Right-click = Clic derecho
+Double-click = Doble clic
+Long press = Pulsación larga
 
 Max zoom out = Alejado de cámara máximo 
 Enable Easter Eggs = Activar "Huevos de Pascua"
 Enable Scenarios (experimental) = Activar Escenarios (experimental)
 Enlarge selected notifications = Expandir notificaciones seleccionadas
- # Requires translation!
-Enable experimental A* pathing = 
+Enable experimental A* pathing = Activar ruta A* experimental
 
 Generate translation files = Generar archivos de traducción
 Translation files are generated successfully. = Archivos de traducción generados correctamente.
@@ -1126,13 +1073,10 @@ The city of [cityname] has started constructing [construction]! = ¡La ciudad de
 Your Golden Age has ended. = Tu Edad de Oro ha terminado.
 [cityName] has been razed to the ground! = ¡[cityName] ha sido arrasada hasta los cimientos!
 We have conquered the city of [cityName]! = ¡Hemos conquistado la ciudad de [cityName]!
- # Requires translation!
-We have destroyed the city of [cityName]! = 
+We have destroyed the city of [cityName]! = ¡Hemos destruido la ciudad de [cityName]!
 Your citizens are revolting due to very high unhappiness! = ¡Tus ciudadanos se están rebelando debido a una infelicidad muy alta!
- # Requires translation!
-[1] [unit] has rebelled against us! = 
- # Requires translation!
-[amount] [unit] unit(s) has rebelled against us! = 
+[1] [unit] has rebelled against us! = ¡[1] [unit] se ha rebelado contra nosotros!
+[amount] [unit] unit(s) has rebelled against us! = ¡[amount] unidad(es) de [unit] se han rebelado contra nosotros!
 Connect road cancelled! = ¡Conexión de carretera cancelada!
 
 # Battle messages


### PR DESCRIPTION
Completa las traducciones faltantes en español para Unciv (diplomacia, chat, opciones y notificaciones) siguiendo el contexto de estrategia 4X.