### PR TITLE
Volume slider for voices is now "live"

### DIFF
--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -691,5 +691,8 @@ class MusicController {
         overlay = null
     }
 
+    fun setOverlayVolume(volume: Float) {
+        overlay?.setVolume(volume)
+    }
     //endregion
 }

--- a/core/src/com/unciv/ui/components/extensions/MusicControls.kt
+++ b/core/src/com/unciv/ui/components/extensions/MusicControls.kt
@@ -44,9 +44,10 @@ interface MusicControls {
             settings.citySoundsVolume = it
         }
 
-    fun Table.addVoicesVolumeSlider(settings: GameSettings) =
+    fun Table.addVoicesVolumeSlider(settings: GameSettings, music: MusicController) =
         addVolumeSlider("Leader voices volume", settings.voicesVolume) {
             settings.voicesVolume = it
+            music.setOverlayVolume(it)
         }
 
     fun Table.addMusicVolumeSlider(settings: GameSettings, music: MusicController) =

--- a/core/src/com/unciv/ui/popups/options/SoundTab.kt
+++ b/core/src/com/unciv/ui/popups/options/SoundTab.kt
@@ -21,7 +21,7 @@ internal class SoundTab(
         addCitySoundsVolumeSlider(settings)
 
         if (music.isVoicesAvailable())
-            addVoicesVolumeSlider(settings)
+            addVoicesVolumeSlider(settings, music)
 
         if (music.isMusicAvailable())
             addMusicControls(settings, music)


### PR DESCRIPTION
An UI PR without screenshots!

To reproduce:
- Install Leader voices - any [mod](https://github.com/RobLoach/Civ-V---Voices) that also contains the looong tracks for `startIntroPart1`
- Ensure "Leader voices volume" is not zero
- Start a new game, close the popup, and while the overlay still plays adjust that volume
- Before: The currently playing voice is unaffected, only the next one is. After: Immediate effect.

Almost an easter egg...