### PR TITLE
Fix two AI evaluation bugs: inverted WLTKD luxury priority, defensive-pact ally force using wrong civ

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
@@ -258,7 +258,10 @@ object MotivationToAttackAutomation {
     private fun getDefensivePactAlliesScore(otherCiv: Civilization, civInfo: Civilization, baseForce: Float, ourCombatStrength: Float): Float {
         var theirAlliesValue = 0f
         for (thirdCiv in otherCiv.diplomacy.values.filter { it.hasFlag(DiplomacyFlags.DefensivePact) && it.otherCiv != civInfo }) {
-            val thirdCivCombatStrengthRatio = (otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce) / ourCombatStrength
+            // The deterrence value of a defensive-pact ALLY must be computed from the ally's force, not
+            // the target's own (previously a weak civ with a strong protector deterred nobody, while a
+            // strong civ's weak ally counted as if it were mighty).
+            val thirdCivCombatStrengthRatio = (thirdCiv.otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce) / ourCombatStrength
             theirAlliesValue += when {
                 thirdCivCombatStrengthRatio > 5 -> -15f
                 thirdCivCombatStrengthRatio > 2.5 -> -10f

--- a/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
@@ -258,9 +258,7 @@ object MotivationToAttackAutomation {
     private fun getDefensivePactAlliesScore(otherCiv: Civilization, civInfo: Civilization, baseForce: Float, ourCombatStrength: Float): Float {
         var theirAlliesValue = 0f
         for (thirdCiv in otherCiv.diplomacy.values.filter { it.hasFlag(DiplomacyFlags.DefensivePact) && it.otherCiv != civInfo }) {
-            // The deterrence value of a defensive-pact ALLY must be computed from the ally's force, not
-            // the target's own (previously a weak civ with a strong protector deterred nobody, while a
-            // strong civ's weak ally counted as if it were mighty).
+            // Deterrence comes from the ally's own force, not the target's
             val thirdCivCombatStrengthRatio = (thirdCiv.otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce) / ourCombatStrength
             theirAlliesValue += when {
                 thirdCivCombatStrengthRatio > 5 -> -15f

--- a/core/src/com/unciv/logic/automation/civilization/TradeAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/TradeAutomation.kt
@@ -211,7 +211,7 @@ object TradeAutomation {
             .filter { resource ->
                 tradeLogic.ourAvailableOffers
                     .none { it.name == resource.name && it.type == TradeOfferType.Luxury_Resource }
-            }.sortedBy { civInfo.cities.count { city -> city.demandedResource == it.name } } // Prioritize resources that get WLTKD
+            }.sortedByDescending { civInfo.cities.count { city -> city.demandedResource == it.name } } // Prioritize resources that get WLTKD
         val trades = ArrayList<Trade>()
         for (i in 0..min(weHaveTheyDont.lastIndex, theyHaveWeDont.lastIndex)) {
             val trade = Trade()


### PR DESCRIPTION
Two one-line evaluation fixes from the same AI self-play audit as #15240/#15275 (the audit's other finds — the peace-check and ring-weighting integer divisions and the join-war inversions — were already fixed independently in #15159/#15147/#15148/#15150).

**1. Inverted WLTKD luxury priority** (`TradeAutomation.potentialLuxuryTrades`): the incoming-luxury list is `sortedBy` the number of our cities demanding it, directly under the comment "Prioritize resources that get WLTKD" — ascending order puts the least-demanded luxuries first, and the pairing loop then trades for exactly those. `sortedByDescending` makes the code match its stated intent, so 1:1 luxury swaps actually trigger We-Love-The-King days.

**2. Defensive-pact ally deterrence computed from the wrong civ** (`MotivationToAttackAutomation.getDefensivePactAlliesScore`): the loop iterates the target's defensive-pact *allies*, but the ratio — named `thirdCivCombatStrengthRatio` — reads `otherCiv`'s (the target's own) force instead of the ally's. Result: a weak civ with a strong protector gets no deterrence bonus from the pact, while a strong civ's weak ally is counted as if it matched the target's strength. Using `thirdCiv.otherCiv` restores the intended "how scary are their friends" semantics.

Compile + `:tests:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)