### PR TITLE
Fix Russian translations (Galleass, increasing buy cost)

### DIFF
--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -2184,8 +2184,8 @@ Retain [relativeAmount]% of the happiness from a luxury after the last copy has 
 [relativeAmount]% of excess happiness converted to [stat] = [relativeAmount]% от излишек счастья превращается в [stat]
 Cannot build [baseUnitFilter] units = Не может строить юниты: [baseUnitFilter]
 Enables construction of Spaceship parts = Позволяет строить части космического корабля
-May buy [baseUnitFilter] units for [nonNegativeAmount] [stat] [cityFilter] at an increasing price ([amount]) = Можно покупать юниты: [baseUnitFilter] за [amount] [stat] [cityFilter] по возрастающей стоимости ([nonNegativeAmount])
-May buy [buildingFilter] buildings for [nonNegativeAmount] [stat] [cityFilter] at an increasing price ([amount]) = Можно покупать здания: [buildingFilter] за [amount] [stat] [cityFilter] по возрастающей стоимости ([nonNegativeAmount])
+May buy [baseUnitFilter] units for [nonNegativeAmount] [stat] [cityFilter] at an increasing price ([amount]) = Можно покупать юниты: [baseUnitFilter] за [nonNegativeAmount] [stat] [cityFilter] по возрастающей стоимости ([amount])
+May buy [buildingFilter] buildings for [nonNegativeAmount] [stat] [cityFilter] at an increasing price ([amount]) = Можно покупать здания: [buildingFilter] за [nonNegativeAmount] [stat] [cityFilter] по возрастающей стоимости ([amount])
 May buy [baseUnitFilter] units for [nonNegativeAmount] [stat] [cityFilter] = Можно покупать юниты: [baseUnitFilter] за [nonNegativeAmount] [stat] [cityFilter]
 May buy [buildingFilter] buildings for [nonNegativeAmount] [stat] [cityFilter] = Можно покупать здания: [buildingFilter] за [nonNegativeAmount] [stat] [cityFilter]
 May buy [baseUnitFilter] units with [stat] [cityFilter] = Можно покупать юниты: [baseUnitFilter] за [stat] [cityFilter]

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -7485,7 +7485,7 @@ Cataphract = Катафракт
 Composite Bowman = Лучник (композитный лук)
 
 
-Galleass = Галера
+Galleass = Галеас
 
 
 Privateer = Капер


### PR DESCRIPTION
## Summary
- Fix Russian translation for **Galleass**: was incorrectly `Галера` (same as Galley); now `Галеас`.
- Fix swapped placeholders in Russian for `BuyUnitsIncreasingCost` / `BuyBuildingsIncreasingCost`: base cost is `[nonNegativeAmount]`, increase is `[amount]` (matches engine and English unique text).

## Test plan
- [ ] Switch game language to Russian
- [ ] Open Civilopedia or unit list and confirm Galleass shows as **Галеас**
- [ ] Confirm Galley still shows as **Галера**
- [ ] With Honor Complete (or similar), confirm Great General faith purchase text shows base **1000** and increase **(500)**, not the reverse