### PR TITLE
Russian: translate Start bias / Avoid [terrain] in Civilopedia

### DIFF
--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -1363,8 +1363,8 @@ Social policies = Общественные институты
 Close = Закрыть
 Do you want to exit the game? = Вы хотите выйти из игры?
 Exit = Выйти
-Start bias: =
-Avoid [terrain] =
+Start bias: = Начальная привязка:
+Avoid [terrain] = Избегать [terrain]
 
 # Maya calendar popup
 
@@ -2263,8 +2263,7 @@ Spies in [cityFilter] cities act as though they have [relativeAmount] levels for
 Starting tech = Начальная технология
 Starts with [tech] = Начинает с технологией [tech]
 Starts with [policy] adopted = Начинает с принятым институтом [policy]
- # Requires translation!
-Start bias [terrainFilter] = 
+Start bias [terrainFilter] = Начальная привязка: [terrainFilter]
 Triggers victory = Приводит к победе
 Triggers a Cultural Victory upon completion = Приводит к культурной победе при завершении
 May buy items in puppet cities = Может покупать товары в городах-сателлитах


### PR DESCRIPTION
## Summary
- Fills Russian translations for Civilopedia start-bias labels that were blank:
  - `Start bias:` → `Начальная привязка:`
  - `Avoid [terrain]` → `Избегать [terrain]`
  - `Start bias [terrainFilter]` → `Начальная привязка: [terrainFilter]`
- Wording aligned with existing `Disable starting bias = Без начальных привязок`.
- Native-speaker one-language PR (no bulk AI translations).

## Test plan
- [ ] Set language to Russian → Civilopedia → Finland (or any Avoid Coast nation)
- [ ] Expect `Начальная привязка:` and `Избегать Побережье` (not `Avoid Побережье` / `Start bias:`)