### PR TITLE
Fix defensive pact count motivation clamp

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -357,7 +357,7 @@ object DiplomacyAutomation {
         // Try to have a defensive pact with 1/5 of all civs
         val civsToAllyWith = 0.20f * allAliveCivs * civInfo.getPersonality().scaledFocus(PersonalityValue.Diplomacy)
         // Goes from 0 to -40 as the civ gets more allies, offset by civsToAllyWith
-        motivation -= (40f * (defensivePacts - civsToAllyWith) / (allAliveCivs - civsToAllyWith)).coerceAtMost(0f)
+        motivation -= (40f * (defensivePacts - civsToAllyWith) / (allAliveCivs - civsToAllyWith)).coerceAtLeast(0f)
 
         return motivation > 0
     }


### PR DESCRIPTION
## Problem

The current clamp keeps the negative value when the number of defensive pacts is below the target. That value is then subtracted and becomes a motivation bonus. When the number of pacts is above the target, the positive value is clamped to zero and the intended penalty is removed.

## Fix

Use `coerceAtLeast(0f)` so the contribution is zero below the target and the penalty is preserved above the target.