### PR TITLE
Fix military unit gift notification locations

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -182,7 +182,7 @@ class CityStateFunctions(val civInfo: Civilization) {
 
         // Point to the gifted unit, then to the other places mentioned in the message
         val unitAction = sequenceOf(MapUnitAction(placedUnit))
-        val notificationActions = unitAction + LocationAction(city.location, city.location)
+        val notificationActions = unitAction + LocationAction(city.location)
         receivingCiv.addNotification(
             "[${civInfo.civName}] gave us a [${militaryUnit.name}] as gift near [${city.name}]!",
             notificationActions,


### PR DESCRIPTION
## Problem

The military unit gift notification adds the recipient city twice. Repeated clicks show the same location twice after selecting the gifted unit.

## Fix

Remove the duplicate location so the notification cycles between the gifted unit and the recipient city.