### PR TITLE
Translate counter-intel spy rank unique to Russian

### DIFF
--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -2254,7 +2254,7 @@ May not generate great prophet equivalents naturally = Великий проро
 [relativeAmount]% enemy spy effectiveness [cityFilter] = [relativeAmount]% эффективности вражеского шпиона [cityFilter]
 New spies start with [amount] level(s) = Новые шпионы начинают с уровня [amount]
  # Requires translation!
-Spies in [cityFilter] cities act as though they have [relativeAmount] levels for [spyAction] = 
+Spies in [cityFilter] cities act as though they have [relativeAmount] levels for [spyAction] = Шпионы [cityFilter]: [relativeAmount] к эффективному уровню при [spyAction] 
 Starting tech = Начальная технология
 Starts with [tech] = Начинает с технологией [tech]
 Starts with [policy] adopted = Начинает с принятым институтом [policy]

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -2253,8 +2253,7 @@ May not generate great prophet equivalents naturally = Великий проро
 [relativeAmount]% spy effectiveness [cityFilter] = [relativeAmount]% эффективности шпионажа [cityFilter]
 [relativeAmount]% enemy spy effectiveness [cityFilter] = [relativeAmount]% эффективности вражеского шпиона [cityFilter]
 New spies start with [amount] level(s) = Новые шпионы начинают с уровня [amount]
- # Requires translation!
-Spies in [cityFilter] cities act as though they have [relativeAmount] levels for [spyAction] = Шпионы [cityFilter]: [relativeAmount] к эффективному уровню при [spyAction] 
+Spies in [cityFilter] cities act as though they have [relativeAmount] levels for [spyAction] = Шпионы [cityFilter] действуют так, будто у них на [relativeAmount] уровней больше для [spyAction]
 Starting tech = Начальная технология
 Starts with [tech] = Начинает с технологией [tech]
 Starts with [policy] adopted = Начинает с принятым институтом [policy]


### PR DESCRIPTION
## Summary
- Russian translation for `Spies in [cityFilter] cities act as though they have [relativeAmount] levels for [spyAction]` (from #15233).
- Wording (native): `Шпионы [cityFilter] действуют так, будто у них на [relativeAmount] уровней больше для [spyAction]`
  - Example with Constabulary: «Шпионы в этом городе действуют так, будто у них на +1 уровней больше для Контрразведка»
  - Uses the same «так, будто» turn of phrase as other Russian Unciv strings (not a short AI-style colon calque).
- Placeholders `[cityFilter]` / `[relativeAmount]` / `[spyAction]` kept intact.

## Test plan
- [x] Key present; all three placeholders preserved
- [x] Russian UI + Constabulary tooltip smoke (manual)