### PR TITLE
chore: Lint gradle script for the unit tests

### DIFF
--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -1,12 +1,23 @@
 import com.unciv.build.BuildConfig
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 // Java 21+ deprecates dynamic agent loading: https://openjdk.org/jeps/451
 val mockitoAgent = configurations.create("mockitoAgent")
 
+// Support Gradle 9 caching seeing the mockito agent
+private class MockitoAgentArgumentProvider(
+    @get:Classpath val agentJar: FileCollection
+) : CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> =
+        listOf("-javaagent:${agentJar.singleFile}")
+}
+
 dependencies {
     testImplementation(libs.junit)
+    @Suppress("AvoidDuplicateDependencies") // false positive
     testImplementation(libs.mockito)
+    @Suppress("AvoidDuplicateDependencies")
     mockitoAgent(libs.mockito) { isTransitive = false }
 }
 
@@ -20,10 +31,10 @@ tasks {
                     TestLogEvent.STANDARD_OUT
             )
 
-            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            exceptionFormat = TestExceptionFormat.FULL
         }
 
-        jvmArgs = listOf("-javaagent:${mockitoAgent.asPath}") // this actually merges into pre-existing jvm args
+        jvmArgumentProviders.add(MockitoAgentArgumentProvider(mockitoAgent))
     }
 }
 


### PR DESCRIPTION
That comment `// this actually merges into pre-existing jvm args` was wrong, and `asPath` could theoretically return more than one jar, which would lead to cryptic initialization failures. So, opportunity to prepare for Gradle 9 - one warning less.