### PR TITLE
Fix join-war force penalty clamp

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
@@ -108,7 +108,7 @@ object DeclareWarPlanEvaluator {
             else -> 0.8f
         }
         if (civToJoinForce + civForce < targetForce * multiplier) {
-            motivation -= 20 * (targetForce * multiplier) / (civToJoinForce + civForce).coerceIn(-1000f, 1000f)
+            motivation -= (20 * (targetForce * multiplier) / (civToJoinForce + civForce)).coerceIn(-1000f, 1000f)
         }
 
         return motivation - 15


### PR DESCRIPTION
# Fix join-war force penalty clamp

## Problem

In `DeclareWarPlanEvaluator.evaluateJoinWarPlan`, the force disadvantage penalty is currently calculated as:

```kotlin
motivation -= 20 * (targetForce * multiplier) / (civToJoinForce + civForce).coerceIn(-1000f, 1000f)
```

Due to operator precedence, `coerceIn` applies to the combined-force denominator instead of the completed penalty. Combined force above 1000 is treated as 1000, while the actual penalty is left unbounded as the target force grows. This can make the AI too reluctant to join an ally war and can make it demand too much payment for a join-war deal.

This regression came from #11807, specifically commit `8d62563154ff8fef52ed47377ba071c18bc28d53` (`Refactored MotivationToAttackAutomation to use a float instead of an int`). While removing the integer conversion, the outer parentheses from the original expression were also removed, moving the clamp from the completed penalty to the denominator.

## Fix

Restore the outer parentheses so the historical `[-1000, 1000]` range applies to the completed penalty:

```kotlin
motivation -= (20 * (targetForce * multiplier) / (civToJoinForce + civForce)).coerceIn(-1000f, 1000f)
```