### PR TITLE
Fix missing translatable entry

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -292,6 +292,7 @@ Friendly =
 Hostile = 
 Irrational = 
 Personality = 
+Personalities = 
 Influence = 
 [leader]'s personality = 
 Neutral personality = 


### PR DESCRIPTION
"Personalities" in the Civilopedia tabs:

Before:
<img width="416" height="87" alt="image" src="https://github.com/user-attachments/assets/1e2b5fb5-d696-4128-82f9-ff5601d1295b" />

After:
<img width="426" height="88" alt="image" src="https://github.com/user-attachments/assets/7873a9fc-36e9-4990-945c-e1aa254863df" />
