### PR TITLE
Fix city founding tile ranker "Oasis" test

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -8,6 +8,7 @@ object Constants {
 
     const val english = "English"
 
+    // Terrain
     const val impassable = "Impassable"
     const val ocean = "Ocean"
 
@@ -45,20 +46,21 @@ object Constants {
 
     const val barbarianEncampment = "Barbarian encampment"
     const val cityCenter = "City center"
-    
+    const val allRoad = "All Road"
+
     // Treaties
     const val peaceTreaty = "Peace Treaty"
     const val researchAgreement = "Research Agreement"
     const val defensivePact = "Defensive Pact"
-    
+
     // Agreements
     const val openBorders = "Open Borders"
-    
+
     // Other trade items
     const val acceptEmbassy = "Accept Embassy"
     const val goldPerTurn = "Gold per turn"
     const val flatGold = "Gold"
-    
+
     /** Used as origin in StatMap or ResourceSupplyList, or the toggle button in DiplomacyOverviewTab */
     const val cityStates = "City-States"
     /** Used as origin in ResourceSupplyList */

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -95,6 +95,9 @@ object CityLocationTileRanker {
         val onCoast = newCityTile.isAdjacentToCoast()
         val onHill = newCityTile.isHill()
         val isNextToMountain = newCityTile.isAdjacentTo(Constants.mountain)
+        val unImprovable = newCityTile.getTerrainMatchingUniques(UniqueType.RestrictedBuildableImprovements)
+            .any { it.params[0] == Constants.allRoad }
+
         // Only count a luxury resource that we don't have yet as unique once
         val newUniqueLuxuryResources = HashSet<TileResource>()
 
@@ -106,7 +109,8 @@ object CityLocationTileRanker {
         // This bonus for settling on river is a bit outsized for the importance, but otherwise they have a habit of settling 1 tile away
         if (newCityTile.isAdjacentToRiver()) tileValue += 20
         // We want to found the city on an oasis because it can't be improved otherwise
-        if (newCityTile.terrainHasUnique(UniqueType.Unbuildable)) tileValue += 3
+        if (unImprovable) tileValue += 3
+
         val resource = newCityTile.tileResource
         if (civ.canSeeResource(resource)) {
             tileValue -= 4
@@ -121,12 +125,12 @@ object CityLocationTileRanker {
 
         var tiles = 0
         for (i in 0..2) {
-                //Ideally, we shouldn't really count the center tile, as it's converted into 1 production 2 food anyways with special cases treated above, but doing so can lead to AI moving settler back and forth until forever
-                for (nearbyTile in newCityTile.getTilesAtDistance(i)) {
-                    tiles++
-                    tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap) * (3f / (i + 1))
-                    //Tiles close to the city can be worked more quickly, and thus should gain higher weight.
-                }
+            //Ideally, we shouldn't really count the center tile, as it's converted into 1 production 2 food anyways with special cases treated above, but doing so can lead to AI moving settler back and forth until forever
+            for (nearbyTile in newCityTile.getTilesAtDistance(i)) {
+                tiles++
+                tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap) * (3f / (i + 1))
+                //Tiles close to the city can be worked more quickly, and thus should gain higher weight.
+            }
         }
 
         // Placing cities on the edge of the map is bad, we can't even build improvements on them!

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.automation.unit
 
+import com.unciv.Constants
 import com.unciv.logic.automation.Automation
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
@@ -93,7 +94,7 @@ object CityLocationTileRanker {
 
         val onCoast = newCityTile.isAdjacentToCoast()
         val onHill = newCityTile.isHill()
-        val isNextToMountain = newCityTile.isAdjacentTo("Mountain")
+        val isNextToMountain = newCityTile.isAdjacentTo(Constants.mountain)
         // Only count a luxury resource that we don't have yet as unique once
         val newUniqueLuxuryResources = HashSet<TileResource>()
 

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -99,7 +99,7 @@ class TileImprovement : RulesetStatsObject() {
         return when (filter) {
             "all", "All" -> true
             "Improvement" -> true // For situations involving tileFilter
-            "All Road" -> isRoad()
+            Constants.allRoad -> isRoad()
             "Great Improvement", "Great" -> isGreatImprovement()
             else -> filter == name || filter == replaces // 2 string equalities is better than hashmap lookup
         }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -346,7 +346,7 @@ enum class UniqueParameterType(
 
     /** Implemented by [Tile.matchesFilter][com.unciv.logic.map.tile.Tile.matchesFilter] */
     TileFilter("tileFilter", "Farm", "Anything that can be used either in an improvementFilter or in a terrainFilter can be used here, plus 'unimproved'", "Tile Filters") {
-        override val staticKnownValues = setOf("unimproved", "improved", "worked", "pillaged", "All Road", "Great Improvement")
+        override val staticKnownValues = setOf("unimproved", "improved", "worked", "pillaged", Constants.allRoad, "Great Improvement")
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = getErrorSeverityForFilter(parameterText, ruleset)
 
@@ -447,8 +447,8 @@ enum class UniqueParameterType(
     },
 
     /** Implemented by [TileImprovement.matchesFilter][com.unciv.models.ruleset.tile.TileImprovement.matchesFilter] */
-    ImprovementFilter("improvementFilter", "All Road", null, "Improvement Filters") {
-        override val staticKnownValues = setOf("Improvement", "All Road", "Great Improvement", "Great") + Constants.all
+    ImprovementFilter("improvementFilter", Constants.allRoad, null, "Improvement Filters") {
+        override val staticKnownValues = setOf("Improvement", Constants.allRoad, "Great Improvement", "Great") + Constants.all
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = getErrorSeverityForFilter(parameterText, ruleset)
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -1306,12 +1306,12 @@ object UniqueTriggerActivation {
                 if (!tileImprovement.matchesFilter(improvementFilter)) return null
                 return {
                     // Don't remove the improvement if we're just removing the roads
-                    if (improvementFilter != "All Road") {
+                    if (improvementFilter != Constants.allRoad) {
                         tile.removeImprovement()
                     }
 
                     // Remove the roads if desired
-                    if (improvementFilter == "All" || improvementFilter == "All Road") {
+                    if (improvementFilter == "All" || improvementFilter == Constants.allRoad) {
                         tile.removeRoad()
                     }
                     true

--- a/core/src/com/unciv/ui/screens/mainmenuscreen/EasterEggRulesets.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/EasterEggRulesets.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.screens.mainmenuscreen
 
+import com.unciv.Constants
 import com.unciv.logic.HolidayDates
 import com.unciv.logic.HolidayDates.Holidays
 import com.unciv.logic.map.MapParameters
@@ -70,7 +71,7 @@ object EasterEggRulesets {
         faith = 9f
         occursOn.addAll(listOf("Grassland", "Plains", "Desert"))
         uniques.add("Must be adjacent to [0] [Coast] tiles")
-        turnsInto = "Mountain"
+        turnsInto = Constants.mountain
         impassable = true
         unbuildable = true
         weight = 999999


### PR DESCRIPTION
Already forgot how the heck I came across this - `terrainHasUnique(UniqueType.Unbuildable)` is bull, because that Unique isn't applicable to terrain at all. Then linted the rest of the function a little. Refrained from hunting down all the hundreds of literals that could use an existing `Constants.const val` - mostly in unit tests, those less-than-perfectly formatted mapgen tests.