### PR TITLE
Start bias unique (Maritime Coast via CityStateType uniques)

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/CityStateTypes.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/CityStateTypes.json
@@ -17,6 +17,7 @@
         "name": "Maritime",
         "friendBonusUniques": ["[+2 Food] [in capital]"],
         "allyBonusUniques": ["[+2 Food] [in capital]", "[+1 Food] [in all cities]"],
+        "startBias": ["Coast"],
         "color": [56, 255, 112]
     },
     {

--- a/android/assets/jsons/Civ V - Gods & Kings/CityStateTypes.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/CityStateTypes.json
@@ -17,7 +17,7 @@
         "name": "Maritime",
         "friendBonusUniques": ["[+2 Food] [in capital]"],
         "allyBonusUniques": ["[+2 Food] [in capital]", "[+1 Food] [in all cities]"],
-        "startBias": ["Coast"],
+        "uniques": ["Start bias [Coast]"],
         "color": [56, 255, 112]
     },
     {

--- a/android/assets/jsons/Civ V - Vanilla/CityStateTypes.json
+++ b/android/assets/jsons/Civ V - Vanilla/CityStateTypes.json
@@ -17,6 +17,7 @@
         "name": "Maritime",
         "friendBonusUniques": ["[+2 Food] [in capital]"],
         "allyBonusUniques": ["[+2 Food] [in capital]", "[+1 Food] [in all cities]"],
+        "startBias": ["Coast"],
         "color": [56, 255, 112]
     },
     {

--- a/android/assets/jsons/Civ V - Vanilla/CityStateTypes.json
+++ b/android/assets/jsons/Civ V - Vanilla/CityStateTypes.json
@@ -17,7 +17,7 @@
         "name": "Maritime",
         "friendBonusUniques": ["[+2 Food] [in capital]"],
         "allyBonusUniques": ["[+2 Food] [in capital]", "[+1 Food] [in all cities]"],
-        "startBias": ["Coast"],
+        "uniques": ["Start bias [Coast]"],
         "color": [56, 255, 112]
     },
     {

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1363,7 +1363,6 @@ Close =
 Do you want to exit the game? = 
 Exit = 
 Start bias: =
-Start bias [terrainFilter] = 
 Avoid [terrain] =
 
 # Maya calendar popup

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1362,8 +1362,9 @@ Social policies =
 Close = 
 Do you want to exit the game? = 
 Exit = 
-Start bias: = 
-Avoid [terrain] = 
+Start bias: =
+Start bias [terrainFilter] = 
+Avoid [terrain] =
 
 # Maya calendar popup
 

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -565,7 +565,7 @@ class GameStarter private constructor(
     private fun getCivsOrderedByAvailableLocations(civs: List<Civilization>): List<Civilization> {
         return civs.shuffled()   // Order should be random since it determines who gets best start
             .sortedBy { civ ->
-                val startBias = civ.nation.getStartBias(ruleset, GameContext(civ))
+                val startBias = civ.nation.getStartBias(ruleset, civ.getGameContextForStartBias())
                 when {
                     civ.civID in tileMap.startingLocationsByNation -> 1 // harshest requirements
                     startBias.any { it in tileMap.naturalWonders } && !gameSetupInfo.gameParameters.noStartBias -> 2
@@ -638,7 +638,7 @@ class GameStarter private constructor(
         if (gameSetupInfo.gameParameters.noStartBias) {
             return freeTiles.random(rng)
         }
-        val startBiases = civ.nation.getStartBias(ruleset, GameContext(civ))
+        val startBiases = civ.nation.getStartBias(ruleset, civ.getGameContextForStartBias())
         if (startBiases.any { it in tileMap.naturalWonders }) {
             // startPref wants Natural wonder neighbor: Rare and very likely to be outside getDistanceFromEdge
             val wonderNeighbor = tileMap.values.asSequence()

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -565,11 +565,12 @@ class GameStarter private constructor(
     private fun getCivsOrderedByAvailableLocations(civs: List<Civilization>): List<Civilization> {
         return civs.shuffled()   // Order should be random since it determines who gets best start
             .sortedBy { civ ->
+                val startBias = civ.nation.getStartBias(ruleset, GameContext(civ))
                 when {
                     civ.civID in tileMap.startingLocationsByNation -> 1 // harshest requirements
-                    civ.nation.startBias.any { it in tileMap.naturalWonders } && !gameSetupInfo.gameParameters.noStartBias -> 2
-                    civ.nation.startBias.contains(Constants.tundra) && !gameSetupInfo.gameParameters.noStartBias -> 3    // Tundra starts are hard to find, so let's do them first
-                    civ.nation.startBias.isNotEmpty() && !gameSetupInfo.gameParameters.noStartBias -> 4 // less harsh
+                    startBias.any { it in tileMap.naturalWonders } && !gameSetupInfo.gameParameters.noStartBias -> 2
+                    startBias.contains(Constants.tundra) && !gameSetupInfo.gameParameters.noStartBias -> 3    // Tundra starts are hard to find, so let's do them first
+                    startBias.isNotEmpty() && !gameSetupInfo.gameParameters.noStartBias -> 4 // less harsh
                     else -> 5  // no requirements
                 }
             }.sortedByDescending { it.isHuman() } // More important for humans to get their start biases!
@@ -637,17 +638,18 @@ class GameStarter private constructor(
         if (gameSetupInfo.gameParameters.noStartBias) {
             return freeTiles.random(rng)
         }
-        if (civ.nation.startBias.any { it in tileMap.naturalWonders }) {
+        val startBiases = civ.nation.getStartBias(ruleset, GameContext(civ))
+        if (startBiases.any { it in tileMap.naturalWonders }) {
             // startPref wants Natural wonder neighbor: Rare and very likely to be outside getDistanceFromEdge
             val wonderNeighbor = tileMap.values.asSequence()
-                .filter { it.isNaturalWonder() && it.naturalWonder!! in civ.nation.startBias }
+                .filter { it.isNaturalWonder() && it.naturalWonder!! in startBiases }
                 .sortedByDescending { startScores[it] }
                 .firstOrNull()
             if (wonderNeighbor != null) return wonderNeighbor
         }
 
         var preferredTiles = freeTiles.toList()
-        for (startBias in civ.nation.startBias) {
+        for (startBias in startBiases) {
             preferredTiles = when {
                 startBias.equalsPlaceholderText("Avoid []") -> {
                     val tileToAvoid = startBias.getPlaceholderParameters()[0]

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -72,6 +72,13 @@ class Civilization : IsPartOfGameInfoSerialization {
     @Transient
     lateinit var gameInfo: GameInfo
 
+    /** Safe context for start-bias uniques (civ may lack [gameInfo] during early map gen). */
+    @Readonly
+    fun getGameContextForStartBias(): GameContext {
+        if (!this::gameInfo.isInitialized) return GameContext.IgnoreConditionals
+        return GameContext(this)
+    }
+
     @Transient
     lateinit var nation: Nation
     

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -74,10 +74,9 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     /** Safe context for start-bias uniques (civ may lack [gameInfo] during early map gen). */
     @Readonly
-    fun getGameContextForStartBias(): GameContext {
-        if (!this::gameInfo.isInitialized) return GameContext.IgnoreConditionals
-        return GameContext(this)
-    }
+    fun getGameContextForStartBias() =
+        if (this::gameInfo.isInitialized) GameContext(this)
+        else GameContext.IgnoreConditionals
 
     @Transient
     lateinit var nation: Nation

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -72,10 +72,13 @@ class Civilization : IsPartOfGameInfoSerialization {
     @Transient
     lateinit var gameInfo: GameInfo
 
-    /** Safe context for start-bias uniques (civ may lack [gameInfo] during early map gen). */
+    /** Context for [UniqueType.StartBias] during map gen / start placement.
+     *  Passes [GameInfo] only — never this [Civilization], which may be only partially initialized.
+     *  Conditionals that need tiles/cities/units are therefore unsupported here.
+     */
     @Readonly
     fun getGameContextForStartBias() =
-        if (this::gameInfo.isInitialized) GameContext(this)
+        if (this::gameInfo.isInitialized) GameContext(gameInfo = gameInfo)
         else GameContext.IgnoreConditionals
 
     @Transient

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
@@ -14,6 +14,7 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.Terrain
 import com.unciv.models.ruleset.tile.TerrainType
 import com.unciv.models.ruleset.tile.TileResource
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.equalsPlaceholderText
@@ -253,7 +254,9 @@ class MapRegions (val ruleset: Ruleset) {
             StartNormalizer.normalizeStart(tileMap[region.startPosition!!], tileMap, tileData, ruleset, isMinorCiv = false)
         }
 
-        val civBiases = civilizations.associateWith { ruleset.nations[it.civName]!!.startBias }
+        val civBiases = civilizations.associateWith {
+            ruleset.nations[it.civName]!!.getStartBias(ruleset, GameContext(it))
+        }
         // This ensures each civ can only be in one of the buckets
         val civsByBiasType = civBiases.entries.groupBy(
             keySelector = {
@@ -420,7 +423,10 @@ class MapRegions (val ruleset: Ruleset) {
     private fun logAssignRegion(success: Boolean, startBiasType: BiasTypes, civ: Civilization, region: Region? = null) {
         if (Log.backend.isRelease()) return
 
-        val logCiv = { civ.civName + " " + ruleset.nations[civ.civName]!!.startBias.joinToString(",", "(", ")") }
+        val logCiv = {
+            val bias = ruleset.nations[civ.civName]!!.getStartBias(ruleset, GameContext(civ))
+            civ.civName + " " + bias.joinToString(",", "(", ")")
+        }
         val msg = if (success) "(%s): %s to %s"
             else "no region (%s) found for %s"
         Log.debug(Tag("assignRegions"), msg, startBiasType, logCiv, region)

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
@@ -255,7 +255,7 @@ class MapRegions (val ruleset: Ruleset) {
         }
 
         val civBiases = civilizations.associateWith {
-            ruleset.nations[it.civName]!!.getStartBias(ruleset, GameContext(it))
+            ruleset.nations[it.civName]!!.getStartBias(ruleset, it.getGameContextForStartBias())
         }
         // This ensures each civ can only be in one of the buckets
         val civsByBiasType = civBiases.entries.groupBy(
@@ -424,7 +424,7 @@ class MapRegions (val ruleset: Ruleset) {
         if (Log.backend.isRelease()) return
 
         val logCiv = {
-            val bias = ruleset.nations[civ.civName]!!.getStartBias(ruleset, GameContext(civ))
+            val bias = ruleset.nations[civ.civName]!!.getStartBias(ruleset, civ.getGameContextForStartBias())
             civ.civName + " " + bias.joinToString(",", "(", ")")
         }
         val msg = if (success) "(%s): %s to %s"

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
@@ -36,7 +36,8 @@ object MinorCivPlacer {
                 uninhabitedHinterland,
                 civs,
                 unassignedCivs,
-                civAssignedToUninhabited
+                civAssignedToUninhabited,
+                ruleset
             )
         }
 
@@ -64,7 +65,8 @@ object MinorCivPlacer {
         uninhabitedHinterland: ArrayList<Tile>,
         civs: List<Civilization>,
         unassignedCivs: MutableList<Civilization>,
-        civAssignedToUninhabited: ArrayList<Civilization>
+        civAssignedToUninhabited: ArrayList<Civilization>,
+        ruleset: Ruleset
     ) {
         val uninhabitedContinents = tileMap.continentSizes.filter {
             it.value >= 4 && // Don't bother with tiny islands
@@ -90,7 +92,10 @@ object MinorCivPlacer {
             (3 * civs.size * numUninhabitedTiles) / (numInhabitedTiles + numUninhabitedTiles)
         val maxByRatio = (civs.size + 1) / 2
         val targetForUninhabited = min(maxByRatio, maxByUninhabited)
-        val civsToAssign = unassignedCivs.take(targetForUninhabited)
+        // Prefer Coast-bias CS for wilderness slots (often coastal).
+        val ordered = unassignedCivs.filter { prefersCoastalStart(it, ruleset) } +
+            unassignedCivs.filterNot { prefersCoastalStart(it, ruleset) }
+        val civsToAssign = ordered.take(targetForUninhabited)
         unassignedCivs.removeAll(civsToAssign)
         civAssignedToUninhabited.addAll(civsToAssign)
     }
@@ -207,24 +212,42 @@ object MinorCivPlacer {
         return unassignedCivs
     }
 
-    /** Attempts to randomly place civs from [civsToPlace] in tiles from [tileList]. Assumes that
+    /**
+     *  Attempts to place civs from [civsToPlace] in tiles from [tileList]. Assumes that
      *  [tileList] is pre-vetted and only contains habitable land tiles.
-     *  Will modify both [civsToPlace] and [tileList] as it goes! */
+     *  City-states with a Coast start bias (nation or [CityStateType]) prefer coastal tiles.
+     *  Will modify both [civsToPlace] and [tileList] as it goes!
+     */
     private fun tryPlaceMinorCivsInTiles(civsToPlace: MutableList<Civilization>, tileMap: TileMap, tileList: MutableList<Tile>, tileData: TileDataMap, ruleset: Ruleset) {
+        // Coastal-preferring CS first so hinterland types do not consume scarce coastal tiles.
+        val ordered = civsToPlace.sortedByDescending { prefersCoastalStart(it, ruleset) }.toMutableList()
+        civsToPlace.clear()
+        civsToPlace.addAll(ordered)
+
         while (tileList.isNotEmpty() && civsToPlace.isNotEmpty()) {
+            val civToAdd = civsToPlace.first()
+            val pool = if (prefersCoastalStart(civToAdd, ruleset)) {
+                val coastal = tileList.filter { it.isAdjacentToCoast() }
+                if (coastal.isNotEmpty()) coastal else tileList
+            } else tileList
+
             val rng = GameContext(gameInfo = tileMap.gameInfo).stateBasedRandom("MinorCivPlcer.tryPlaceMinorCivsInTiles")
-            val chosenTile = tileList.random(rng)
+            val chosenTile = pool.random(rng)
             tileList.remove(chosenTile)
             val data = tileData[chosenTile]!!
             // If the randomly chosen tile is too close to a player or a city state, discard it
             if (data.impacts.containsKey(MapRegions.ImpactType.MinorCiv))
                 continue
             // Otherwise, go ahead and place the minor civ
-            val civToAdd = civsToPlace.first()
             civsToPlace.remove(civToAdd)
             placeMinorCiv(civToAdd, tileMap, chosenTile, tileData, ruleset)
         }
     }
+
+    /** True when nation or city-state type start bias includes Coast. */
+    @Readonly
+    fun prefersCoastalStart(civ: Civilization, ruleset: Ruleset): Boolean =
+        "Coast" in civ.nation.getStartBias(ruleset)
 
     @Readonly
     private fun canPlaceMinorCiv(tile: Tile, tileData: TileDataMap) = !tile.isWater && !tile.isImpassible() &&

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
@@ -6,6 +6,8 @@ import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.translations.equalsPlaceholderText
+import com.unciv.models.translations.getPlaceholderParameters
 import yairm210.purity.annotations.Readonly
 import kotlin.math.min
 
@@ -215,21 +217,27 @@ object MinorCivPlacer {
     /**
      *  Attempts to place civs from [civsToPlace] in tiles from [tileList]. Assumes that
      *  [tileList] is pre-vetted and only contains habitable land tiles.
-     *  City-states with a Coast start bias (nation or [CityStateType]) prefer coastal tiles.
+     *  Respects start biases (nation field + StartBias uniques on nation / [CityStateType]),
+     *  including `Avoid [terrainFilter]`, same idea as [com.unciv.logic.GameStarter] major placement.
      *  Will modify both [civsToPlace] and [tileList] as it goes!
      */
     private fun tryPlaceMinorCivsInTiles(civsToPlace: MutableList<Civilization>, tileMap: TileMap, tileList: MutableList<Tile>, tileData: TileDataMap, ruleset: Ruleset) {
-        // Coastal-preferring CS first so hinterland types do not consume scarce coastal tiles.
-        val ordered = civsToPlace.sortedByDescending { prefersCoastalStart(it, ruleset) }.toMutableList()
+        // More constrained biases (and coastal) first so they do not lose scarce matching tiles.
+        val ordered = civsToPlace.sortedWith(
+            compareByDescending<Civilization> {
+                it.nation.getStartBias(ruleset, it.getGameContextForStartBias()).size
+            }.thenByDescending { prefersCoastalStart(it, ruleset) }
+        ).toMutableList()
         civsToPlace.clear()
         civsToPlace.addAll(ordered)
 
         while (tileList.isNotEmpty() && civsToPlace.isNotEmpty()) {
             val civToAdd = civsToPlace.first()
-            val pool = if (prefersCoastalStart(civToAdd, ruleset)) {
-                val coastal = tileList.filter { it.isAdjacentToCoast() }
-                if (coastal.isNotEmpty()) coastal else tileList
-            } else tileList
+            val preferred = filterTilesByStartBias(
+                tileList,
+                civToAdd.nation.getStartBias(ruleset, civToAdd.getGameContextForStartBias())
+            )
+            val pool = preferred.ifEmpty { tileList }
 
             val rng = GameContext(gameInfo = tileMap.gameInfo).stateBasedRandom("MinorCivPlcer.tryPlaceMinorCivsInTiles")
             val chosenTile = pool.random(rng)
@@ -242,6 +250,26 @@ object MinorCivPlacer {
             civsToPlace.remove(civToAdd)
             placeMinorCiv(civToAdd, tileMap, chosenTile, tileData, ruleset)
         }
+    }
+
+    /** Prefer tiles matching positive start biases; drop tiles matching `Avoid [filter]`. */
+    @Readonly
+    fun filterTilesByStartBias(tiles: List<Tile>, startBiases: Collection<String>): List<Tile> {
+        var preferred = tiles
+        for (startBias in startBiases) {
+            preferred = when {
+                startBias.equalsPlaceholderText("Avoid []") -> {
+                    val tileToAvoid = startBias.getPlaceholderParameters()[0]
+                    preferred.filter { tile ->
+                        tile.getTilesInDistance(1).none { it.matchesTerrainFilter(tileToAvoid, null) }
+                    }
+                }
+                else -> preferred.filter { tile ->
+                    tile.getTilesInDistance(1).any { it.matchesTerrainFilter(startBias, null) }
+                }
+            }
+        }
+        return preferred
     }
 
     /** True when nation or city-state type start bias includes Coast. */

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
@@ -247,7 +247,7 @@ object MinorCivPlacer {
     /** True when nation or city-state type start bias includes Coast. */
     @Readonly
     fun prefersCoastalStart(civ: Civilization, ruleset: Ruleset): Boolean =
-        "Coast" in civ.nation.getStartBias(ruleset)
+        "Coast" in civ.nation.getStartBias(ruleset, GameContext(civ))
 
     @Readonly
     private fun canPlaceMinorCiv(tile: Tile, tileData: TileDataMap) = !tile.isWater && !tile.isImpassible() &&

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
@@ -247,7 +247,7 @@ object MinorCivPlacer {
     /** True when nation or city-state type start bias includes Coast. */
     @Readonly
     fun prefersCoastalStart(civ: Civilization, ruleset: Ruleset): Boolean =
-        "Coast" in civ.nation.getStartBias(ruleset, GameContext(civ))
+        "Coast" in civ.nation.getStartBias(ruleset, civ.getGameContextForStartBias())
 
     @Readonly
     private fun canPlaceMinorCiv(tile: Tile, tileData: TileDataMap) = !tile.isWater && !tile.isImpassible() &&

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -89,7 +89,9 @@ enum class RulesetFile(
     UnitTypes("UnitTypes.json", { unitTypes.values.asSequence() }),
     VictoryTypes("VictoryTypes.json", getINamed = { victories.values.asSequence() }),
     CityStateTypes("CityStateTypes.json", getUniques =
-        { cityStateTypes.values.asSequence().flatMap { it.allyBonusUniqueMap.getAllUniques() + it.friendBonusUniqueMap.getAllUniques() } },
+        { cityStateTypes.values.asSequence().flatMap {
+            it.allyBonusUniqueMap.getAllUniques() + it.friendBonusUniqueMap.getAllUniques() + it.uniqueObjects
+        } },
         getINamed = { cityStateTypes.values.asSequence() }),
     Personalities("Personalities.json", { personalities.values.asSequence() }),
     Events("Events.json", { events.values.asSequence() + events.values.flatMap { it.choices } }),
@@ -575,6 +577,13 @@ class Ruleset {
                     cityStateTypes[cityStateType.name] = CityStateType().apply {
                         name = cityStateType.name
                         color = cityStateType.color
+                        uniques = ArrayList(cityStateType.uniques.filter {
+                            UniqueValidator(this@Ruleset).checkUnique(
+                                Unique(it),
+                                false,
+                                null
+                            ).isEmpty()
+                        })
                         friendBonusUniques = ArrayList(cityStateType.friendBonusUniques.filter {
                             UniqueValidator(this@Ruleset).checkUnique(
                                 Unique(it),

--- a/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
+++ b/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
@@ -17,6 +17,9 @@ class CityStateType: INamed {
     private fun ArrayList<String>.toUniqueMap() =
         UniqueMap(asSequence().map { Unique(it, sourceObjectType = UniqueTarget.CityState, sourceObjectName = name) })
 
+    /** Same semantics as [Nation.startBias], applied to every city-state of this type. */
+    var startBias = ArrayList<String>()
+
     var color: List<Int> = listOf(255,255,255)
     private val colorObject by lazy { colorFromRGB(color) }
     @Readonly fun getColor() = colorObject

--- a/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
+++ b/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
@@ -14,11 +14,13 @@ class CityStateType: INamed {
     val friendBonusUniqueMap by lazy { friendBonusUniques.toUniqueMap() }
     var allyBonusUniques = ArrayList<String>()
     val allyBonusUniqueMap by lazy { allyBonusUniques.toUniqueMap() }
+
+    /** Type-wide uniques (e.g. [UniqueType.StartBias]), applied to every city-state of this type. */
+    var uniques = ArrayList<String>()
+    val uniqueMap by lazy { uniques.toUniqueMap() }
+
     private fun ArrayList<String>.toUniqueMap() =
         UniqueMap(asSequence().map { Unique(it, sourceObjectType = UniqueTarget.CityState, sourceObjectName = name) })
-
-    /** Same semantics as [Nation.startBias], applied to every city-state of this type. */
-    var startBias = ArrayList<String>()
 
     var color: List<Int> = listOf(255,255,255)
     private val colorObject by lazy { colorFromRGB(color) }

--- a/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
+++ b/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
@@ -1,28 +1,25 @@
 package com.unciv.models.ruleset.nation
 
-import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTarget
-import com.unciv.models.stats.INamed
 import com.unciv.ui.components.extensions.colorFromRGB
 import yairm210.purity.annotations.Readonly
 
-class CityStateType: INamed {
-    override var name = ""
+class CityStateType : RulesetObject() {
+    override fun getUniqueTarget() = UniqueTarget.CityState
 
     var friendBonusUniques = ArrayList<String>()
-    val friendBonusUniqueMap by lazy { friendBonusUniques.toUniqueMap() }
+    @delegate:Transient
+    val friendBonusUniqueMap: UniqueMap by lazy { uniqueMapProvider(uniqueObjectsProvider(friendBonusUniques)) }
+
     var allyBonusUniques = ArrayList<String>()
-    val allyBonusUniqueMap by lazy { allyBonusUniques.toUniqueMap() }
+    @delegate:Transient
+    val allyBonusUniqueMap: UniqueMap by lazy { uniqueMapProvider(uniqueObjectsProvider(allyBonusUniques)) }
 
-    /** Type-wide uniques (e.g. [UniqueType.StartBias]), applied to every city-state of this type. */
-    var uniques = ArrayList<String>()
-    val uniqueMap by lazy { uniques.toUniqueMap() }
-
-    private fun ArrayList<String>.toUniqueMap() =
-        UniqueMap(asSequence().map { Unique(it, sourceObjectType = UniqueTarget.CityState, sourceObjectName = name) })
-
-    var color: List<Int> = listOf(255,255,255)
+    var color: List<Int> = listOf(255, 255, 255)
     private val colorObject by lazy { colorFromRGB(color) }
     @Readonly fun getColor() = colorObject
+
+    override fun makeLink() = "CityStateType/$name"
 }

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -108,7 +108,7 @@ class Nation : RulesetObject() {
     @Readonly
     fun getStartBias(ruleset: Ruleset): List<String> {
         val typeName = cityStateType ?: return startBias
-        val typeBias = ruleset.cityStateTypes[typeName]?.startBias.orEmpty()
+        val typeBias = ruleset.cityStateTypes[typeName]?.startBias ?: emptyList()
         if (typeBias.isEmpty()) return startBias
         if (startBias.isEmpty()) return typeBias
         return (startBias + typeBias).distinct()

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -101,6 +101,19 @@ class Nation : RulesetObject() {
     val isBarbarian by lazy { name == Constants.barbarians }
     val isSpectator by lazy { name == Constants.spectator }
 
+    /**
+     * Nation [startBias] plus, for city-states, [CityStateType.startBias] from [ruleset].
+     * Type biases apply to every city-state of that type; per-nation biases are kept as well.
+     */
+    @Readonly
+    fun getStartBias(ruleset: Ruleset): List<String> {
+        val typeName = cityStateType ?: return startBias
+        val typeBias = ruleset.cityStateTypes[typeName]?.startBias.orEmpty()
+        if (typeBias.isEmpty()) return startBias
+        if (startBias.isEmpty()) return typeBias
+        return (startBias + typeBias).distinct()
+    }
+
     // This is its own transient because we'll need to check this for every tile-to-tile movement which is harsh
     @Transient
     var forestsAndJunglesAreRoads = false

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -131,8 +131,8 @@ class Nation : RulesetObject() {
      * Effective start biases: Nation [startBias] field, plus [UniqueType.StartBias] uniques on the
      * nation, plus (for city-states) [UniqueType.StartBias] on their [CityStateType].
      *
-     * Conditionals are evaluated with [gameContext] — pass [GameContext] for the civ when available,
-     * otherwise [GameContext] with gameInfo / [GameContext.IgnoreConditionals] during early map gen.
+     * Conditionals use [gameContext] — callers should pass GameInfo-only context (or
+     * [GameContext.IgnoreConditionals]), not a partially initialized [com.unciv.logic.civilization.Civilization].
      */
     @Readonly
     fun getStartBias(ruleset: Ruleset, gameContext: GameContext = GameContext.IgnoreConditionals): Collection<String> {

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -16,22 +16,9 @@ import com.unciv.ui.objectdescriptions.NationDescriptions.getCivilopediaTextLine
 import yairm210.purity.annotations.Readonly
 
 class Nation : RulesetObject() {
+    // region Serialized fields
     var leaderName = ""
-
-    /**
-     * Retrieves a display name for the nation's leader, considering the provided title (untranslated).
-     *
-     * @param [title] Optional title to apply to the leader. For example: `[leaderName] the Great`
-     */
-    @Readonly fun getLeaderDisplayName(title: String = ""): String = when {
-        isCityState || isSpectator -> name
-        title.isEmpty() -> "[$leaderName] of [$name]"
-        else -> "[${title.fillPlaceholders(leaderName)}] of [$name]"
-    }
-
     val style = ""
-    @Readonly fun getStyleOrCivName() = style.ifEmpty { name }
-
     var cityStateType: String? = null
     var preferredVictoryType: String = Constants.neutralVictoryType
 
@@ -84,22 +71,14 @@ class Nation : RulesetObject() {
     var favoredReligion: String? = null
 
     var cities: ArrayList<String> = arrayListOf()
+    // endregion
 
-    override fun getUniqueTarget() = UniqueTarget.Nation
-
+    // region Transients
     @Transient
-    private var outerColorObject:ImmutableColor = ImmutableColor(Color.WHITE) // Not lateinit for unit tests
-    fun getOuterColor(): ImmutableColor = outerColorObject
+    private var outerColorObject: ImmutableColor = ImmutableColor(Color.WHITE) // Not lateinit for unit tests
 
     @Transient
     private var innerColorObject: ImmutableColor = ImmutableColor(Color.BLACK) // Not lateinit for unit tests
-
-    fun getInnerColor(): ImmutableColor = innerColorObject
-
-    val isCityState by lazy { cityStateType != null }
-    val isMajorCiv by lazy { !isBarbarian && !isCityState && !isSpectator }
-    val isBarbarian by lazy { name == Constants.barbarians }
-    val isSpectator by lazy { name == Constants.spectator }
 
     // This is its own transient because we'll need to check this for every tile-to-tile movement which is harsh
     @Transient
@@ -109,17 +88,44 @@ class Nation : RulesetObject() {
     @Transient
     var ignoreHillMovementCost = false
 
-    fun setTransients() {
-        fun safeColorFromRGB(rgb: List<Int>) = ImmutableColor(if (rgb.size >= 3) colorFromRGB(rgb) else Color.PURPLE)
+    val isCityState by lazy { cityStateType != null }
+    val isMajorCiv by lazy { !isBarbarian && !isCityState && !isSpectator }
+    val isBarbarian by lazy { name == Constants.barbarians }
+    val isSpectator by lazy { name == Constants.spectator }
+    // endregion
 
-        outerColorObject = safeColorFromRGB(outerColor)
-
-        innerColorObject = if (innerColor == null) ImmutableColor(ImageGetter.CHARCOAL)
-                           else safeColorFromRGB(innerColor!!)
-
-        forestsAndJunglesAreRoads = uniqueMap.hasUnique(UniqueType.ForestsAndJunglesAreRoads)
-        ignoreHillMovementCost = uniqueMap.hasUnique(UniqueType.IgnoreHillMovementCost)
+    // region Overrides
+    override fun getUniqueTarget() = UniqueTarget.Nation
+    override fun makeLink() = "Nation/$name"
+    override fun getSortGroup(ruleset: Ruleset) = when {
+        isCityState -> 1
+        isBarbarian -> 9
+        else -> 0
     }
+    override fun getSubCategory(ruleset: Ruleset): String? = when {
+        isCityState -> "City-States"
+        isBarbarian -> "Other"
+        else -> "Civilizations"
+    }
+    override fun getCivilopediaTextLines(ruleset: Ruleset) = getCivilopediaTextLinesImpl(ruleset)
+    // endregion
+
+    // region API
+    /**
+     * Retrieves a display name for the nation's leader, considering the provided title (untranslated).
+     *
+     * @param [title] Optional title to apply to the leader. For example: `[leaderName] the Great`
+     */
+    @Readonly fun getLeaderDisplayName(title: String = ""): String = when {
+        isCityState || isSpectator -> name
+        title.isEmpty() -> "[$leaderName] of [$name]"
+        else -> "[${title.fillPlaceholders(leaderName)}] of [$name]"
+    }
+
+    @Readonly fun getStyleOrCivName() = style.ifEmpty { name }
+
+    fun getOuterColor(): ImmutableColor = outerColorObject
+    fun getInnerColor(): ImmutableColor = innerColorObject
 
     /**
      * Effective start biases: Nation [startBias] field, plus [UniqueType.StartBias] uniques on the
@@ -142,19 +148,17 @@ class Nation : RulesetObject() {
         return result
     }
 
-    override fun makeLink() = "Nation/$name"
-    override fun getSortGroup(ruleset: Ruleset) = when {
-        isCityState -> 1
-        isBarbarian -> 9
-        else -> 0
-    }
-    override fun getSubCategory(ruleset: Ruleset): String? = when {
-        isCityState -> "City-States"
-        isBarbarian -> "Other"
-        else -> "Civilizations"
-    }
+    fun setTransients() {
+        fun safeColorFromRGB(rgb: List<Int>) = ImmutableColor(if (rgb.size >= 3) colorFromRGB(rgb) else Color.PURPLE)
 
-    override fun getCivilopediaTextLines(ruleset: Ruleset) = getCivilopediaTextLinesImpl(ruleset)
+        outerColorObject = safeColorFromRGB(outerColor)
+
+        innerColorObject = if (innerColor == null) ImmutableColor(ImageGetter.CHARCOAL)
+                           else safeColorFromRGB(innerColor!!)
+
+        forestsAndJunglesAreRoads = uniqueMap.hasUnique(UniqueType.ForestsAndJunglesAreRoads)
+        ignoreHillMovementCost = uniqueMap.hasUnique(UniqueType.IgnoreHillMovementCost)
+    }
 
     @Readonly
     fun matchesFilter(filter: String, state: GameContext? = null, multiFilter: Boolean = true): Boolean {
@@ -168,7 +172,9 @@ class Nation : RulesetObject() {
             state != null && hasTagUnique(filter, state) ||
             state == null && hasTagUnique(filter)
     }
+    // endregion
 
+    // region Helpers
     @Readonly
     private fun matchesSingleFilter(filter: String): Boolean {
         // All cases are compile-time constants, for performance
@@ -179,4 +185,5 @@ class Nation : RulesetObject() {
             else -> filter == name
         }
     }
+    // endregion
 }

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -141,7 +141,8 @@ class Nation : RulesetObject() {
         for (unique in uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
             result.add(unique.params[0])
         }
-        val type = ruleset.cityStateTypes[cityStateType] ?: return result
+        val typeName = cityStateType ?: return result
+        val type = ruleset.cityStateTypes[typeName] ?: return result
         for (unique in type.uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
             result.add(unique.params[0])
         }

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -101,28 +101,6 @@ class Nation : RulesetObject() {
     val isBarbarian by lazy { name == Constants.barbarians }
     val isSpectator by lazy { name == Constants.spectator }
 
-    /**
-     * Effective start biases: Nation [startBias] field, plus [UniqueType.StartBias] uniques on the
-     * nation, plus (for city-states) [UniqueType.StartBias] on their [CityStateType].
-     *
-     * Conditionals are evaluated with [gameContext] — pass [GameContext] for the civ when available,
-     * otherwise [GameContext] with gameInfo / [GameContext.IgnoreConditionals] during early map gen.
-     */
-    @Readonly
-    fun getStartBias(ruleset: Ruleset, gameContext: GameContext = GameContext.IgnoreConditionals): List<String> {
-        val result = LinkedHashSet<String>()
-        result.addAll(startBias)
-        for (unique in uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
-            result.add(unique.params[0])
-        }
-        val typeName = cityStateType ?: return result.toList()
-        val type = ruleset.cityStateTypes[typeName] ?: return result.toList()
-        for (unique in type.uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
-            result.add(unique.params[0])
-        }
-        return result.toList()
-    }
-
     // This is its own transient because we'll need to check this for every tile-to-tile movement which is harsh
     @Transient
     var forestsAndJunglesAreRoads = false
@@ -143,6 +121,26 @@ class Nation : RulesetObject() {
         ignoreHillMovementCost = uniqueMap.hasUnique(UniqueType.IgnoreHillMovementCost)
     }
 
+    /**
+     * Effective start biases: Nation [startBias] field, plus [UniqueType.StartBias] uniques on the
+     * nation, plus (for city-states) [UniqueType.StartBias] on their [CityStateType].
+     *
+     * Conditionals are evaluated with [gameContext] — pass [GameContext] for the civ when available,
+     * otherwise [GameContext] with gameInfo / [GameContext.IgnoreConditionals] during early map gen.
+     */
+    @Readonly
+    fun getStartBias(ruleset: Ruleset, gameContext: GameContext = GameContext.IgnoreConditionals): Collection<String> {
+        val result = LinkedHashSet<String>()
+        result.addAll(startBias)
+        for (unique in uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
+            result.add(unique.params[0])
+        }
+        val type = ruleset.cityStateTypes[cityStateType] ?: return result
+        for (unique in type.uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
+            result.add(unique.params[0])
+        }
+        return result
+    }
 
     override fun makeLink() = "Nation/$name"
     override fun getSortGroup(ruleset: Ruleset) = when {

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -102,16 +102,25 @@ class Nation : RulesetObject() {
     val isSpectator by lazy { name == Constants.spectator }
 
     /**
-     * Nation [startBias] plus, for city-states, [CityStateType.startBias] from [ruleset].
-     * Type biases apply to every city-state of that type; per-nation biases are kept as well.
+     * Effective start biases: Nation [startBias] field, plus [UniqueType.StartBias] uniques on the
+     * nation, plus (for city-states) [UniqueType.StartBias] on their [CityStateType].
+     *
+     * Conditionals are evaluated with [gameContext] — pass [GameContext] for the civ when available,
+     * otherwise [GameContext] with gameInfo / [GameContext.IgnoreConditionals] during early map gen.
      */
     @Readonly
-    fun getStartBias(ruleset: Ruleset): List<String> {
-        val typeName = cityStateType ?: return startBias
-        val typeBias = ruleset.cityStateTypes[typeName]?.startBias ?: emptyList()
-        if (typeBias.isEmpty()) return startBias
-        if (startBias.isEmpty()) return typeBias
-        return (startBias + typeBias).distinct()
+    fun getStartBias(ruleset: Ruleset, gameContext: GameContext = GameContext.IgnoreConditionals): List<String> {
+        val result = LinkedHashSet<String>()
+        result.addAll(startBias)
+        for (unique in uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
+            result.add(unique.params[0])
+        }
+        val typeName = cityStateType ?: return result.toList()
+        val type = ruleset.cityStateTypes[typeName] ?: return result.toList()
+        for (unique in type.uniqueMap.getMatchingUniques(UniqueType.StartBias, gameContext)) {
+            result.add(unique.params[0])
+        }
+        return result.toList()
     }
 
     // This is its own transient because we'll need to check this for every tile-to-tile movement which is harsh

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -291,6 +291,9 @@ enum class UniqueType(
     StartingTech("Starting tech", UniqueTarget.Tech),
     StartsWithTech("Starts with [tech]", UniqueTarget.Nation),
     StartsWithPolicy("Starts with [policy] adopted", UniqueTarget.Nation),
+    StartBias("Start bias [terrainFilter]", UniqueTarget.Nation, UniqueTarget.CityState,
+        docDescription = "Same effect as a Nation startBias field entry. Merged with the startBias field " +
+            "and, for city-states, with matching uniques on their CityStateType. Supports conditionals."),
 
     /// Victory
     TriggersVictory("Triggers victory", UniqueTarget.Global),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -293,7 +293,10 @@ enum class UniqueType(
     StartsWithPolicy("Starts with [policy] adopted", UniqueTarget.Nation),
     StartBias("Start bias [terrainFilter]", UniqueTarget.Nation, UniqueTarget.CityState,
         docDescription = "Same effect as a Nation startBias field entry. Merged with the startBias field " +
-            "and, for city-states, with matching uniques on their CityStateType. Supports conditionals."),
+            "and, for city-states, with matching uniques on their CityStateType. " +
+            "Conditionals run against GameInfo only during map generation / start placement " +
+            "(no Civilization — it may be only partially initialized). " +
+            "Do not use conditionals that require tiles, cities, or units."),
 
     /// Victory
     TriggersVictory("Triggers victory", UniqueTarget.Global),

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -171,6 +171,7 @@ open class RulesetValidator protected constructor(
                     if (reportRulesetSpecificErrors) UniqueValidator.allParameterSeverities else UniqueValidator.extensionModParameterSeverities)
                 lines.addAll(errors)
             }
+            uniqueValidator.checkUniques(cityStateType, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 

--- a/core/src/com/unciv/ui/objectdescriptions/NationDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/NationDescriptions.kt
@@ -39,8 +39,9 @@ object NationDescriptions {
         }
         textList += FormattedLine()
 
-        if (startBias.isNotEmpty()) {
-            startBias.withIndex().forEach {
+        val effectiveStartBias = getStartBias(ruleset)
+        if (effectiveStartBias.isNotEmpty()) {
+            effectiveStartBias.withIndex().forEach {
                 // can be "Avoid []"
                 val link = if ('[' !in it.value) it.value
                 else squareBraceRegex.find(it.value)!!.groups[1]!!.value

--- a/core/src/com/unciv/ui/objectdescriptions/NationDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/NationDescriptions.kt
@@ -41,15 +41,15 @@ object NationDescriptions {
 
         val effectiveStartBias = getStartBias(ruleset)
         if (effectiveStartBias.isNotEmpty()) {
-            effectiveStartBias.withIndex().forEach {
+            for ((index, bias) in effectiveStartBias.withIndex()) {
                 // can be "Avoid []"
-                val link = if ('[' !in it.value) it.value
-                else squareBraceRegex.find(it.value)!!.groups[1]!!.value
+                val link = if ('[' !in bias) bias
+                else squareBraceRegex.find(bias)!!.groups[1]!!.value
                 textList += FormattedLine(
-                    (if (it.index == 0) "[Start bias:] " else "") + it.value.tr(),  // extra tr because tr cannot nest {[]}
+                    (if (index == 0) "[Start bias:] " else "") + bias.tr(),  // extra tr because tr cannot nest {[]}
                     link = "Terrain/$link",
-                    indent = if (it.index == 0) 0 else 1,
-                    iconCrossed = it.value.startsWith("Avoid "))
+                    indent = if (index == 0) 0 else 1,
+                    iconCrossed = bias.startsWith("Avoid "))
             }
             textList += FormattedLine()
         }

--- a/docs/Modders/Mod-file-structure/2-Civilization-related-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/2-Civilization-related-JSON-files.md
@@ -62,7 +62,7 @@ Each nation has the following structure:
 | leaderName              | String                                                              | none     | Omit only for city states! If you want LeaderPortraits, the image file names must match exactly, including case                                 |
 | style                   | String                                                              | none     | Modifier appended to pixel unit image names                                                                                                     |
 | cityStateType           | String                                                              | none     | Distinguishes major civilizations from city states (must be in [CityStateTypes.json](#citystatetypesjson))                                      |
-| startBias               | List of strings                                                     | empty    | Zero or more of: [terrainFilter](../Unique-parameters.md#terrainfilter) or "Avoid [terrainFilter]". [^S]                                        |
+| startBias               | List of strings                                                     | empty    | Zero or more of: [terrainFilter](../Unique-parameters.md#terrainfilter) or "Avoid [terrainFilter]". Also merged with `Start bias [terrainFilter]` uniques on the nation and (for city-states) on their CityStateType. [^S] |
 | preferredVictoryType    | String                                                              | Neutral  | The victory type major civilizations will pursue (need not be specified in [VictoryTypes.json](5-Miscellaneous-JSON-files.md#victorytypesjson)) |
 | personality             | String                                                              | none     | The name of the personality specified in [Personalities.json](#personalitiesjson) [^P]                                                          |
 | favoredReligion         | String                                                              | none     | The religion major civilization will choose if available when founding a religion. Must be in [Religions.json](#religionsjson)                  |
@@ -175,6 +175,7 @@ Each city state type has the following structure:
 | name               | String                                                              | Required        |                                                                                                            |
 | friendBonusUniques | List of Strings                                                     | empty           | List of [unique abilities](../uniques.md) granted to major civilizations when friends with this city state |
 | allyBonusUniques   | List of Strings                                                     | empty           | List of [unique abilities](../uniques.md) granted to  major civilizations when allied to city state        |
+| uniques            | List of Strings                                                     | empty           | Type-wide [uniques](../uniques.md) for every city-state of this type (e.g. `Start bias [Coast]`)            |
 | color              | [List of 3× Integer](5-Miscellaneous-JSON-files.md#rgb-colors-list) | [255, 255, 255] | RGB color of text in civilopedia                                                                           |
 
 ## Policies.json

--- a/docs/Modders/schemas/CityStateTypes.schema.json
+++ b/docs/Modders/schemas/CityStateTypes.schema.json
@@ -29,6 +29,16 @@
         "title": "Ally Bonus Uniques",
         "description": "List of unique abilities granted to major civilizations when allied to city state"
       },
+      "startBias": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "examples": ["Avoid [Tundra]", "Avoid [Desert]", "Coast", "Grassland"]
+        },
+        "uniqueItems": true,
+        "title": "Start Bias",
+        "description": "Types of tiles where every city-state of this type is more likely to start. Merged with any per-nation startBias."
+      },
       "color": {
         "$ref": "refs/Color.schema.json",
         "description": "RGB color of text in civilopedia",

--- a/docs/Modders/schemas/CityStateTypes.schema.json
+++ b/docs/Modders/schemas/CityStateTypes.schema.json
@@ -29,15 +29,10 @@
         "title": "Ally Bonus Uniques",
         "description": "List of unique abilities granted to major civilizations when allied to city state"
       },
-      "startBias": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "examples": ["Avoid [Tundra]", "Avoid [Desert]", "Coast", "Grassland"]
-        },
-        "uniqueItems": true,
-        "title": "Start Bias",
-        "description": "Types of tiles where every city-state of this type is more likely to start. Merged with any per-nation startBias."
+      "uniques": {
+        "$ref": "refs/Uniques.schema.json",
+        "title": "Uniques",
+        "description": "Type-wide uniques applied to every city-state of this type (e.g. Start bias [Coast]). Merged with Nation startBias and Nation Start bias uniques."
       },
       "color": {
         "$ref": "refs/Color.schema.json",

--- a/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
+++ b/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
@@ -1,0 +1,70 @@
+package com.unciv.logic.map
+
+import com.unciv.logic.map.mapgenerator.mapregions.MinorCivPlacer
+import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.ruleset.nation.CityStateType
+import com.unciv.models.ruleset.nation.Nation
+import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class CityStateTypeStartBiasTests {
+
+    @Before
+    fun loadRulesets() {
+        if (RulesetCache.isEmpty())
+            RulesetCache.loadRulesets(noMods = true)
+    }
+
+    @Test
+    fun `G&K Maritime city-state type has Coast start bias`() {
+        val ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
+        val maritime = ruleset.cityStateTypes["Maritime"]!!
+        Assert.assertTrue("Coast" in maritime.startBias)
+    }
+
+    @Test
+    fun `Nation getStartBias merges type and nation biases`() {
+        val ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
+        val type = CityStateType().apply {
+            name = "TestType"
+            startBias = arrayListOf("Coast")
+        }
+        ruleset.cityStateTypes[type.name] = type
+
+        val nation = Nation().apply {
+            name = "TestCS"
+            cityStateType = type.name
+            startBias = arrayListOf("Grassland")
+        }
+
+        val bias = nation.getStartBias(ruleset)
+        Assert.assertEquals(listOf("Grassland", "Coast"), bias)
+    }
+
+    @Test
+    fun `prefersCoastalStart uses city-state type startBias`() {
+        val game = TestGame()
+        game.makeHexagonalMap(3)
+        val ruleset = game.ruleset
+        val type = CityStateType().apply {
+            name = "CoastalType"
+            startBias = arrayListOf("Coast")
+        }
+        ruleset.cityStateTypes[type.name] = type
+
+        val nation = Nation().apply {
+            name = "CoastalCS"
+            cityStateType = type.name
+        }
+        ruleset.nations[nation.name] = nation
+
+        val civ = game.addCiv(nation)
+        Assert.assertTrue(MinorCivPlacer.prefersCoastalStart(civ, ruleset))
+    }
+}

--- a/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
+++ b/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.map
 
+import com.unciv.Constants
 import com.unciv.logic.map.mapgenerator.mapregions.MinorCivPlacer
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.RulesetCache
@@ -83,5 +84,22 @@ class CityStateTypeStartBiasTests {
 
         val civ = game.addCiv(nation)
         Assert.assertTrue(MinorCivPlacer.prefersCoastalStart(civ, ruleset))
+    }
+
+    @Test
+    fun `filterTilesByStartBias keeps Hill and drops Avoid Snow`() {
+        val game = TestGame()
+        game.makeHexagonalMap(2, Constants.grassland)
+        // Distance 2 so Avoid [Snow] on the hill tile does not see the snow neighbor.
+        val hillTile = game.setTileTerrainAndFeatures(HexCoord.Zero, Constants.grassland, Constants.hill)
+        val snowTile = game.setTileTerrain(HexCoord(2, 0), Constants.snow)
+
+        val tiles = listOf(hillTile, snowTile)
+        val hillOnly = MinorCivPlacer.filterTilesByStartBias(tiles, listOf("Hill"))
+        Assert.assertEquals(listOf(hillTile), hillOnly)
+
+        val avoidSnow = MinorCivPlacer.filterTilesByStartBias(tiles, listOf("Avoid [Snow]"))
+        Assert.assertEquals(listOf(hillTile), avoidSnow)
+        Assert.assertFalse(avoidSnow.contains(snowTile))
     }
 }

--- a/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
+++ b/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
@@ -5,6 +5,8 @@ import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.nation.CityStateType
 import com.unciv.models.ruleset.nation.Nation
+import com.unciv.models.ruleset.unique.GameContext
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
 import org.junit.Assert
@@ -22,18 +24,21 @@ class CityStateTypeStartBiasTests {
     }
 
     @Test
-    fun `G&K Maritime city-state type has Coast start bias`() {
+    fun `G&K Maritime city-state type has Coast start bias unique`() {
         val ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
         val maritime = ruleset.cityStateTypes["Maritime"]!!
-        Assert.assertTrue("Coast" in maritime.startBias)
+        Assert.assertTrue(
+            maritime.uniqueMap.getMatchingUniques(UniqueType.StartBias, GameContext.IgnoreConditionals)
+                .any { it.params[0] == "Coast" }
+        )
     }
 
     @Test
-    fun `Nation getStartBias merges type and nation biases`() {
+    fun `Nation getStartBias merges type unique and nation field`() {
         val ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
         val type = CityStateType().apply {
             name = "TestType"
-            startBias = arrayListOf("Coast")
+            uniques = arrayListOf("Start bias [Coast]")
         }
         ruleset.cityStateTypes[type.name] = type
 
@@ -48,13 +53,25 @@ class CityStateTypeStartBiasTests {
     }
 
     @Test
-    fun `prefersCoastalStart uses city-state type startBias`() {
+    fun `Nation StartBias unique merges with field`() {
+        val ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
+        val nation = Nation().apply {
+            name = "BiasNation"
+            startBias = arrayListOf("Hills")
+            uniques = arrayListOf("Start bias [Coast]")
+        }
+        val bias = nation.getStartBias(ruleset)
+        Assert.assertEquals(listOf("Hills", "Coast"), bias)
+    }
+
+    @Test
+    fun `prefersCoastalStart uses city-state type StartBias unique`() {
         val game = TestGame()
         game.makeHexagonalMap(3)
         val ruleset = game.ruleset
         val type = CityStateType().apply {
             name = "CoastalType"
-            startBias = arrayListOf("Coast")
+            uniques = arrayListOf("Start bias [Coast]")
         }
         ruleset.cityStateTypes[type.name] = type
 

--- a/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
+++ b/tests/src/com/unciv/logic/map/CityStateTypeStartBiasTests.kt
@@ -49,7 +49,7 @@ class CityStateTypeStartBiasTests {
         }
 
         val bias = nation.getStartBias(ruleset)
-        Assert.assertEquals(listOf("Grassland", "Coast"), bias)
+        Assert.assertEquals(listOf("Grassland", "Coast"), bias.toList())
     }
 
     @Test
@@ -61,7 +61,7 @@ class CityStateTypeStartBiasTests {
             uniques = arrayListOf("Start bias [Coast]")
         }
         val bias = nation.getStartBias(ruleset)
-        Assert.assertEquals(listOf("Hills", "Coast"), bias)
+        Assert.assertEquals(listOf("Hills", "Coast"), bias.toList())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- New unique `Start bias [terrainFilter]` (`UniqueTarget.Nation`, `CityState`) — preferred over a dedicated `CityStateType.startBias` field (per review).
- `Nation.getStartBias(ruleset, gameContext)` merges: nation `startBias` field + nation StartBias uniques + (for city-states) CityStateType `uniques`.
- Conditionals during map-gen placement use **GameInfo-only** `GameContext` (no half-init `Civilization`) — tile/city/unit conditionals are unsupported there; see KDoc on `getGameContextForStartBias`.
- Vanilla / G&K Maritime: `"uniques": ["Start bias [Coast]"]`.
- `MinorCivPlacer` applies the full bias filter (`matchesTerrainFilter` + `Avoid []`), same idea as major placement; `MapRegions` / `GameStarter` use effective biases.

## Follow-ups (not in this PR)
- Civilopedia: show CityStateType `civilopediaText` / type uniques on the CS Nation page.
- Inherit CityStateType uniques into Nation (`BaseUnit.setRuleset`-style).
- Deprecate `Nation.startBias` field once uniques are the single source of truth.

## Test plan
- [x] `CityStateTypeStartBiasTests` (merge unique/field, Coastal preference, Hill / Avoid filter)
- [x] CI green
- [x] Local sample (25× Large Pangaea, RekMOD iron, 12 CS): Maritime coastal **58/59 ≈ 98%** (prior run 69/72 ≈ 96%; master baseline ~25%)