### PR TITLE
Fix the rounding of the values in the city ministats

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -26,7 +26,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.view.CityView
 import kotlin.math.ceil
-import kotlin.math.round
+import kotlin.math.roundToInt
 
 class CityStatsTable(private val cityScreen: CityScreen) : Table() {
     private val cityView: CityView = cityScreen.cityView
@@ -436,7 +436,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
                 }
                 add(icon).size(27f).padRight(3f)
                 val valueToDisplay = if (stat == Stat.Happiness) cityView.getHappinessList().values.sum() else amount
-                add((valueToDisplay + 0.5).toInt().toLabel()).padRight(5f)
+                add((valueToDisplay.roundToInt()).toLabel()).padRight(5f)
                 if (cityScreen.isCrampedPortrait() && (expanderIsOpen == null || !expanderIsOpen) && stat == Stat.Gold) {
                     row()
                 }

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -436,7 +436,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
                 }
                 add(icon).size(27f).padRight(3f)
                 val valueToDisplay = if (stat == Stat.Happiness) cityView.getHappinessList().values.sum() else amount
-                add(round(valueToDisplay).toInt().toLabel()).padRight(5f)
+                add((valueToDisplay + 0.5).toInt().toLabel()).padRight(5f)
                 if (cityScreen.isCrampedPortrait() && (expanderIsOpen == null || !expanderIsOpen) && stat == Stat.Gold) {
                     row()
                 }


### PR DESCRIPTION
The function round() was used to round the values in the city stat minimenu. This function however rounds values ending in .5 to the nearest even integer. For determening the amount of generated food .5 is however rounded up. Therefore, I changed the rounding so values ending in .5 are always rounded up.