### PR TITLE
Fix Korean tech boost UA

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -644,9 +644,9 @@ class CityConstructions : IsPartOfGameInfoSerialization {
          * It is unclear whether RA modifiers should apply. For now, they do not.
          */
         fun applyKoreanUnique() {
-            if (! building.isStatRelated(Stat.Science, city)) return
-            if (! civ.hasUnique(UniqueType.TechBoostWhenScientificBuildingsBuiltInCapital)) return
-            if (! city.isCapital()) return
+            if (!building.isStatRelated(Stat.Science, city)) return
+            if (!civ.hasUnique(UniqueType.TechBoostWhenScientificBuildingsBuiltInCapital)) return
+            if (!city.isCapital()) return
             val availableTechCosts = city.getRuleset().technologies.values
                 .filter { civ.tech.canBeResearched(it.name) }
                 .map { civ.tech.costOfTech(it.name) }

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -640,9 +640,8 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
         /**
          * The [Korean unique](https://civilization.fandom.com/wiki/Korean_(Civ5)#Strategy) gives the same tech boost as a [research agreement](https://civilization.fandom.com/wiki/Diplomacy_(Civ5)#Research_Agreement).
-         * We use Vanilla / G&K logic as it is more straightforward.
-         * It is unclear whether RA modifiers should apply.
-         * For now, the tech boost is half of the median cost of our researchable techs.
+         * We use Vanilla / G&K logic as it is more straightforward, i.e. half of the median cost of our researchable techs.
+         * It is unclear whether RA modifiers should apply. For now, they do not.
          */
         fun applyKoreanUnique() {
             if (! building.isStatRelated(Stat.Science, city)) return

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -639,9 +639,10 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             civ.cache.updateHasActiveEnemyMovementPenalty()
 
         /**
-         * The Korean unique apparently gives the same tech boost as a [research agreement](https://civilization.fandom.com/wiki/Diplomacy_(Civ5)#Research_Agreement).
+         * The [Korean unique](https://civilization.fandom.com/wiki/Korean_(Civ5)#Strategy) gives the same tech boost as a [research agreement](https://civilization.fandom.com/wiki/Diplomacy_(Civ5)#Research_Agreement).
          * We use Vanilla / G&K logic as it is more straightforward.
-         * The tech boost is half of the median cost of the civ's researchable techs.
+         * It is unclear whether RA modifiers should apply.
+         * For now, the tech boost is half of the median cost of our researchable techs.
          */
         fun applyKoreanUnique() {
             if (! building.isStatRelated(Stat.Science, city)) return

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -638,10 +638,29 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         if (building.hasUnique(UniqueType.EnemyUnitsSpendExtraMovement))
             civ.cache.updateHasActiveEnemyMovementPenalty()
 
-        // Korean unique - apparently gives the same as the research agreement
-        if (building.isStatRelated(Stat.Science, city) && civ.hasUnique(UniqueType.TechBoostWhenScientificBuildingsBuiltInCapital)
-            && city.isCapital())
-            civ.tech.addScience(civ.tech.scienceOfLast8Turns.sum() / 8)
+        /**
+         * The Korean unique apparently gives the same tech boost as a [research agreement](https://civilization.fandom.com/wiki/Diplomacy_(Civ5)#Research_Agreement).
+         * We use Vanilla / G&K logic as it is more straightforward.
+         * The tech boost is half of the median cost of the civ's researchable techs.
+         */
+        fun applyKoreanUnique() {
+            if (! building.isStatRelated(Stat.Science, city)) return
+            if (! civ.hasUnique(UniqueType.TechBoostWhenScientificBuildingsBuiltInCapital)) return
+            if (! city.isCapital()) return
+            val availableTechCosts = city.getRuleset().technologies.values
+                .filter { civ.tech.canBeResearched(it.name) }
+                .map { civ.tech.costOfTech(it.name) }
+                .sorted()
+            if (availableTechCosts.isEmpty()) return
+            val n = availableTechCosts.size
+            val medianCost =
+                if (n % 2 == 1) availableTechCosts[n / 2].toFloat()
+                else (availableTechCosts[n / 2 - 1] + availableTechCosts[n / 2]) / 2f
+            val techBoost = (0.5f * medianCost).roundToInt()
+            civ.tech.addScience(techBoost)
+        }
+        
+        applyKoreanUnique()
 
         val previousHappiness = civ.getHappiness()
         // can cause civ happiness update: reassignPopulationDeferred -> reassignPopulation -> cityStats.update -> civ.updateHappiness


### PR DESCRIPTION
The implementation did not correspond with the original comment. It also did not account for game speed.
This PR ensures the Korean tech boost uses Vanilla / G&K research agreement logic.
It is unclear whether RA modifiers should also apply. For now, they do not.