### PR TITLE
Persist multiplayer chat history on this device (opt-in)

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -2011,6 +2011,8 @@ Invalid ID! =
 # Multiplayer options tab
 
 Enable multiplayer status button in singleplayer games = 
+Save chat history on this device = 
+Chat messages are stored only on your device. They are not uploaded to the multiplayer server. = 
 Update status of currently played game every: = 
 In-game, update status of all games every: = 
 Server address = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -2012,7 +2012,7 @@ Invalid ID! =
 
 Enable multiplayer status button in singleplayer games = 
 Save chat history on this device = 
-Chat messages are stored only on your device. They are not uploaded to the multiplayer server. = 
+Chat for each game is stored only on this device (by game id). It is not uploaded to the multiplayer server. = 
 Update status of currently played game every: = 
 In-game, update status of all games every: = 
 Server address = 

--- a/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.MultiplayerAuthException
 import com.unciv.logic.multiplayer.storage.MultiplayerFileNotFoundException
 import com.unciv.logic.multiplayer.storage.MultiplayerServer
+import com.unciv.logic.multiplayer.chat.ChatStore
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.components.extensions.isLargerThan
 import com.unciv.utils.Dispatcher
@@ -159,6 +160,7 @@ class Multiplayer {
         }
 
         val playerCiv = gameInfo.getCivilization(playerCivName)
+        val wasLocalPlayer = playerCiv.playerId == UncivGame.Current.settings.multiplayer.getUserId()
 
         //Set civ info to AI
         playerCiv.playerType = PlayerType.AI
@@ -181,6 +183,7 @@ class Multiplayer {
 
         multiplayerServer.uploadGame(gameInfo, withPreview = true)
         game.updatePreview(gameInfo.asPreview())
+        if (wasLocalPlayer) ChatStore.deleteGameHistory(gameInfo.gameId)
         return ""
     }
 

--- a/core/src/com/unciv/logic/multiplayer/MultiplayerFiles.kt
+++ b/core/src/com/unciv/logic/multiplayer/MultiplayerFiles.kt
@@ -5,6 +5,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameInfoPreview
 import com.unciv.logic.event.EventBus
+import com.unciv.logic.multiplayer.chat.ChatStore
 import com.unciv.utils.debug
 import yairm210.purity.annotations.Readonly
 import java.time.Instant
