### PR TITLE
City-states found first city in place by default (opt-out unique)

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -432,6 +432,7 @@ Enable Nuclear Weapons =
 No City Razing = 
 No Barbarians = 
 Disable starting bias = 
+City-states found first city in place = 
 Raging Barbarians = 
 No Ancient Ruins = 
 No Natural Wonders = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -432,7 +432,6 @@ Enable Nuclear Weapons =
 No City Razing = 
 No Barbarians = 
 Disable starting bias = 
-City-states found first city in place = 
 Raging Barbarians = 
 No Ancient Ruins = 
 No Natural Wonders = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -432,6 +432,7 @@ Enable Nuclear Weapons =
 No City Razing = 
 No Barbarians = 
 Disable starting bias = 
+City-states search for first city location = 
 Raging Barbarians = 
 No Ancient Ruins = 
 No Natural Wonders = 

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -72,6 +72,17 @@ object SpecificUnitAutomation {
     }
 
     fun automateSettlerActions(unit: MapUnit, dangerousTiles: HashSet<Tile>) {
+        // Civ5 HomelandAI PlotFirstTurnSettlerMoves: city-states found in place on their start tile
+        // instead of wandering for a slightly better site (Unciv's major-civ settler search).
+        if (unit.civ.isCityState && unit.civ.cities.isEmpty()) {
+            val foundHere = UnitActionsFromUniques.getFoundCityAction(unit, unit.getTile())
+            if (foundHere?.action != null && unit.hasMovement()) {
+                foundHere.action.invoke()
+                return
+            }
+            // Cannot found here (blocked / invalid) — fall through to normal search.
+        }
+
         // If we don't have any cities, we are probably at the start of the game with only one settler
         // If we are at the start of the game lets spend a maximum of 3 turns to settle our first city
         // As our turns progress lets shrink the area that we look at to make sure that we stay on target

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -72,9 +72,11 @@ object SpecificUnitAutomation {
     }
 
     fun automateSettlerActions(unit: MapUnit, dangerousTiles: HashSet<Tile>) {
-        // Civ5 HomelandAI PlotFirstTurnSettlerMoves: city-states found in place on their start tile
-        // instead of wandering for a slightly better site (Unciv's major-civ settler search).
-        if (unit.civ.isCityState && unit.civ.cities.isEmpty()) {
+        // Opt-in: city-states found in place on their start tile (Civ5 PlotFirstTurnSettlerMoves),
+        // instead of Unciv's major-civ-style wander for a slightly better site.
+        if (unit.civ.isCityState && unit.civ.cities.isEmpty()
+            && unit.civ.gameInfo.ruleset.modOptions.hasUnique(UniqueType.CityStatesFoundFirstCityInPlace)
+        ) {
             val foundHere = UnitActionsFromUniques.getFoundCityAction(unit, unit.getTile())
             if (foundHere?.action != null && unit.hasMovement()) {
                 foundHere.action.invoke()

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -72,11 +72,9 @@ object SpecificUnitAutomation {
     }
 
     fun automateSettlerActions(unit: MapUnit, dangerousTiles: HashSet<Tile>) {
-        // Opt-in: city-states found in place on their start tile (Civ5 PlotFirstTurnSettlerMoves),
-        // instead of Unciv's major-civ-style wander for a slightly better site.
-        if (unit.civ.isCityState && unit.civ.cities.isEmpty()
-            && unit.civ.gameInfo.ruleset.modOptions.hasUnique(UniqueType.CityStatesFoundFirstCityInPlace)
-        ) {
+        // City-state starts are predetermined by map gen / editor — trust that tile
+        // (Civ5 PlotFirstTurnSettlerMoves). Do not wander for a slightly better site.
+        if (unit.civ.isCityState && unit.civ.cities.isEmpty()) {
             val foundHere = UnitActionsFromUniques.getFoundCityAction(unit, unit.getTile())
             if (foundHere?.action != null && unit.hasMovement()) {
                 foundHere.action.invoke()

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -72,8 +72,8 @@ object SpecificUnitAutomation {
     }
 
     fun automateSettlerActions(unit: MapUnit, dangerousTiles: HashSet<Tile>) {
-        // City-state starts are predetermined by map gen / editor — trust that tile by default
-        // (Civ5 PlotFirstTurnSettlerMoves). Mods can opt out via CityStatesSearchForFirstCitySite.
+        // City-state starts are predetermined by map gen / editor — trust that tile by default.
+        // Mods can opt out via CityStatesSearchForFirstCitySite.
         if (unit.civ.isCityState && unit.civ.cities.isEmpty()
             && !unit.civ.gameInfo.ruleset.modOptions.hasUnique(UniqueType.CityStatesSearchForFirstCitySite)
         ) {

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -72,9 +72,11 @@ object SpecificUnitAutomation {
     }
 
     fun automateSettlerActions(unit: MapUnit, dangerousTiles: HashSet<Tile>) {
-        // City-state starts are predetermined by map gen / editor — trust that tile
-        // (Civ5 PlotFirstTurnSettlerMoves). Do not wander for a slightly better site.
-        if (unit.civ.isCityState && unit.civ.cities.isEmpty()) {
+        // City-state starts are predetermined by map gen / editor — trust that tile by default
+        // (Civ5 PlotFirstTurnSettlerMoves). Mods can opt out via CityStatesSearchForFirstCitySite.
+        if (unit.civ.isCityState && unit.civ.cities.isEmpty()
+            && !unit.civ.gameInfo.ruleset.modOptions.hasUnique(UniqueType.CityStatesSearchForFirstCitySite)
+        ) {
             val foundHere = UnitActionsFromUniques.getFoundCityAction(unit, unit.getTile())
             if (foundHere?.action != null && unit.hasMovement()) {
                 foundHere.action.invoke()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1091,6 +1091,9 @@ enum class UniqueType(
         docDescription = "In this case, 'starting era' means the first defined Era in the entire ruleset."),
     AllowRazeCapital("Allow raze capital", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
     AllowRazeHolyCity("Allow raze holy city", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
+    CityStatesFoundFirstCityInPlace("City-states found first city in place", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals,
+        docDescription = "City-state settlers with no cities yet found on their current tile when valid, instead of searching for a better nearby site. " +
+            "Matches Civ5 HomelandAI first-turn settler behaviour. Without this unique, city-states use the same settler search as majors."),
 
     SuppressWarnings("Suppress warning [validationWarning]", *UniqueTarget.CanIncludeSuppression, flags = UniqueFlag.setOfHiddenNoConditionals, docDescription = Suppression.uniqueDocDescription),
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1096,7 +1096,7 @@ enum class UniqueType(
         UniqueTarget.ModOptions,
         flags = UniqueFlag.setOfNoConditionals,
         docDescription = "By default, city-state settlers with no cities yet found on their current tile when valid " +
-            "(Civ5 HomelandAI / predetermined start). With this unique they use the same nearby-site search as major civs.",
+            "(predetermined map-gen / editor start). With this unique they use the same nearby-site search as major civs.",
     ),
 
     SuppressWarnings("Suppress warning [validationWarning]", *UniqueTarget.CanIncludeSuppression, flags = UniqueFlag.setOfHiddenNoConditionals, docDescription = Suppression.uniqueDocDescription),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1091,9 +1091,6 @@ enum class UniqueType(
         docDescription = "In this case, 'starting era' means the first defined Era in the entire ruleset."),
     AllowRazeCapital("Allow raze capital", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
     AllowRazeHolyCity("Allow raze holy city", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
-    CityStatesFoundFirstCityInPlace("City-states found first city in place", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals,
-        docDescription = "City-state settlers with no cities yet found on their current tile when valid, instead of searching for a better nearby site. " +
-            "Matches Civ5 HomelandAI first-turn settler behaviour. Without this unique, city-states use the same settler search as majors."),
 
     SuppressWarnings("Suppress warning [validationWarning]", *UniqueTarget.CanIncludeSuppression, flags = UniqueFlag.setOfHiddenNoConditionals, docDescription = Suppression.uniqueDocDescription),
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1091,6 +1091,13 @@ enum class UniqueType(
         docDescription = "In this case, 'starting era' means the first defined Era in the entire ruleset."),
     AllowRazeCapital("Allow raze capital", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
     AllowRazeHolyCity("Allow raze holy city", UniqueTarget.ModOptions, flags = UniqueFlag.setOfNoConditionals),
+    CityStatesSearchForFirstCitySite(
+        "City-states search for first city location",
+        UniqueTarget.ModOptions,
+        flags = UniqueFlag.setOfNoConditionals,
+        docDescription = "By default, city-state settlers with no cities yet found on their current tile when valid " +
+            "(Civ5 HomelandAI / predetermined start). With this unique they use the same nearby-site search as major civs.",
+    ),
 
     SuppressWarnings("Suppress warning [validationWarning]", *UniqueTarget.CanIncludeSuppression, flags = UniqueFlag.setOfHiddenNoConditionals, docDescription = Suppression.uniqueDocDescription),
 


### PR DESCRIPTION
## Summary
- By default, city-state settlers with no cities yet **found in place** when the current tile is valid (Civ5 `PlotFirstTurnSettlerMoves`; start tiles from map gen / editor are trusted).
- Opt-out ModOptions unique: `City-states search for first city location` — restores the previous nearby-site wander (same search path as major civs).
- If founding on the start tile is impossible, existing fallback settler search still applies.
- Major-civ settler logic is unchanged.

## Motivation
Review feedback preferred settle-in-place as the default for predetermined CS starts, while still keeping a switch for mods that want the old wander behaviour.

## Test plan
- [x] Local sample (10× Medium Pangaea, 8 CS): after `automateSettlerActions`, **founded 80/80 = 100%**, **stayed on start tile 80/80 = 100%** (`alreadyFoundedAfterStart=0`)
- [x] With `City-states search for first city location`: automation completes without crash
- [ ] Invalid / blocked start tile: CS falls back to normal settler search (manual)
- [ ] Major AI first settler behaviour unchanged (manual)
- [x] CI green

## Notes
- No AI translations.