### PR TITLE
Fix two AI spaceship-race bugs: dead space-resource reserve, war push overwriting parts

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -782,6 +782,11 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         spaceResources.clear()
         spaceResources.addAll(ruleset.buildings.values.filter { it.hasUnique(UniqueType.SpaceshipPart) }
             .flatMap { it.getResourceRequirementsPerTurn().keys })
+        // Spaceship parts are UNITS in the base ruleset (SS Booster etc., each requiring Aluminum).
+        // Without harvesting unit requirements too, the resource half of this set is empty in vanilla,
+        // which silently deadens freeUpSpaceResources and Automation's space-resource reserve.
+        spaceResources.addAll(ruleset.units.values.filter { it.hasUnique(UniqueType.SpaceshipPart) }
+            .flatMap { it.getResourceRequirementsPerTurn().keys })
         spaceResources.addAll(ruleset.victories.values.flatMap { it.requiredSpaceshipParts })
 
         barbarians.setTransients(this)

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -783,8 +783,6 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         spaceResources.addAll(ruleset.buildings.values.filter { it.hasUnique(UniqueType.SpaceshipPart) }
             .flatMap { it.getResourceRequirementsPerTurn().keys })
         // Spaceship parts are UNITS in the base ruleset (SS Booster etc., each requiring Aluminum).
-        // Without harvesting unit requirements too, the resource half of this set is empty in vanilla,
-        // which silently deadens freeUpSpaceResources and Automation's space-resource reserve.
         spaceResources.addAll(ruleset.units.values.filter { it.hasUnique(UniqueType.SpaceshipPart) }
             .flatMap { it.getResourceRequirementsPerTurn().keys })
         spaceResources.addAll(ruleset.victories.values.flatMap { it.requiredSpaceshipParts })

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -578,7 +578,13 @@ object NextTurnAutomation {
         for (city in civInfo.cities) {
             if (shouldAnnexCity(civInfo, city)) city.annexCity()
 
-            if (city.health < city.getMaxHealth() || civHasSignificantlyWeakerMilitaryThanEnemies) {
+            // A city mid-spaceship-part stays on it during the empire-wide military push: parts are
+            // civilian units, so tryTrainMilitaryUnit's "already training military" guard doesn't protect
+            // them, and the weaker-military condition re-fires every turn of a long war — repeatedly
+            // knocking the civ off its own win condition. A city actually under attack still drops
+            // everything for defenses.
+            val onSpaceshipPart = city.cityConstructions.getCurrentConstruction().name in civInfo.gameInfo.spaceResources
+            if (city.health < city.getMaxHealth() || (civHasSignificantlyWeakerMilitaryThanEnemies && !onSpaceshipPart)) {
                 Automation.tryTrainMilitaryUnit(city) // need defenses if city is under attack
                 if (city.cityConstructions.constructionQueue.isNotEmpty())
                     continue // found a unit to build so move on

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -578,11 +578,7 @@ object NextTurnAutomation {
         for (city in civInfo.cities) {
             if (shouldAnnexCity(civInfo, city)) city.annexCity()
 
-            // A city mid-spaceship-part stays on it during the empire-wide military push: parts are
-            // civilian units, so tryTrainMilitaryUnit's "already training military" guard doesn't protect
-            // them, and the weaker-military condition re-fires every turn of a long war — repeatedly
-            // knocking the civ off its own win condition. A city actually under attack still drops
-            // everything for defenses.
+            // Don't pull a city off a spaceship part it's already building for the military push (only if actually attacked)
             val onSpaceshipPart = city.cityConstructions.getCurrentConstruction().name in civInfo.gameInfo.spaceResources
             if (city.health < city.getMaxHealth() || (civHasSignificantlyWeakerMilitaryThanEnemies && !onSpaceshipPart)) {
                 Automation.tryTrainMilitaryUnit(city) // need defenses if city is under attack


### PR DESCRIPTION
Follow-up to #15240, from the same self-play diagnosis effort. Both fixes target the same measured AI failure: winning the tech race but losing the spaceship launch (~15% of losses in 1,248-game 4-civ self-play at 350 turns, where ~94% of wins are Scientific).

**1. `GameInfo.spaceResources` never contains the parts' resources in the base ruleset** (`GameInfo.setTransients`): the set harvests resource requirements only from *buildings* with the "Spaceship part" unique — but vanilla parts are *units* (SS Booster etc., each requiring Aluminum). Result: the resource half of the set is empty, so `freeUpSpaceResources` iterates part *names*, `getResourceAmount("SS Booster")` is always 0, and the whole disband-a-unit/sell-a-building valve plus `Automation.allowSpendingResource`'s space reserve are silent no-ops. The AI can fill its army with Aluminum consumers, complete Apollo, and stall the spaceship indefinitely with nothing ever freeing the Aluminum. Fix: also harvest resource requirements from units with the unique (one statement; the existing "is this a part" name-membership usages are unaffected — no construction is named "Aluminum").

**2. The weaker-military production push knocks cities off spaceship parts every turn** (`NextTurnAutomation.automateCities`): when `ownForce < 0.66 × sum(war enemies)`, every city gets `tryTrainMilitaryUnit` — and since parts are civilian units, the "already training a military unit" guard doesn't protect them. In a long defensive war the 0.66× condition holds near-permanently, so a civ that is one part from winning gets pulled off it every single turn. Fix: a city currently building a part keeps building it under the *empire-wide* push; a city that is itself damaged still drops everything for defenses, unchanged.

Compile + `:tests:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)