### PR TITLE
Font fallback rendering glyphs

### DIFF
--- a/android/src/com/unciv/app/AndroidFont.kt
+++ b/android/src/com/unciv/app/AndroidFont.kt
@@ -30,6 +30,15 @@ class AndroidFont : FontImplementation {
     private val paint: Paint = getPaintInstance()
     private var currentFontFamily: String? = null
 
+    /** Scratch Paint used both to test glyph coverage (via [Paint.hasGlyph]) and, when the
+     *  configured font lacks a glyph, to actually render the substituted fallback glyph.
+     *  Kept entirely separate from [paint] so the primary/configured font's state - which
+     *  the public [getMetrics] override reads, e.g. for line-height layout - is never
+     *  touched by fallback handling. */
+    private val fallbackPaint: Paint = getPaintInstance().apply {
+        typeface = Typeface.DEFAULT
+    }
+
     private fun getPaintInstance() = Paint().apply {
         isAntiAlias = true
         strokeWidth = 0f
@@ -82,17 +91,23 @@ class AndroidFont : FontImplementation {
         if (!name.startsWith("$family-")) return Int.MAX_VALUE
         if (style.weight == FontStyle.FONT_WEIGHT_NORMAL && style.slant == FontStyle.FONT_SLANT_UPRIGHT) return 1
         return 2 +
-                abs(style.weight - FontStyle.FONT_WEIGHT_NORMAL) / 100 +
-                abs(style.slant - FontStyle.FONT_SLANT_UPRIGHT)
+            abs(style.weight - FontStyle.FONT_WEIGHT_NORMAL) / 100 +
+            abs(style.slant - FontStyle.FONT_SLANT_UPRIGHT)
     }
 
-    override fun getFontSize(): Int {
-        return paint.textSize.toInt()
-    }
+    override fun getFontSize() = paint.textSize.toInt()
 
     override fun getCharPixmap(symbolString: String): Pixmap {
-        val metric = getMetrics()  // Use our interpretation instead of paint.fontMetrics because it fixes some bad metrics
-        var width = paint.measureText(symbolString).toInt()
+        return if (useFallbackFor(symbolString)) {
+            fallbackPaint.textSize = paint.textSize
+            renderPixmap(symbolString, fallbackPaint, getFallbackMetrics())
+        } else {
+            renderPixmap(symbolString, paint, getMetrics())
+        }
+    }
+
+    private fun renderPixmap(symbolString: String, renderPaint: Paint, metric: FontMetricsCommon): Pixmap {
+        var width = renderPaint.measureText(symbolString).toInt()
         var height = ceil(metric.height).toInt()
         if (width == 0) {
             height = getFontSize()
@@ -101,7 +116,7 @@ class AndroidFont : FontImplementation {
 
         val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
-        canvas.drawText(symbolString, 0f, metric.leading + metric.ascent + 1f, paint)
+        canvas.drawText(symbolString, 0f, metric.leading + metric.ascent + 1f, renderPaint)
 
         val pixmap = Pixmap(width, height, Pixmap.Format.RGBA8888)
         val data = IntArray(width * height)
@@ -113,6 +128,23 @@ class AndroidFont : FontImplementation {
         }
         bitmap.recycle()
         return pixmap
+    }
+
+    /**
+     * Tests whether a symbol should fall back to [Typeface.DEFAULT] rendering.
+     *
+     * On API<23, we can't test and say "no fallback".
+     * Order: configured font -> plain system default -> give up (tofu).
+     * The "system default" tier covers the case of a mod font deliberately scoped
+     * to only a few special glyphs, which needs somewhere to fall back to for the
+     * ordinary Latin/UI text it was never meant to cover.
+     */
+    private fun useFallbackFor(symbolString: String): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
+            return false // Can't test coverage pre-23; accept possible tofu on old devices.
+        if (paint.hasGlyph(symbolString)) return false
+        if (paint.typeface === Typeface.DEFAULT) return false
+        return fallbackPaint.hasGlyph(symbolString)
     }
 
     override fun getSystemFonts(): Sequence<FontFamilyData> {
@@ -147,39 +179,48 @@ class AndroidFont : FontImplementation {
             .map { FontFamilyData(it, it) }
     }
 
-    override fun getMetrics(): FontMetricsCommon {
-        val ascent = -paint.fontMetrics.ascent  // invert to get distance
-        val descent = paint.fontMetrics.descent
-        val top = -paint.fontMetrics.top  // invert to get distance
-        val bottom = paint.fontMetrics.bottom
+    override fun getMetrics() =
+        computeMetrics(paint.fontMetrics)
+
+    /** Metrics for the fallback typeface, used only while rendering a substituted glyph.
+     *  Relies on fallbackPaint already being configured with the Typeface and size.
+     */
+    private fun getFallbackMetrics() =
+        computeMetrics(fallbackPaint.fontMetrics)
+
+    // Corrections: Some Android fonts report bullshit
+    // Examples: "ComingSoon" and "NotoSansSymbols" fonts on Android "S"
+    // See https://github.com/yairm210/Unciv/issues/10308
+
+    // Hardcode values for the worst of them - I've seen NotoSansSymbols returning (42.4, 11.1, 68.1, 11.1),
+    // or (53.4, 14.6, 117.7, 28.8): looks off, or (53.4, 14.6, 53.4, -11.1) - top below ascent
+    // By discarding and re-instantiating our Paint instance on every setFontFamily you can get Noto to almost,
+    // but not quite, report exclusively the "off" metrics. Curiously, soft start (Unciv exited through its own dialog,
+    // but not removed from android's "recents list") or hard start (dev-tools kill, reinstall or swipe out of recents)
+    // do seem to have an effect on the metrics reported by Noto (and only by Noto), though I haven't been able to
+    // prove a reliable pattern. These hardcoded values are empiric.
+    private fun computeMetrics(rawMetrics: Paint.FontMetrics): FontMetricsCommon {
+        val ascent = -rawMetrics.ascent  // invert to get distance
+        val descent = rawMetrics.descent
+        val top = -rawMetrics.top  // invert to get distance
+        val bottom = rawMetrics.bottom
         val height = top + bottom
         val leading = top - ascent
         val ascentDescentHeight = ascent + descent
 
-        // Corrections: Some Android fonts report bullshit
-        // Examples: "ComingSoon" and "NotoSansSymbols" fonts on Android "S"
-        // See https://github.com/yairm210/Unciv/issues/10308
-
-        // Hardcode values for the worst of them - I've seen NotoSansSymbols returning (42.4, 11.1, 68.1, 11.1),
-        // or (53.4, 14.6, 117.7, 28.8): looks off, or (53.4, 14.6, 53.4, -11.1) - top below ascent
-        // By discarding and re-instantiating our Paint instance on every setFontFamily you can get Noto to almost,
-        // but not quite, report exclusively the "off" metrics. Curiously, soft start (Unciv exited through its own dialog,
-        // but not removed from android's "recents list") or hard start (dev-tools kill, reinstall or swipe out of recents)
-        // do seem to have an effect on the metrics reported by Noto (and only by Noto), though I haven't been able to
-        // prove a reliable pattern. These hardcoded values are empiric.
         if (currentFontFamily == "NotoSansSymbols")
             return FontMetricsCommon(53.4f, 14.6f, 100f, 33f)
 
         if (height >= 1.02f * ascentDescentHeight)
-            // maximum dimensions at least 2% larger than recommended ascender top to descender bottom distance:
-            // looks sensible, keep those metrics
+        // maximum dimensions at least 2% larger than recommended ascender top to descender bottom distance:
+        // looks sensible, keep those metrics
             return FontMetricsCommon(ascent, descent, height, leading)
 
         // When recommended size equals maximum size...
         if (height >= 0.98f * ascentDescentHeight)
-            // "ComingSoon" reports top==ascent and bottom==descent: give it some room.
-            // Note: It still looks way off with all virtual leading at the top, but that's unavoidable -
-            // it **really has** those monster descenders (the 'y') and you gotta put them somewhere.
+        // "ComingSoon" reports top==ascent and bottom==descent: give it some room.
+        // Note: It still looks way off with all virtual leading at the top, but that's unavoidable -
+        // it **really has** those monster descenders (the 'y') and you gotta put them somewhere.
             return FontMetricsCommon(ascent, descent, ascentDescentHeight * 1.25f, ascentDescentHeight * 0.25f)
 
         // recommended size bigger than maximum size - O|O - swap inner and outer metrics

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -168,16 +168,18 @@ internal class AdvancedTab(
     }
 
     private fun addFontFamilySelect() {
+        // What both java.awt.Font.createFont and android.graphics.Typeface.createFromFile support:
+        val supportedExtensions = setOf("ttf", "otf")
+
         /** Build provider for [addAsyncSelectBox]: per-mod scan */
         @Suppress("NewApi")
         fun loadModFonts(mod: Path) = flow {
-            kotlin.io.path.fileVisitor {  }
             if (!mod.isDirectory()) return@flow
             val fontsPath = mod.resolve("fonts")
             if (!fontsPath.exists() || !fontsPath.isDirectory()) return@flow
             java.nio.file.Files.list(fontsPath).use { stream->
                 for (file in stream) {
-                    if (file.extension.lowercase() != "ttf") continue
+                    if (file.extension.lowercase() !in supportedExtensions) continue
                     emit(FontFamilyData(
                         "${file.nameWithoutExtension} (${mod.name})",
                         file.nameWithoutExtension,

--- a/desktop/src/com/unciv/app/desktop/DesktopFont.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopFont.kt
@@ -20,37 +20,38 @@ class DesktopFont : FontImplementation {
     private lateinit var font: Font
     private lateinit var metric: FontMetrics
 
+    // Note that these are all size 1
+    private val allFontsCache by lazy {
+        GraphicsEnvironment.getLocalGraphicsEnvironment().allFonts
+    }
+
+    // Keyed by the size-1 font instances, payload size-X derived fonts
+    private val successfulFallbackFonts = LinkedHashMap<Font, Pair<Font, FontMetrics>>()
+
+    // Theoretically needs dispose, it's still the more efficient compromise to keep it for the lifetime
+    private val metricsProbeGraphics =
+        BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR).createGraphics()
+
     override fun setFontFamily(fontFamilyData: FontFamilyData, size: Int) {
-
-        // Mod font
-        if (fontFamilyData.filePath != null)
-        {
-            this.font = createFontFromFile(fontFamilyData.filePath!!, size)
+        font = if (fontFamilyData.filePath != null) {
+            // Mod font
+            createFontFromFile(fontFamilyData.filePath!!, size)
+        } else {
+            // System font
+            Font(fontFamilyData.invariantName, Font.PLAIN, size)
         }
-        // System font
-        else
-        {
-            this.font = Font(fontFamilyData.invariantName, Font.PLAIN, size)
-        }
-
-        val bufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR)
-        val graphics = bufferedImage.createGraphics()
-        this.metric = graphics.getFontMetrics(font)
-        graphics.dispose()
+        metric = font.getFontMetrics()
     }
 
     private fun createFontFromFile(path: String, size: Int): Font {
         var font: Font
-        try
-        {
+        try {
             // Try to create and register new font
             val fontFile = UncivGame.Current.files.getLocalFile(path).file()
             val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
             font = Font.createFont(Font.TRUETYPE_FONT, fontFile).deriveFont(size.toFloat())
             ge.registerFont(font)
-        }
-        catch (_: Exception)
-        {
+        } catch (_: Exception) {
             // Fallback to default, if failed.
             font = Font(Fonts.DEFAULT_FONT_FAMILY, Font.PLAIN, size)
         }
@@ -61,25 +62,36 @@ class DesktopFont : FontImplementation {
         return font.size
     }
 
-    override fun getCharPixmap(char: Char) = getCharPixmapCommon(char.toString(), metric.charWidth(char))
+    override fun getCharPixmap(char: Char) = getCharPixmapCommon(char.toString()) { metric.charWidth(char) }
 
-    override fun getCharPixmap(symbolString: String) = getCharPixmapCommon(symbolString, metric.stringWidth(symbolString))
+    override fun getCharPixmap(symbolString: String) = getCharPixmapCommon(symbolString) { metric.stringWidth(symbolString) }
 
-    private fun getCharPixmapCommon(symbolString: String, measuredWidth: Int): Pixmap {
-        var width = measuredWidth
-        var height = metric.height
+    private fun getCharPixmapCommon(symbolString: String, measureWidth: (FontMetrics) -> Int): Pixmap {
+        val renderFont: Font
+        val renderMetric: FontMetrics
+        if (font.canDisplayUpTo(symbolString) == -1) {
+            renderFont = font
+            renderMetric = metric
+        } else {
+            val fallback = findFallbackFont(symbolString)
+            renderFont = fallback.first
+            renderMetric = fallback.second
+        }
+
+        var width = measureWidth(renderMetric)
+        var height = renderMetric.height
         if (width == 0) {
             // This happens e.g. for the Tab character
-            height = font.size
+            height = renderFont.size
             width = height
         }
 
         val bi = BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR)
         val g = bi.createGraphics()
         g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-        g.font = font
+        g.font = renderFont
         g.color = Color.WHITE
-        g.drawString(symbolString, 0, metric.leading + metric.ascent)
+        g.drawString(symbolString, 0, renderMetric.leading + renderMetric.ascent)
 
         val pixmap = Pixmap(bi.width, bi.height, Pixmap.Format.RGBA8888)
         val data = bi.getRGB(0, 0, bi.width, bi.height, null, 0, bi.width)
@@ -93,9 +105,27 @@ class DesktopFont : FontImplementation {
         return pixmap
     }
 
+    private fun Font.getFontMetrics() = metricsProbeGraphics.getFontMetrics(this)
+
+    private fun findFallbackFont(symbolString: String): Pair<Font, FontMetrics> {
+        val candidateFonts = successfulFallbackFonts.keys.asSequence()
+            .plus(allFontsCache.asSequence().filterNot { it in successfulFallbackFonts })
+        for (font in candidateFonts) {
+            if (font.canDisplayUpTo(symbolString) != -1) continue
+            // Found a font that can render this symbol, now
+            // cache a properly sized Font instance and its metrics
+            return successfulFallbackFonts.getOrPut(font) {
+                val sizedFont = font.deriveFont(getFontSize().toFloat()) // The Int overload is for style, not size
+                sizedFont to sizedFont.getFontMetrics()
+            }
+        }
+        return this.font to this.metric // No fallback, use configured font anyway
+    }
+
+    /** This is for the Options dialog user-choice list of fonts */
     override fun getSystemFonts(): Sequence<FontFamilyData> {
-        val cjkLanguage = " CJK " +System.getProperty("user.language").uppercase()
-        return GraphicsEnvironment.getLocalGraphicsEnvironment().allFonts.asSequence()
+        val cjkLanguage = " CJK " + System.getProperty("user.language").uppercase()
+        return allFontsCache.asSequence()
             .filter { " CJK " !in it.fontName || cjkLanguage in it.fontName }
             .map { FontFamilyData(it.family, it.getFamily(Locale.ROOT)) }
             .distinctBy { it.invariantName }

--- a/docs/Modders/Mods.md
+++ b/docs/Modders/Mods.md
@@ -14,7 +14,7 @@ There are three main kinds of mods:
 
 -   **Extension mods** - these add new nations/units/buildings/resources to a base ruleset - can be either to the default ruleset, or to a base ruleset mod. Easy to do and probably the better place to get started - for example, [creating a new Civilization](Making-a-new-Civilization.md)
 -   **Base Ruleset mods** - these replace the entire existing ruleset - tech tree, units, policies, nations etc - to give an entirely different experience than the base game. These generally require quite a bit of work, but give a whole new experience, and so are the most popular. [A minimal example can be found here](https://github.com/yairm210/Unciv-minimal-base-ruleset) as a template to build off of ("Use this template" green button in top right, "Create a new repository"). For requirements, see [Requirements](Mod-file-structure/1-Overview.md#requirements-for-base-rulesets)
--   **Ruleset-agnostic mods** - these do not contain any ruleset-related jsons, but instead contain other affects. Audiovisual mods (including tilesets, unitsets, and UI skins) and map mods are in this category.
+-   **Ruleset-agnostic mods** - these do not contain any ruleset-related jsons, but instead contain other assets. [Audiovisual](#audiovisual-components) mods (including tilesets, unitsets, and UI skins), [font](#fonts) mods and map mods are in this category.
 
 Creating and editing mods from your phone is NOT RECOMMENDED - it's *much easier* using a desktop device!
 
@@ -49,6 +49,15 @@ Custom tilesets and unitsets are a subgroup of these - see [Creating a custom ti
 Such mods are candidates for the "Permanent audiovisual mod" switch available on the Mod Management Screen, see [Permanent audiovisual mods](Images-and-Audio.md#permanent-audiovisual-mods).
 
 Images need to be 'packed' before the game can use them, which the desktop version can do for you. Please make sure to read the [Texture atlas](Images-and-Audio.md#images-and-the-texture-atlas) chapter!
+
+## Fonts
+
+Mods can supply fonts as TTF or OTF files in a "fonts" folder (but the actual file name must use lowercase extensions).
+
+These are available unter Options-Advanced-Font once the mod is installed (the "Permanent audiovisual mod" switch has no effect).
+A mod containing font(s) can be standalone, or it can carry the font to support text contained in its json, when that text uses unusual characters not typically present in system fonts (e.g. Klingon or Phoenician script do have Unicode codepoints but most system fonts don't have glyphs for either).
+If the font is required to render the mod's text, then the Modder is responsible for informing users to manually select that font - there's no automatic use.
+Also, at this time there's no automatic fallback to use system default fonts for missing glyphs, so the font should be complete enough to cover all Unciv text.
 
 ## Adding maps to mods
 


### PR DESCRIPTION
Closes #15234

Usecases:
- A Mod using unusual Unicode codepoints, that includes a specialized font in the Mod covering them (Klingon?).
    - User selects it, any text not covered by the font shows tofu boxes.
    - With this PR: any text not covered by the font renders using system default, which is a scan of all system fonts on Android and a scan of JRE-filtered system fonts on desktop.
- A Mod using unusual Unicode codepoints, and does _not_ include its own font, the system _has_ a font covering that script, and the default AWT font-scan will not find it (on Android with "Default Font" selected, it will always find a glyph defined in any of the system fonts). With this PR: fallback font will find those glyphs.
- Will also help when users select outlandish fonts by mistake or out of curiosity, and those lack the symbols needed for the UI
- Will also help with some setups getting Bangla or Hindi rendered without much font testing
- Fly-by fix: We limited Mod-supplied fonts to ttf, while the underlying stack always supported otf as well. otf allowed. Missing wiki description added.

<details><summary>Example usecase 2</summary>

Mod file English.properties:
```
diacritics_support = true # required for text using surrogate pairs in UCS-16
Dido = 𐤀𐤋𐤔𐤏
Bet Mekes = 𐤁𐤕 𐤌𐤊𐤎
Carthage = 𐤒𐤓𐤕𐤇𐤃𐤔𐤕
Utique = 𐤏𐤕𐤒
Hippo Regius = 𐤇𐤐𐤍
Gades = 𐤂𐤃𐤓
```

Without this:
<img width="856" height="450" alt="" src="https://github.com/user-attachments/assets/748bb346-ca27-40d6-b3bd-d68ef21f497b" />

With this:
<img width="856" height="450" alt="" src="https://github.com/user-attachments/assets/a44b46da-c6fe-408b-93ec-c75b1a48833a" />

This was on windross, where the single font covering those codepoints is Segoe UI Historic, and not covered by AWT's limited font scan. Explicitly selecting that would work in master, but then the rest of the UI looks different too.

</details>