@@ -40,9 +41,13 @@ class MultiplayerFiles {
         files.deleteSave(fileHandle)
 
         val game = savedGames[fileHandle] ?: return
+        val gameId = game.preview?.gameId
 
-        debug("Deleting game %s with id %s", fileHandle.name(), game.preview?.gameId)
+        debug("Deleting game %s with id %s", fileHandle.name(), gameId)
         savedGames.remove(game.fileHandle)
+        if (!gameId.isNullOrBlank()) {
+            ChatStore.deleteGameHistory(gameId)
+        }
     }
 
     internal fun addGame(newGame: GameInfo) {

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistence.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistence.kt
@@ -1,0 +1,82 @@
+package com.unciv.logic.multiplayer.chat
+
+import com.badlogic.gdx.files.FileHandle
+import com.unciv.UncivGame
+import com.unciv.json.json
+import com.unciv.utils.Log
+import java.util.UUID
+
+/**
+ * Local on-device persistence for multiplayer chat history.
+ * Never uploads to the multiplayer server — files live under [FOLDER] next to GameSettings.
+ */
+object ChatHistoryPersistence {
+    const val FOLDER = "MultiplayerChat"
+    const val MAX_MESSAGES = 200
+
+    class StoredChat {
+        var messages: ArrayList<StoredMessage> = arrayListOf()
+    }
+
+    class StoredMessage {
+        var civName: String = ""
+        var message: String = ""
+    }
+
+    fun isEnabled(): Boolean {
+        if (!UncivGame.isCurrentInitialized()) return false
+        return try {
+            UncivGame.Current.settings.multiplayer.saveChatHistory
+        } catch (_: UninitializedPropertyAccessException) {
+            false
+        }
+    }
+
+    fun loadMessages(gameId: UUID): List<Pair<String, String>>? {
+        if (!isEnabled()) return null
+        return readFrom(fileFor(gameId))
+    }
+
+    fun saveMessages(gameId: UUID, messages: List<Pair<String, String>>) {
+        if (!isEnabled()) return
+        writeTo(fileFor(gameId), messages)
+    }
+
+    /** Round-trip helpers used by production I/O and unit tests. */
+    fun trimMessages(messages: List<Pair<String, String>>): List<Pair<String, String>> {
+        if (messages.size <= MAX_MESSAGES) return messages
+        return messages.takeLast(MAX_MESSAGES)
+    }
+
+    fun readFrom(file: FileHandle): List<Pair<String, String>>? {
+        if (!file.exists()) return null
+        return try {
+            val stored = json().fromJson(StoredChat::class.java, file)
+            stored.messages.map { it.civName to it.message }
+        } catch (ex: Exception) {
+            Log.error("Failed to load chat history from ${file.path()}", ex)
+            null
+        }
+    }
+
+    fun writeTo(file: FileHandle, messages: List<Pair<String, String>>) {
+        try {
+            val trimmed = trimMessages(messages)
+            val stored = StoredChat().apply {
+                this.messages = ArrayList(trimmed.map { pair ->
+                    StoredMessage().apply {
+                        civName = pair.first
+                        message = pair.second
+                    }
+                })
+            }
+            file.parent().mkdirs()
+            file.writeString(json().toJson(stored), false, Charsets.UTF_8.name())
+        } catch (ex: Exception) {
+            Log.error("Failed to save chat history to ${file.path()}", ex)
+        }
+    }
+
+    private fun fileFor(gameId: UUID): FileHandle =
+        UncivGame.Current.files.getLocalFile("$FOLDER/$gameId.json")
+}

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistence.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistence.kt
@@ -8,67 +8,64 @@ import java.util.UUID
 
 /**
  * Local on-device persistence for multiplayer chat history.
- * Never uploads to the multiplayer server — files live under [FOLDER] next to GameSettings.
+ * Never uploads to the multiplayer server — files live under [FOLDER] in the local files root
+ * (one JSON file per game id).
  */
 object ChatHistoryPersistence {
     const val FOLDER = "MultiplayerChat"
     const val MAX_MESSAGES = 200
 
     class StoredChat {
-        var messages: ArrayList<StoredMessage> = arrayListOf()
-    }
-
-    class StoredMessage {
-        var civName: String = ""
-        var message: String = ""
+        var messages: ArrayList<Chat.Line> = arrayListOf()
     }
 
     fun isEnabled(): Boolean {
         if (!UncivGame.isCurrentInitialized()) return false
-        return try {
-            UncivGame.Current.settings.multiplayer.saveChatHistory
-        } catch (_: UninitializedPropertyAccessException) {
-            false
-        }
+        return UncivGame.Current.settings.multiplayer.saveChatHistory
     }
 
-    fun loadMessages(gameId: UUID): List<Pair<String, String>>? {
+    fun loadMessages(gameId: UUID): List<Chat.Line>? {
         if (!isEnabled()) return null
         return readFrom(fileFor(gameId))
     }
 
-    fun saveMessages(gameId: UUID, messages: List<Pair<String, String>>) {
+    fun saveMessages(gameId: UUID, messages: List<Chat.Line>) {
         if (!isEnabled()) return
         writeTo(fileFor(gameId), messages)
     }
 
+    fun deleteForGame(gameId: UUID) {
+        if (!UncivGame.isCurrentInitialized()) return
+        try {
+            val file = fileFor(gameId)
+            if (file.exists()) file.delete()
+        } catch (ex: Exception) {
+            Log.error("Failed to delete chat history for $gameId", ex)
+        }
+    }
+
     /** Round-trip helpers used by production I/O and unit tests. */
-    fun trimMessages(messages: List<Pair<String, String>>): List<Pair<String, String>> {
+    fun trimMessages(messages: List<Chat.Line>): List<Chat.Line> {
         if (messages.size <= MAX_MESSAGES) return messages
         return messages.takeLast(MAX_MESSAGES)
     }
 
-    fun readFrom(file: FileHandle): List<Pair<String, String>>? {
+    fun readFrom(file: FileHandle): List<Chat.Line>? {
         if (!file.exists()) return null
         return try {
             val stored = json().fromJson(StoredChat::class.java, file)
-            stored.messages.map { it.civName to it.message }
+            stored.messages.toList()
         } catch (ex: Exception) {
             Log.error("Failed to load chat history from ${file.path()}", ex)
             null
         }
     }
 
-    fun writeTo(file: FileHandle, messages: List<Pair<String, String>>) {
+    fun writeTo(file: FileHandle, messages: List<Chat.Line>) {
         try {
             val trimmed = trimMessages(messages)
             val stored = StoredChat().apply {
-                this.messages = ArrayList(trimmed.map { pair ->
-                    StoredMessage().apply {
-                        civName = pair.first
-                        message = pair.second
-                    }
-                })
+                this.messages = ArrayList(trimmed)
             }
             file.parent().mkdirs()
             file.writeString(json().toJson(stored), false, Charsets.UTF_8.name())

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
@@ -16,13 +16,13 @@ class Chat(
     var unreadCount = 0
 
     /**
-     * One chat row. [toCivName] is reserved for private messages (protocol v2); null = public.
-     * Defaults exist so Gdx Json can deserialize persisted history.
+     * One chat row. [isPrivate] matches protocol v2 inbound `private: true` (see #15291);
+     * false = public. Defaults exist so Gdx Json can deserialize persisted history.
      */
     data class Line(
         var sender: String = "",
         var text: String = "",
-        var toCivName: String? = null,
+        var isPrivate: Boolean = false,
     )
 
     private val messages: MutableList<Line> =
@@ -48,8 +48,8 @@ class Chat(
     /**
      * Although public, this should only be called when a ChatMessageReceivedEvent is received once.
      */
-    fun addMessage(civName: String, message: String, toCivName: String? = null) {
-        messages.add(Line(civName, message, toCivName))
+    fun addMessage(civName: String, message: String, isPrivate: Boolean = false) {
+        messages.add(Line(civName, message, isPrivate))
         ChatHistoryPersistence.saveMessages(gameId, messages)
     }
 

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
@@ -9,13 +9,16 @@ import java.util.LinkedList
 import java.util.Queue
 import java.util.UUID
 
-data class Chat(
+class Chat(
     val gameId: UUID,
+    loadedMessages: List<Pair<String, String>>? = null,
 ) {
     var unreadCount = 0
 
     // <civName, message> pairs
-    private val messages: MutableList<Pair<String, String>> = mutableListOf(INITIAL_MESSAGE)
+    private val messages: MutableList<Pair<String, String>> =
+        if (loadedMessages.isNullOrEmpty()) mutableListOf(INITIAL_MESSAGE)
+        else loadedMessages.toMutableList()
 
     val length: Int get() = messages.size
 
@@ -37,6 +40,11 @@ data class Chat(
      */
     fun addMessage(civName: String, message: String) {
         messages.add(Pair(civName, message))
+        ChatHistoryPersistence.saveMessages(gameId, messages)
+    }
+
+    fun persist() {
+        ChatHistoryPersistence.saveMessages(gameId, messages)
     }
 
     fun forEachMessage(action: (String, String) -> Unit) {
@@ -65,17 +73,25 @@ object ChatStore {
      */
     private var globalMessages: Queue<Pair<String, String>> = LinkedList()
 
-    fun getChatByGameId(gameId: UUID): Chat = gameIdToChat.getOrPut(gameId) { Chat(gameId) }
+    fun getChatByGameId(gameId: UUID): Chat = gameIdToChat.getOrPut(gameId) {
+        Chat(gameId, ChatHistoryPersistence.loadMessages(gameId))
+    }
     fun getChatByGameId(gameId: String): Chat = getChatByGameId(UUID.fromString(gameId))
 
     fun getGameIds() = gameIdToChat.keys.map { uuid -> uuid.toString() }
 
-    /**
-     * Clears chat by triggering a garbage collection.
-     */
+    /** Flush in-memory chats to disk (when the setting is on), then drop RAM state. */
     fun clear() {
-        gameIdToChat = mutableMapOf()
+        flushAll()
+        gameIdToChat = synchronizedMap(mutableMapOf())
         globalMessages = LinkedList()
+    }
+
+    fun flushAll() {
+        if (!ChatHistoryPersistence.isEnabled()) return
+        for (chat in gameIdToChat.values) {
+            chat.persist()
+        }
     }
 
     fun relayChatMessage(incomingChatMsg: Response.Chat) {

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
@@ -11,16 +11,26 @@ import java.util.UUID
 
 class Chat(
     val gameId: UUID,
-    loadedMessages: List<Pair<String, String>>? = null,
-) {
+    loadedMessages: List<Line>? = null,
+) : Iterable<Chat.Line> {
     var unreadCount = 0
 
-    // <civName, message> pairs
-    private val messages: MutableList<Pair<String, String>> =
+    /**
+     * One chat row. [toCivName] is reserved for private messages (protocol v2); null = public.
+     * Defaults exist so Gdx Json can deserialize persisted history.
+     */
+    data class Line(
+        var sender: String = "",
+        var text: String = "",
+        var toCivName: String? = null,
+    )
+
+    private val messages: MutableList<Line> =
         if (loadedMessages.isNullOrEmpty()) mutableListOf(INITIAL_MESSAGE)
         else loadedMessages.toMutableList()
 
-    val length: Int get() = messages.size
+    val size: Int get() = messages.size
+    override fun iterator() = messages.iterator()
 
     /**
      * Only requests a message to be sent.
@@ -38,8 +48,8 @@ class Chat(
     /**
      * Although public, this should only be called when a ChatMessageReceivedEvent is received once.
      */
-    fun addMessage(civName: String, message: String) {
-        messages.add(Pair(civName, message))
+    fun addMessage(civName: String, message: String, toCivName: String? = null) {
+        messages.add(Line(civName, message, toCivName))
         ChatHistoryPersistence.saveMessages(gameId, messages)
     }
 
@@ -47,14 +57,8 @@ class Chat(
         ChatHistoryPersistence.saveMessages(gameId, messages)
     }
 
-    fun forEachMessage(action: (String, String) -> Unit) {
-        for ((civName, message) in messages) {
-            action(civName, message)
-        }
-    }
-
     companion object {
-        val INITIAL_MESSAGE = "System" to "Welcome to Chat!"
+        val INITIAL_MESSAGE = Line("System", "Welcome to Chat!")
     }
 }
 
@@ -94,9 +98,16 @@ object ChatStore {
         }
     }
 
+    /** Drop local history file and in-memory chat for a finished, abandoned, or deleted game. */
+    fun deleteGameHistory(gameId: String) {
+        val uuid = gameId.toUUIDOrNull() ?: return
+        gameIdToChat.remove(uuid)
+        ChatHistoryPersistence.deleteForGame(uuid)
+    }
+
     fun relayChatMessage(incomingChatMsg: Response.Chat) {
         Gdx.app.postRunnable {
-            if (incomingChatMsg.gameId == null || incomingChatMsg.gameId.isBlank()) {
+            if (incomingChatMsg.gameId.isNullOrBlank()) {
                 relayGlobalMessage(incomingChatMsg.message, incomingChatMsg.civName)
             } else {
                 val gameId = try {

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatWebSocket.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatWebSocket.kt
@@ -189,8 +189,7 @@ object ChatWebSocket {
                 this.sendSerialized(Message.Join(gameIds.toList()))
 
                 while (this.isActive) {
-                    val response = receiveDeserialized<Response>()
-                    when (response) {
+                    when (val response = receiveDeserialized<Response>()) {
                         is Response.Chat -> ChatStore.relayChatMessage(response)
 
                         is Response.Error -> ChatStore.relayGlobalMessage(

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -389,7 +389,7 @@ class GameSettings {
         var turnCheckerEnabled = true
         var turnCheckerPersistentNotificationEnabled = true
         var turnCheckerDelay: Duration = Duration.ofMinutes(5)
-        /** When true, multiplayer chat is stored under MultiplayerChat/ on this device only. */
+        /** When true, multiplayer chat is stored under MultiplayerChat/ in the local files root (one file per game id). */
         var saveChatHistory = false
         var statusButtonInSinglePlayer = false
         var currentGameRefreshDelay: Duration = Duration.ofSeconds(10)

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -389,6 +389,8 @@ class GameSettings {
         var turnCheckerEnabled = true
         var turnCheckerPersistentNotificationEnabled = true
         var turnCheckerDelay: Duration = Duration.ofMinutes(5)
+        /** When true, multiplayer chat is stored under MultiplayerChat/ on this device only. */
+        var saveChatHistory = false
         var statusButtonInSinglePlayer = false
         var currentGameRefreshDelay: Duration = Duration.ofSeconds(10)
         var allGameRefreshDelay: Duration = Duration.ofMinutes(5)

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -43,7 +43,7 @@ internal class MultiplayerTab(
 
         addCheckbox("Save chat history on this device", mpSettings::saveChatHistory)
         add(
-            "Chat messages are stored only on your device. They are not uploaded to the multiplayer server."
+            "Chat for each game is stored only on this device (by game id). It is not uploaded to the multiplayer server."
                 .toLabel(Color.GRAY)
         ).colspan(2).left().padBottom(10f).row()
 

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -41,6 +41,12 @@ internal class MultiplayerTab(
             mpSettings::statusButtonInSinglePlayer, updateWorld = true
         )
 
+        addCheckbox("Save chat history on this device", mpSettings::saveChatHistory)
+        add(
+            "Chat messages are stored only on your device. They are not uploaded to the multiplayer server."
+                .toLabel(Color.GRAY)
+        ).colspan(2).left().padBottom(10f).row()
+
         addSeparator()
 
         val curRefreshSelect = RefreshSelectOptions(

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -17,6 +17,7 @@ import com.unciv.logic.event.EventBus
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.MapVisualization
 import com.unciv.logic.multiplayer.MultiplayerGameUpdated
+import com.unciv.logic.multiplayer.chat.ChatStore
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.MultiplayerAuthException
 import com.unciv.logic.trade.TradeEvaluation
@@ -439,8 +440,11 @@ class WorldScreen(
             when {
                 viewingCiv.shouldShowDiplomaticVotingResults() ->
                     UncivGame.Current.pushScreen(DiplomaticVoteResultScreen(gameInfo.diplomaticVictoryVotesCast, viewingCiv))
-                !gameInfo.oneMoreTurnMode && (viewingCiv.isDefeated() || gameInfo.checkForVictory()) ->
+                !gameInfo.oneMoreTurnMode && (viewingCiv.isDefeated() || gameInfo.checkForVictory()) -> {
+                    if (gameInfo.gameParameters.isOnlineMultiplayer && gameInfo.checkForVictory())
+                        ChatStore.deleteGameHistory(gameInfo.gameId)
                     game.pushScreen(VictoryScreen(this))
+                }
                 viewingCiv.greatPeople.freeGreatPeople > 0 ->
                     game.pushScreen(GreatPersonPickerScreen(this, viewingCiv))
                 viewingCiv.popupAlerts.any() -> AlertPopup(this, viewingCiv.popupAlerts.first())

--- a/core/src/com/unciv/ui/screens/worldscreen/chat/ChatPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/chat/ChatPopup.kt
@@ -11,39 +11,119 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
+import com.unciv.logic.GameInfo
 import com.unciv.logic.multiplayer.chat.Chat
 import com.unciv.logic.multiplayer.chat.ChatStore
+import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.extensions.brighten
 import com.unciv.ui.components.extensions.coerceLightnessAtLeast
+import com.unciv.ui.components.extensions.getContrastRatio
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.ColorMarkupLabel
 import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
+import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.worldscreen.WorldScreen
 
 
-private val civChatColorsMap = mapOf<String, Color>(
+private val civChatColorsMap = mapOf(
     "System" to Color.WHITE,
-    "Server" to Color.DARK_GRAY,
+    "Server" to Color.LIGHT_GRAY,
 )
+
+/** Approximate Popup InnerTable tone — for nation-name contrast checks. */
+private val chatPanelBackground = Color.DARK_GRAY
+
+private const val NAME_MIN_CONTRAST = 3.0
+private const val NAME_LIGHTEN = 0.18f
+private const val NAME_MIN_LIGHTNESS = 0.55f
+
+private fun isTooCloseToWhite(color: Color): Boolean =
+    color.r > 0.82f && color.g > 0.82f && color.b > 0.82f
+
+private fun fallbackColorForName(name: String): Color {
+    val hue = ((name.hashCode() % 360) + 360) % 360
+    return Color().fromHsv(hue.toFloat(), 0.70f, 0.95f)
+}
+
+/**
+ * Readable nation color on the dark chat panel.
+ * Prefer outer, then inner; skip near-white (body is white); else a stable hash hue.
+ */
+private fun pickNationNameColor(nation: Nation?, senderName: String): Color {
+    val candidates = buildList {
+        if (nation != null) {
+            add(nation.getOuterColor())
+            add(nation.getInnerColor())
+        }
+    }
+
+    for (color in candidates) {
+        if (isTooCloseToWhite(color)) continue
+        if (getContrastRatio(chatPanelBackground, color) < NAME_MIN_CONTRAST) continue
+        return color.brighten(NAME_LIGHTEN).apply { a = 1f }
+    }
+    for (color in candidates) {
+        if (isTooCloseToWhite(color)) continue
+        return color.coerceLightnessAtLeast(NAME_MIN_LIGHTNESS).apply { a = 1f }
+    }
+    return fallbackColorForName(senderName)
+}
+
+private fun resolveNation(gameInfo: GameInfo, senderCivName: String): Nation? =
+    gameInfo.getCivilizationOrNull(senderCivName)?.nation
+        ?: gameInfo.ruleset.nations[senderCivName]
+
+/** One chat line: no bubble — nation-colored name + white body. */
+fun createChatMessageLine(
+    gameInfo: GameInfo,
+    senderCivName: String,
+    message: String,
+    suffix: String? = null,
+): Table {
+    val row = Table()
+
+    if (senderCivName in civChatColorsMap) {
+        val line = Label(
+            "${senderCivName.tr()}${if (suffix != null) " [${suffix.tr()}]" else ""}: ${message.tr()}",
+            BaseScreen.skin
+        ).apply {
+            wrap = true
+            setAlignment(Align.left)
+            color = civChatColorsMap.getValue(senderCivName)
+        }
+        row.add(line).growX().left()
+        return row
+    }
+
+    val nameColor = pickNationNameColor(resolveNation(gameInfo, senderCivName), senderCivName)
+    val suffixPart = if (suffix != null) " ({$suffix})" else ""
+    val nameMarkup = "#" + nameColor.toString().substring(0, 6)
+    val line = ColorMarkupLabel(
+        "«$nameMarkup»{$senderCivName}$suffixPart:«WHITE» $message",
+        defaultColor = Color.WHITE
+    ).apply {
+        wrap = true
+        setAlignment(Align.left)
+    }
+    row.add(line).growX().left()
+    return row
+}
 
 class ChatPopup(
     val chat: Chat,
     private val worldScreen: WorldScreen,
 ) : Popup(screen = worldScreen, scrollable = Scrollability.None) {
-    companion object {
-        // the percentage of the minimum lightness allowed for a civName
-        const val CIVNAME_COLOR_MIN_LIGHTNESS = 0.55f
-    }
-
     private val chatTable = Table(skin)
     private val scrollPane = ScrollPane(chatTable, skin)
     private val messageField = UncivTextField(hint = "Type something...")
 
     init {
         ChatStore.chatPopup = this
-        chatTable.defaults().growX().pad(5f).center()
+        chatTable.defaults().growX().pad(5f).left()
 
         /**
          * Layout:
@@ -52,7 +132,6 @@ class ChatPopup(
          * | MessageField | SendButton |
          */
 
-        // Header: |  ChatHeader | CloseButton  |
         val chatHeader = Table(skin)
         val chatLabel = "Chat".toLabel(fontSize = 30, alignment = Align.center)
         val chatIcon = ImageGetter.getImage("OtherIcons/Chat")
@@ -70,23 +149,19 @@ class ChatPopup(
                 }
         ).size(chatLabel.height * 1.3f).right().row()
 
-        // Chat: |  ChatTable (colSpan = 2)  |
         scrollPane.setFadeScrollBars(false)
         scrollPane.setScrollingDisabled(true, false)
         add(scrollPane).colspan(2)
             .size(0.5f * worldScreen.stage.width, 0.5f * worldScreen.stage.height)
             .expand().fill().row()
 
-        // Input: | MessageField | SendButton |
         add(messageField).expandX().fillX()
         val sendButton = Button(skin)
         sendButton.add(ImageGetter.getImage("OtherIcons/Send"))
         add(sendButton).size(messageField.height * 1.2f, messageField.height).padLeft(1f).row()
 
-        // populate previous chats
         populateChat()
 
-        // Send button logic (for demo, just adds to UI)
         sendButton.onClick { sendMessage() }
 
         messageField.addListener(object : InputListener() {
@@ -124,21 +199,9 @@ class ChatPopup(
         suffix: String? = null,
         scroll: Boolean = true
     ) {
-        val line = Label(
-            "${senderCivName.tr()}${if (suffix != null) " [${suffix.tr()}]" else ""}: ${message.tr()}",
-            skin
-        ).apply {
-            wrap = true
-
-            val civNameColor =
-                civChatColorsMap[senderCivName]
-                    ?: worldScreen.gameInfo.getCivilizationOrNull(senderCivName)?.nation?.getOuterColor()
-                    ?: Color.BLACK
-
-            color = civNameColor.coerceLightnessAtLeast(CIVNAME_COLOR_MIN_LIGHTNESS)
-        }
-
-        chatTable.add(line).row()
+        chatTable.add(
+            createChatMessageLine(worldScreen.gameInfo, senderCivName, message, suffix)
+        ).growX().left().row()
         if (scroll) scrollToBottom()
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/chat/ChatPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/chat/ChatPopup.kt
@@ -144,9 +144,8 @@ class ChatPopup(
 
     private fun populateChat() {
         chatTable.clearChildren()
-        chat.forEachMessage { civName, message ->
+        for ((civName, message) in chat)
             addMessage(civName, message)
-        }
         ChatStore.pollGlobalMessages { civName, message ->
             addMessage(civName, message, suffix = "one time")
         }

--- a/tests/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistenceTests.kt
+++ b/tests/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistenceTests.kt
@@ -1,0 +1,60 @@
+package com.unciv.logic.multiplayer.chat
+
+import com.badlogic.gdx.files.FileHandle
+import com.unciv.testing.GdxTestRunner
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.file.Files
+
+@RunWith(GdxTestRunner::class)
+class ChatHistoryPersistenceTests {
+
+    @Test
+    fun `round-trip save and load`() {
+        val dir = FileHandle(Files.createTempDirectory("chat-hist-rt").toFile())
+        val file = dir.child("game.json")
+        val messages = listOf(
+            "System" to "Welcome to Chat!",
+            "Rome" to "hello",
+            "Egypt" to "hi there",
+        )
+
+        ChatHistoryPersistence.writeTo(file, messages)
+        assertTrue(file.exists())
+
+        val loaded = ChatHistoryPersistence.readFrom(file)
+        assertEquals(messages, loaded)
+
+        dir.deleteDirectory()
+    }
+
+    @Test
+    fun `trim keeps only the last MAX_MESSAGES`() {
+        val overflow = ChatHistoryPersistence.MAX_MESSAGES + 50
+        val messages = (1..overflow).map { "Civ$it" to "msg$it" }
+
+        val trimmed = ChatHistoryPersistence.trimMessages(messages)
+        assertEquals(ChatHistoryPersistence.MAX_MESSAGES, trimmed.size)
+        assertEquals("Civ${overflow - ChatHistoryPersistence.MAX_MESSAGES + 1}", trimmed.first().first)
+        assertEquals("Civ$overflow", trimmed.last().first)
+
+        val dir = FileHandle(Files.createTempDirectory("chat-hist-trim").toFile())
+        val file = dir.child("game.json")
+        ChatHistoryPersistence.writeTo(file, messages)
+        val loaded = ChatHistoryPersistence.readFrom(file)!!
+        assertEquals(ChatHistoryPersistence.MAX_MESSAGES, loaded.size)
+        assertEquals(trimmed, loaded)
+
+        dir.deleteDirectory()
+    }
+
+    @Test
+    fun `missing file returns null`() {
+        val dir = FileHandle(Files.createTempDirectory("chat-hist-miss").toFile())
+        assertNull(ChatHistoryPersistence.readFrom(dir.child("nope.json")))
+        dir.deleteDirectory()
+    }
+}

--- a/tests/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistenceTests.kt
+++ b/tests/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistenceTests.kt
@@ -20,7 +20,7 @@ class ChatHistoryPersistenceTests {
             Chat.Line("System", "Welcome to Chat!"),
             Chat.Line("Rome", "hello"),
             Chat.Line("Egypt", "hi there"),
-            Chat.Line("Rome", "psst", toCivName = "Egypt"),
+            Chat.Line("Rome", "psst", isPrivate = true),
         )
 
         ChatHistoryPersistence.writeTo(file, messages)
@@ -31,7 +31,7 @@ class ChatHistoryPersistenceTests {
         for (i in messages.indices) {
             assertEquals(messages[i].sender, loaded[i].sender)
             assertEquals(messages[i].text, loaded[i].text)
-            assertEquals(messages[i].toCivName, loaded[i].toCivName)
+            assertEquals(messages[i].isPrivate, loaded[i].isPrivate)
         }
 
         dir.deleteDirectory()

--- a/tests/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistenceTests.kt
+++ b/tests/src/com/unciv/logic/multiplayer/chat/ChatHistoryPersistenceTests.kt
@@ -17,16 +17,22 @@ class ChatHistoryPersistenceTests {
         val dir = FileHandle(Files.createTempDirectory("chat-hist-rt").toFile())
         val file = dir.child("game.json")
         val messages = listOf(
-            "System" to "Welcome to Chat!",
-            "Rome" to "hello",
-            "Egypt" to "hi there",
+            Chat.Line("System", "Welcome to Chat!"),
+            Chat.Line("Rome", "hello"),
+            Chat.Line("Egypt", "hi there"),
+            Chat.Line("Rome", "psst", toCivName = "Egypt"),
         )
 
         ChatHistoryPersistence.writeTo(file, messages)
         assertTrue(file.exists())
 
-        val loaded = ChatHistoryPersistence.readFrom(file)
-        assertEquals(messages, loaded)
+        val loaded = ChatHistoryPersistence.readFrom(file)!!
+        assertEquals(messages.size, loaded.size)
+        for (i in messages.indices) {
+            assertEquals(messages[i].sender, loaded[i].sender)
+            assertEquals(messages[i].text, loaded[i].text)
+            assertEquals(messages[i].toCivName, loaded[i].toCivName)
+        }
 
         dir.deleteDirectory()
     }
@@ -34,19 +40,19 @@ class ChatHistoryPersistenceTests {
     @Test
     fun `trim keeps only the last MAX_MESSAGES`() {
         val overflow = ChatHistoryPersistence.MAX_MESSAGES + 50
-        val messages = (1..overflow).map { "Civ$it" to "msg$it" }
+        val messages = (1..overflow).map { Chat.Line("Civ$it", "msg$it") }
 
         val trimmed = ChatHistoryPersistence.trimMessages(messages)
         assertEquals(ChatHistoryPersistence.MAX_MESSAGES, trimmed.size)
-        assertEquals("Civ${overflow - ChatHistoryPersistence.MAX_MESSAGES + 1}", trimmed.first().first)
-        assertEquals("Civ$overflow", trimmed.last().first)
+        assertEquals("Civ${overflow - ChatHistoryPersistence.MAX_MESSAGES + 1}", trimmed.first().sender)
+        assertEquals("Civ$overflow", trimmed.last().sender)
 
         val dir = FileHandle(Files.createTempDirectory("chat-hist-trim").toFile())
         val file = dir.child("game.json")
         ChatHistoryPersistence.writeTo(file, messages)
         val loaded = ChatHistoryPersistence.readFrom(file)!!
         assertEquals(ChatHistoryPersistence.MAX_MESSAGES, loaded.size)
-        assertEquals(trimmed, loaded)
+        assertEquals(trimmed.map { it.sender to it.text }, loaded.map { it.sender to it.text })
 
         dir.deleteDirectory()
     }


### PR DESCRIPTION
## Summary
- Adds opt-in **Save chat history on this device** (default off) under Options → Multiplayer, with a gray note that history stays on the device (per game id) and is not uploaded to the server.
- When enabled, chat is stored as `MultiplayerChat/<gameId>.json` (last 200 messages). Load on first access; save on each new message; flush before `ChatStore.clear()` / websocket stop.
- Message model is `Chat.Line(sender, text, isPrivate)` — `isPrivate` matches protocol v2 inbound `private: true` (#15291) for forward-compatible local history; this PR does **not** implement PM UI/protocol.
- One-shot System/reconnect lines are unchanged (they never enter `Chat.messages`). Turning the setting off stops writing but does not delete existing files. Finished/abandoned/deleted games drop their local chat file.

**Conflict note:** preferred rebase order with sibling chat PRs is #15289 → #15290 → #15291. Happy to rebase when conflicts appear.

## Test plan
- [x] `.\gradlew tests:test --tests "com.unciv.logic.multiplayer.chat.ChatHistoryPersistenceTests"`
- [x] Setting off (default): chat still works; no files under MultiplayerChat/
- [x] Enable setting → send messages → quit/reopen same MP game → history restored
- [x] Disable setting → new messages not written; old files remain
- [x] Confirm Options text clearly says on-device / not uploaded