### PR TITLE
Fix master compile after cityView rename (#15280)

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -61,7 +61,7 @@ class CityScreen(
         const val wltkIconSize = 40f
     }
 
-    private val selectedCiv: Civilization = cityView.getViewer()
+    private val selectedCiv: Civilization = cityView.viewer
 
     internal val isSpying = selectedCiv.gameInfo.isEspionageEnabled() && !cityView.isOwnedByViewer() && !selectedCiv.isSpectator()
 

--- a/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
@@ -119,7 +119,7 @@ class WorldMapHolder(
                 val child = tileGroupMap.hit(x, y, true) ?: return
 
                 if (child is CityButton) { // the city button can be below the tilegroup, since it moves down when first clicked
-                    onTileClicked(child.city.getCenterTile())
+                    onTileClicked(child.cityView.getCenterTile())
                     return
                 }
                 if (child is WorldTileGroup) {

--- a/core/src/com/unciv/view/CityView.kt
+++ b/core/src/com/unciv/view/CityView.kt
@@ -138,7 +138,7 @@ class CityView(city: City, viewer: Civilization, spectatorMode: Boolean = false)
     @Readonly fun canBePurchasedWithStat(construction: INonPerpetualConstruction, stat: Stat): Boolean =
         construction.canBePurchasedWithStat(city, stat)
 
-    @Readonly fun getViewer(): Civilization = viewer
+    // getViewer() would clash with public `viewer` from ForeignCityView (same JVM signature).
     @Readonly fun isOwnedByViewer(): Boolean = city.civ === viewer
     @Readonly fun isOwnedTile(tile: Tile): Boolean = tile.getCity() === city
     @Readonly private fun getTile(tileView: TileView) = tileView.getTile()


### PR DESCRIPTION
﻿## Summary
- After #15280, master does not compile. This PR fixes both breakages:
  1. `WorldMapHolder` still called `CityButton.city` → use `cityView.getCenterTile()`.
  2. `CityView.getViewer()` accidentally overrides the JVM getter from public `ForeignCityView.viewer` → drop the method; `CityScreen` uses `cityView.viewer`.
- Local verify: `.\gradlew :core:compileKotlin` succeeds on this branch.

## CI note
`buildAndTest.yml` uses `pull_request_target` with default checkout (base master), so fork PR checks stay red until this lands on master — they are not testing the PR head.

## Test plan
- [x] `.\gradlew :core:compileKotlin`
- [ ] Click a city button on the world map — centers/selects that city tile
- [ ] Open CityScreen for an owned city — loads without crash
