### PR TITLE
Document license of Unciv logo files and 2 icons

### DIFF
--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -34,7 +34,7 @@ Unciv logo (e.g. `extraImages/Icons/Unciv icon v6.png`, `android/assets/ExtraIma
 The following files include the Unciv logo:
 
 - `android/assets/ExtraImages/banner.png` by letstalkaboutdune; includes work by The Bucketeer / @GeneralWadaling (tiles) and yairm210 and u-ndefine (Unciv logo), released under CC BY-SA 3.0
-- `extraImages/Feature graphic - Google Play.png` by letstalkaboutdune; includes the Unciv logo by yairm210 and u-ndefine, released under [UNKNOWN LICENSE, probably CC BY 3.0]
+- `extraImages/Feature graphic - Google Play.png` by letstalkaboutdune; includes the Unciv logo by yairm210 and u-ndefine, released under [UNKNOWN LICENSE, probably non-free]
 
 The base tile icons for the "Fantasy Hex" tileset were created CuddlyClover at <https://cuddlyclover.itch.io/fantasy-hex-tiles> with a few additions by various contributors, licensed CC BY 4.0.
 

--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -9,6 +9,7 @@ The works listed in this document fall under various licenses. Here’s a list o
 * CC BY 4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
 * CC BY-SA 4.0 [Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)
 * Public domain: The work has been released into the public domain.
+* Unknown license: A few works have unknown authorship and/or licensing.
 
 ## Icon Credits
 
@@ -22,7 +23,21 @@ Flag Icons made by [Freepik](https://www.flaticon.com/authors/freepik) from [www
 -   [Galician flag] made from [wikipedia asset for the civil flag of Galicia](https://en.wikipedia.org/wiki/File:Flag_of_Galicia_(civil).svg): (public domain)
 -   [Hindi flag] made from [wikipedia asset for India's flag](https://en.wikipedia.org/w/index.php?curid=23473510): (public domain)
 
-New Unciv logo made by u-ndefined on Discord
+Unciv logo (e.g. `extraImages/Icons/Unciv icon v6.png`, `android/assets/ExtraImages/Icons/Unciv128.png` and other files) by yairm210 and u-ndefine, licensed under CC BY 4.0. This logo includes the following icons:
+- [Gear](https://thenounproject.com/term/gear/29368) by Alex Bickov (CC BY 3.0)
+- [Apple](https://thenounproject.com/term/apple/1139396) by Pedro Gonçalves (CC BY 3.0)
+- [gold](https://thenounproject.com/term/gold/25438) by Eliricon (CC BY 3.0)
+- [Beaker](https://thenounproject.com/term/beaker/621510) by Delwar Hossain (CC BY 3.0)
+- [Music](https://thenounproject.com/term/music/5611/) by Naomi Atkinson (CC BY 3.0)
+- [Smiley](https://thenounproject.com/term/smiley/1024026) by Alexander Skowalsky (CC BY 3.0)
+- [City](https://thenounproject.com/icon/city-1765370/) by Muhajir ila Robbi (CC BY 3.0)
+
+The following files include the Unciv logo:
+
+- Various files in `extraImages` contain different renderings of the same logo
+- `android/assets/ExtraImages/banner.png` by letstalkaboutdune; includes work by The Bucketeer / @GeneralWadaling (tiles) and yairm210 and u-ndefine (Unciv logo), released under CC BY-SA 3.0
+- `extraImages/Feature graphic - Google Play.png` by letstalkaboutdune; includes the Unciv logo by yairm210 and u-ndefine. The licensing is UNKNOWN due to unknown authorship and licensing of the background (`extraImages/Steam/library_hero.png`)
+- In `extraImages/Steam/`, the files `library_capsule.png`, `store_capsule_header.png`, `store_capsule_main.png`, `store_capsule_small.png`, `store_capsule_vertical.png` include the Unciv logo by yairm210 and u-ndefine. The full licensing and authorship of those files is UNKNOWN due to unknown authorship and licensing of the background
 
 The base tile icons for the "Fantasy Hex" tileset were created CuddlyClover at <https://cuddlyclover.itch.io/fantasy-hex-tiles> with a few additions by various contributors, licensed CC BY 4.0.
 
@@ -653,7 +668,7 @@ HexaRealm tileset images by legacymtgsalvationuser69544 [here](https://github.co
     -   [Spear](https://thenounproject.com/term/spear/3930020/) by Firza Alamsyah
     -   [pennant](https://thenounproject.com/term/pennant/194797/) by Sara Jeffries
 -   [Maya civilization](https://thenounproject.com/term/maya-civilization/1715786/) by Olena Panasovska for The Maya
--   Aztec icon by Kāne, on Unciv Discord server
+-   Aztec icon by Kāne, on Unciv Discord server (CC BY 3.0)
 -   [Questionmark](https://thenounproject.com/icon/questionmark-4248169/) by YURR.studio for Random nation indicator
 -   [View](https://thenounproject.com/icon/view-4211245/) by Adrien Coquet for Spectator
 
@@ -799,7 +814,7 @@ HexaRealm tileset images by legacymtgsalvationuser69544 [here](https://github.co
 - [RobotArm](https://thenounproject.com/icon/robot-7300306/) by Faizal khusein
 - [RobotHeadSquare](https://thenounproject.com/icon/robot-head-6356754/) by Ahmad Arzaha
 - [RobotHeadRect](https://thenounproject.com/icon/robot-1704106/) by suib icon
-- Bobot by reallybasicname in the Discord
+- Bobot by reallybasicname in the Discord (CC BY 3.0)
 - [DollarSign](https://thenounproject.com/icon/dollar-sign-6466560/) by Ahmad Arzaha
 - Spy hideout is gimped from [hide](https://thenounproject.com/icon/hide-8013/) by Luis Prado and the one listed for Spy
 - [hold](https://thenounproject.com/icon/hold-222516/) by icon 54 as long-press indicator

--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -22,7 +22,7 @@ Flag Icons made by [Freepik](https://www.flaticon.com/authors/freepik) from [www
 -   [Galician flag] made from [wikipedia asset for the civil flag of Galicia](https://en.wikipedia.org/wiki/File:Flag_of_Galicia_(civil).svg): (public domain)
 -   [Hindi flag] made from [wikipedia asset for India's flag](https://en.wikipedia.org/w/index.php?curid=23473510): (public domain)
 
-Unciv logo (e.g. `extraImages/Icons/Unciv icon v6.png`, `android/assets/ExtraImages/Icons/Unciv128.png` and likely other files) by yairm210 and u-ndefine, licensed under CC BY 4.0. This logo includes the following icons:
+Unciv logo (e.g. `extraImages/Icons/Unciv icon v6.png`, `android/assets/ExtraImages/Icons/Unciv128.png` and other files) by yairm210 and u-ndefine, licensed under CC BY 4.0. This logo includes the following icons:
 - [Gear](https://thenounproject.com/term/gear/29368) by Alex Bickov (CC BY 3.0)
 - [Apple](https://thenounproject.com/term/apple/1139396) by Pedro Gonçalves (CC BY 3.0)
 - [gold](https://thenounproject.com/term/gold/25438) by Eliricon (CC BY 3.0)

--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -22,7 +22,19 @@ Flag Icons made by [Freepik](https://www.flaticon.com/authors/freepik) from [www
 -   [Galician flag] made from [wikipedia asset for the civil flag of Galicia](https://en.wikipedia.org/wiki/File:Flag_of_Galicia_(civil).svg): (public domain)
 -   [Hindi flag] made from [wikipedia asset for India's flag](https://en.wikipedia.org/w/index.php?curid=23473510): (public domain)
 
-New Unciv logo made by u-ndefined on Discord
+Unciv logo (e.g. `extraImages/Icons/Unciv icon v6.png`, `android/assets/ExtraImages/Icons/Unciv128.png` and likely other files) by yairm210 and u-ndefine, licensed under CC BY 4.0. This logo includes the following icons:
+- [Gear](https://thenounproject.com/term/gear/29368) by Alex Bickov (CC BY 3.0)
+- [Apple](https://thenounproject.com/term/apple/1139396) by Pedro Gonçalves (CC BY 3.0)
+- [gold](https://thenounproject.com/term/gold/25438) by Eliricon (CC BY 3.0)
+- [Beaker](https://thenounproject.com/term/beaker/621510) by Delwar Hossain (CC BY 3.0)
+- [Music](https://thenounproject.com/term/music/5611/) by Naomi Atkinson (CC BY 3.0)
+- [Smiley](https://thenounproject.com/term/smiley/1024026) by Alexander Skowalsky (CC BY 3.0)
+- [City](https://thenounproject.com/icon/city-1765370/) by Muhajir ila Robbi (CC BY 3.0)
+
+The following files include the Unciv logo:
+
+- `android/assets/ExtraImages/banner.png` by letstalkaboutdune; includes work by The Bucketeer / @GeneralWadaling (tiles) and yairm210 and u-ndefine (Unciv logo), released under CC BY-SA 3.0
+- `extraImages/Feature graphic - Google Play.png` by letstalkaboutdune; includes the Unciv logo by yairm210 and u-ndefine, released under [UNKNOWN LICENSE, probably CC BY 3.0]
 
 The base tile icons for the "Fantasy Hex" tileset were created CuddlyClover at <https://cuddlyclover.itch.io/fantasy-hex-tiles> with a few additions by various contributors, licensed CC BY 4.0.
 
@@ -653,7 +665,7 @@ HexaRealm tileset images by legacymtgsalvationuser69544 [here](https://github.co
     -   [Spear](https://thenounproject.com/term/spear/3930020/) by Firza Alamsyah
     -   [pennant](https://thenounproject.com/term/pennant/194797/) by Sara Jeffries
 -   [Maya civilization](https://thenounproject.com/term/maya-civilization/1715786/) by Olena Panasovska for The Maya
--   Aztec icon by Kāne, on Unciv Discord server
+-   Aztec icon by Kāne, on Unciv Discord server (CC BY 3.0)
 -   [Questionmark](https://thenounproject.com/icon/questionmark-4248169/) by YURR.studio for Random nation indicator
 -   [View](https://thenounproject.com/icon/view-4211245/) by Adrien Coquet for Spectator
 
@@ -799,7 +811,7 @@ HexaRealm tileset images by legacymtgsalvationuser69544 [here](https://github.co
 - [RobotArm](https://thenounproject.com/icon/robot-7300306/) by Faizal khusein
 - [RobotHeadSquare](https://thenounproject.com/icon/robot-head-6356754/) by Ahmad Arzaha
 - [RobotHeadRect](https://thenounproject.com/icon/robot-1704106/) by suib icon
-- Bobot by reallybasicname in the Discord
+- Bobot by reallybasicname in the Discord (CC BY 3.0)
 - [DollarSign](https://thenounproject.com/icon/dollar-sign-6466560/) by Ahmad Arzaha
 - Spy hideout is gimped from [hide](https://thenounproject.com/icon/hide-8013/) by Luis Prado and the one listed for Spy
 - [hold](https://thenounproject.com/icon/hold-222516/) by icon 54 as long-press indicator


### PR DESCRIPTION
Fixes #15287. Well, *almost*. This PR is a draft.

This PR documents the licensing of the Unciv logo unambigiously and the missing credit for all parties. @u-ndefine stated their contribution falls under CC BY 4.0.

Partially updated are also two files related to the Unciv logo. For the `banner.png`, I documented the license as CC BY-SA 3.0 because it includes HexaRealm tiles, which are CC BY-SA 3.0, so this is practically the only real license choice.

One license has not been figured out yet. For `Feature graphic - Google Play.png`, I am not sure. This file includes the Unciv logo and some "fancy background". It was committed by @letstalkaboutdune but I don’t know 100% if they are also the author. If I had to bet, I assume this file is going to be CC BY 4.0 because it is based on the CC BY 4.0 Unciv logo.

While I was at it, I also decided to mention a license for two user-contributed in-game icons (not the Unciv logo): CC BY 3.0. This is admittedly based on an assumption. I justify this choice because all game icons have a "default license" written in the Credits file as such:
> Unless otherwise specified, all the following are from [the Noun Project](https://thenounproject.com) either licenced under CC BY 3.0 or released into the Public Domain.

If someone *really* wants to make sure, you might to reach out to Kāne (Aztec icon) and reallybasicname (Bobot icon) on Discord. (I do not use Discord.) I am not sure if this is strictly needed, since both authors probably already gave consent via that "default license".

----

TODO (to move this PR out of draft):

1. [DONE: The answer is that it is likely non-free. The original author does not remember the license.] Figure out correct license for `Feature graphic - Google Play.png`
2. [DONE: The answer is "yes"]. Question: @letstalkaboutdune: Did you create `banner.png` and `Feature graphic - Google Play.png`?

TODO (post-draft):
1. Verify that everything else this PR changes is OK