### PR TITLE
Implement v1 headless MCP server for LLM counterparty control

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "unciv": {
+      "command": "./desktop/mcp-agent.sh"
+    }
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,6 +120,11 @@ project(":desktop") {
 
         // Needed for Windows turn notifiers
         "api"(rootProject.libs.bundles.jna)
+
+        // MCP server for the LLM counterparty agent (McpAgentLauncher)
+        "implementation"(rootProject.libs.mcp.sdk.server)
+        // HeadlessApplication gives McpAgentLauncher a real Gdx.app (Chat/etc. call Gdx.app.postRunnable)
+        "implementation"(rootProject.libs.gdx.backend.headless)
     }
 }
 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -106,7 +106,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     // Why is one of these called 'buildable' and the other 'constructable'?
     @Readonly
-    internal fun getBuildableBuildings(): Sequence<Building> = city.getRuleset().buildings.values
+    fun getBuildableBuildings(): Sequence<Building> = city.getRuleset().buildings.values
         .asSequence().filter { it.isBuildable(this) }
 
     @Readonly

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatStore.kt
@@ -45,6 +45,10 @@ data class Chat(
         }
     }
 
+    /** Messages recorded from [fromIndex] (inclusive) onward - for consumers that poll incrementally. */
+    fun messagesSince(fromIndex: Int): List<Pair<String, String>> =
+        if (fromIndex >= messages.size) emptyList() else messages.subList(fromIndex, messages.size).toList()
+
     companion object {
         val INITIAL_MESSAGE = "System" to "Welcome to Chat!"
     }

--- a/core/src/com/unciv/logic/multiplayer/chat/ChatWebSocket.kt
+++ b/core/src/com/unciv/logic/multiplayer/chat/ChatWebSocket.kt
@@ -4,6 +4,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.multiplayer.chat.ChatWebSocket.job
 import com.unciv.logic.multiplayer.chat.ChatWebSocket.start
 import com.unciv.utils.Concurrency
+import com.unciv.utils.Log
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.websocket.*
@@ -147,21 +148,20 @@ object ChatWebSocket {
 
     @OptIn(ExperimentalTime::class)
     private fun handleWebSocketThrowables(t: Throwable) {
-        print("ChatError: ${t.message}. Reconnecting...")
-
         if (reconnectionAttempts == 0) {
             lastRetry = Clock.System.now()
+            Log.debug("ChatError: %s. Reconnecting...", t.message)
             ChatStore.relayGlobalMessage("WebSocket connection closed. Cause: [${t.cause}]")
             if (t.message?.contains("401") == true) {
                 ChatStore.relayGlobalMessage("Authentication issue detected! You have to set a password to use Chat.")
             }
         } else {
             val now = Clock.System.now()
-            print(" (Last retry was ${(now - lastRetry).toString(DurationUnit.SECONDS, 2)} ago)")
+            Log.debug("ChatError: %s. Reconnecting... (Last retry was %s ago)", t.message,
+                (now - lastRetry).toString(DurationUnit.SECONDS, 2))
             lastRetry = now
         }
 
-        println()
         restart(dueToError = true)
     }
 
@@ -179,7 +179,7 @@ object ChatWebSocket {
 
             session!!.runCatching {
                 if (isActive) {
-                    println("ChatLog: Connected to WebSocket.")
+                    Log.debug("ChatLog: Connected to WebSocket.")
                     ChatStore.relayGlobalMessage("Successfully connected to WebSocket server!")
                     resetExponentialBackoff()
                 }
@@ -238,7 +238,7 @@ object ChatWebSocket {
             }
         } else resetExponentialBackoff()
 
-        if (force) println("ChatLog: A force restart seems to be requested!")
+        if (force) Log.debug("ChatLog: A force restart seems to be requested!")
 
         GlobalScope.launch {
             if (!force) {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -73,6 +73,9 @@ object UnitActions {
             addUnmappedUnitActions(unit)             // No mapped getter: Enumerate all...
         }.filter { it.type == unitActionType }       // ...and take ones matching the type.
 
+    /** Action types with a directly-callable, headless-safe provider (no [GUI] use during enumeration) - see [getUnitActions] with a [UnitActionType]. */
+    val mappedActionTypes: Set<UnitActionType> get() = actionTypeToFunctions.keys
+
     private val actionTypeToFunctions = linkedMapOf<UnitActionType, (unit: MapUnit, tile: Tile) -> Sequence<UnitAction>>(
         // Determined by unit uniques
         UnitActionType.Transform to UnitActionsFromUniques::getTransformActions,

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -73,9 +73,6 @@ object UnitActions {
             addUnmappedUnitActions(unit)             // No mapped getter: Enumerate all...
         }.filter { it.type == unitActionType }       // ...and take ones matching the type.
 
-    /** Action types with a directly-callable, headless-safe provider (no [GUI] use during enumeration) - see [getUnitActions] with a [UnitActionType]. */
-    val mappedActionTypes: Set<UnitActionType> get() = actionTypeToFunctions.keys
-
     private val actionTypeToFunctions = linkedMapOf<UnitActionType, (unit: MapUnit, tile: Tile) -> Sequence<UnitAction>>(
         // Determined by unit uniques
         UnitActionType.Transform to UnitActionsFromUniques::getTransformActions,
@@ -176,6 +173,8 @@ object UnitActions {
     private suspend fun SequenceScope<UnitAction>.addEscortAction(unit: MapUnit) {
         // Air units cannot escort
         if (unit.baseUnit.movesLikeAirUnits) return
+        // Depends on which units are selected in the world screen - nothing to check headless.
+        if (!GUI.isWorldLoaded()) return
 
         val worldScreen = GUI.getWorldScreen()
         val selectedUnits = worldScreen.bottomUnitTable.selectedUnits
@@ -215,6 +214,8 @@ object UnitActions {
         // have the visual bug that the tile overlays for the eligible swap locations are drawn for
         // /all/ selected units instead of only the first one. This could be fixed, but again,
         // swapping makes little sense for multiselect anyway.
+        // Depends on which units are selected in the world screen - nothing to check headless.
+        if (!GUI.isWorldLoaded()) return
         val worldScreen = GUI.getWorldScreen()
         if (worldScreen.bottomUnitTable.selectedUnits.size > 1) return
         // Only show the swap action if there is at least one possible swap movement

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -20,7 +20,8 @@ object UnitActionsPillage {
     internal fun getPillageActions(unit: MapUnit, tile: Tile): Sequence<UnitAction> {
         val pillageAction = getPillageAction(unit, tile)
             ?: return emptySequence()
-        if (pillageAction.action == null || unit.civ.isAIOrAutoPlaying())
+        // No world screen to confirm with (headless), same as auto-playing: just do it.
+        if (pillageAction.action == null || unit.civ.isAIOrAutoPlaying() || !GUI.isWorldLoaded())
             return sequenceOf(pillageAction)
         else return sequenceOf(UnitAction(UnitActionType.Pillage, 65f, pillageAction.title) {
             val pillageText = "Are you sure you want to pillage this [${tile.getImprovementToPillageName()!!}]?"

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -48,6 +48,21 @@ tasks.register<JavaExec>("debug") {
     debug = true
 }
 
+tasks.register<JavaExec>("runMcpAgent") {
+    // Must stay quiet: this process speaks MCP JSON-RPC over stdio, so nothing but
+    // protocol traffic may reach stdout (all Unciv logging goes to stderr).
+    dependsOn(tasks.getByName("classes"))
+    mainClass.set("com.unciv.app.desktop.mcp.McpAgentLauncher")
+    classpath = sourceSets.main.get().runtimeClasspath
+    standardInput = System.`in`
+    workingDir = assetsDir
+    isIgnoreExitValue = true
+    // Auth calls go through java.net.HttpURLConnection (SimpleHttp.kt), which consults the JVM's
+    // system ProxySelector - on some macOS setups that throws "Failed to select a proxy" for any
+    // URL, localhost included. This process never needs a proxy, so skip system lookup entirely.
+    systemProperty("java.net.useSystemProxies", "false")
+}
+
 tasks.register<Jar>("dist") { // Compiles the jar file
     dependsOn(tasks.getByName("classes"))
 

--- a/desktop/mcp-agent.sh
+++ b/desktop/mcp-agent.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Launches the headless MCP agent for an LLM client - see docs/Developers/MCP-agent.md.
+# Gradle can't configure the :android module on JDK 24+, so prefer a 17 if one is installed.
+set -e
+cd "$(dirname "$0")/.."
+if [ -z "$JAVA_HOME" ] && [ -x /usr/libexec/java_home ]; then
+    home17="$(/usr/libexec/java_home -v 17 2>/dev/null || true)"
+    if [ -n "$home17" ]; then export JAVA_HOME="$home17"; fi
+fi
+exec ./gradlew -q :desktop:runMcpAgent

--- a/desktop/src/com/unciv/app/desktop/mcp/GameStateView.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/GameStateView.kt
@@ -1,0 +1,164 @@
+package com.unciv.app.desktop.mcp
+
+import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.Notification
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.UnitActionType
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/** Whether map/unit reads are filtered to what [agentCiv] can actually see. */
+enum class VisibilityMode { FULL, RESTRICTED }
+
+/**
+ * Turns engine state into compact JSON for an MCP tool response.
+ * [VisibilityMode.RESTRICTED] filters tiles/units through [Tile.isVisible]/[Tile.isExplored]
+ * exactly as the human client's fog of war would.
+ */
+class GameStateView(private val visibility: VisibilityMode) {
+
+    fun civSummary(agentCiv: Civilization): JsonObject = buildJsonObject {
+        put("civName", agentCiv.civName)
+        put("gold", agentCiv.gold)
+        put("happiness", agentCiv.getHappiness())
+        val statMap = agentCiv.stats.getStatMapForNextTurn()
+        val totals = statMap.values.fold(com.unciv.models.stats.Stats()) { acc, s -> acc.add(s); acc }
+        putJsonObject("incomePerTurn") {
+            put("gold", totals.gold)
+            put("science", totals.science)
+            put("culture", totals.culture)
+            put("faith", totals.faith)
+        }
+        putJsonObject("research") {
+            put("current", agentCiv.tech.currentTechnologyName())
+            putJsonArray("queue") { agentCiv.tech.techsToResearch.forEach { add(JsonPrimitive(it)) } }
+            putJsonArray("researched") { agentCiv.tech.techsResearched.forEach { add(JsonPrimitive(it)) } }
+            // Valid names for set_research - the agent otherwise has to guess.
+            putJsonArray("researchable") {
+                agentCiv.gameInfo.ruleset.technologies.values
+                    .filter { agentCiv.tech.canBeResearched(it.name) }
+                    .forEach { add(JsonPrimitive(it.name)) }
+            }
+        }
+        putJsonArray("adoptedPolicies") { agentCiv.policies.getAdoptedPolicies().forEach { add(JsonPrimitive(it)) } }
+        put("cityCount", agentCiv.cities.size)
+        put("unitCount", agentCiv.units.getCivUnitsSize())
+    }
+
+    fun cities(agentCiv: Civilization): JsonArray = buildJsonArray {
+        for (city in agentCiv.cities) {
+            add(buildJsonObject {
+                put("name", city.name)
+                put("population", city.population.population)
+                put("health", city.health)
+                put("position", positionOf(city.getCenterTile()))
+                put("currentProduction", city.cityConstructions.currentConstructionName())
+                putJsonArray("productionQueue") { city.cityConstructions.constructionQueue.forEach { add(JsonPrimitive(it)) } }
+                // Valid names for set_city_production - the agent otherwise has to guess.
+                putJsonArray("buildable") {
+                    city.cityConstructions.getBuildableBuildings().forEach { add(JsonPrimitive(it.name)) }
+                    city.cityConstructions.getConstructableUnits().forEach { add(JsonPrimitive(it.name)) }
+                }
+            })
+        }
+    }
+
+    fun units(agentCiv: Civilization): JsonArray = buildJsonArray {
+        for (unit in agentCiv.units.getCivUnits()) {
+            add(buildJsonObject {
+                put("id", unit.id)
+                put("name", unit.name)
+                put("position", positionOf(unit.getTile()))
+                put("health", unit.health)
+                put("movementLeft", unit.currentMovement)
+                putJsonArray("availableActions") {
+                    availableActions(unit).forEach { add(JsonPrimitive(it)) }
+                }
+            })
+        }
+    }
+
+    fun map(agentCiv: Civilization, gameInfo: com.unciv.logic.GameInfo): JsonArray = buildJsonArray {
+        for (tile in gameInfo.tileMap.tileList) {
+            val entry = tileToJson(tile, agentCiv) ?: continue
+            add(entry)
+        }
+    }
+
+    /** Same as [map] but limited to tiles within [radius] hexes of ([centerX], [centerY]) - keeps large maps out of the LLM's context. */
+    fun map(agentCiv: Civilization, gameInfo: com.unciv.logic.GameInfo, centerX: Int, centerY: Int, radius: Int): JsonArray = buildJsonArray {
+        for (tile in gameInfo.tileMap.tileList) {
+            if (com.unciv.logic.map.HexMath.getDistance(centerX, centerY, tile.position.x, tile.position.y) > radius) continue
+            val entry = tileToJson(tile, agentCiv) ?: continue
+            add(entry)
+        }
+    }
+
+    fun events(agentCiv: Civilization, sinceTurns: Int): JsonObject = buildJsonObject {
+        putJsonArray("current") { agentCiv.notifications.forEach { add(notificationToJson(it)) } }
+        putJsonArray("log") {
+            for (turnLog in agentCiv.notificationsLog.takeLast(sinceTurns)) {
+                add(buildJsonObject {
+                    put("turn", turnLog.turn)
+                    putJsonArray("notifications") { turnLog.notifications.forEach { add(notificationToJson(it)) } }
+                })
+            }
+        }
+    }
+
+    private fun tileToJson(tile: Tile, agentCiv: Civilization): JsonObject? {
+        if (visibility == VisibilityMode.RESTRICTED && !tile.isExplored(agentCiv)) return null
+        val visible = visibility == VisibilityMode.FULL || tile.isVisible(agentCiv)
+        return buildJsonObject {
+            put("position", positionOf(tile))
+            put("baseTerrain", tile.baseTerrain)
+            put("improvement", tile.getShownImprovement(agentCiv))
+            put("visible", visible)
+            if (visible) {
+                put("resource", tile.resource)
+                put("owningCity", tile.getCity()?.name)
+                tile.civilianUnit?.let { put("civilianUnit", it.name) }
+                tile.militaryUnit?.let { put("militaryUnit", it.name) }
+            }
+        }
+    }
+
+    /**
+     * [UnitActions.getUnitActions] (no type arg) enumerates every action provider, including
+     * addEscortAction/addSwapAction, which eagerly call [com.unciv.GUI.getWorldScreen] even
+     * though we're headless - that's an instant NPE, every time, for every land/sea unit.
+     * So instead of that enumerator, list only what's headless-safe to check:
+     * - mapped action types (FoundCity, ConstructImprovement, ...) via the type-filtered
+     *   overload, which invokes just that one provider - except ConnectRoad, which *also*
+     *   eagerly touches the world screen (for units that can build roads).
+     * - the common unmapped verbs (Fortify/Sleep/Explore/Automate), whose real availability
+     *   we derive from the same unit-state checks their GUI actions use internally, since
+     *   asking the crashing enumerator isn't an option.
+     */
+    private fun availableActions(unit: MapUnit): List<String> = buildList {
+        for (type in UnitActions.mappedActionTypes) {
+            if (type == UnitActionType.ConnectRoad) continue
+            if (UnitActions.getUnitActions(unit, type).any { it.action != null }) add(type.name)
+        }
+        if (unit.canFortify() && unit.hasMovement()) add(UnitActionType.Fortify.name)
+        if (!unit.isFortified() && !unit.canFortify() && !unit.isGuarding() && unit.hasMovement()) add(UnitActionType.Sleep.name)
+        if (!unit.baseUnit.movesLikeAirUnits && !unit.isExploring()) add(UnitActionType.Explore.name)
+        if (!unit.isAutomated() && unit.hasMovement()) add(UnitActionType.Automate.name)
+    }
+
+    private fun notificationToJson(notification: Notification): JsonElement = JsonPrimitive(notification.text)
+
+    private fun positionOf(tile: Tile): JsonObject = buildJsonObject {
+        put("x", tile.position.x)
+        put("y", tile.position.y)
+    }
+}

--- a/desktop/src/com/unciv/app/desktop/mcp/GameStateView.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/GameStateView.kt
@@ -1,10 +1,14 @@
 package com.unciv.app.desktop.mcp
 
+import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.Notification
+import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitActionType
+import com.unciv.ui.screens.victoryscreen.RankingType
+import com.unciv.ui.screens.victoryscreen.VictoryScreen
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -52,6 +56,20 @@ class GameStateView(private val visibility: VisibilityMode) {
         putJsonArray("adoptedPolicies") { agentCiv.policies.getAdoptedPolicies().forEach { add(JsonPrimitive(it)) } }
         put("cityCount", agentCiv.cities.size)
         put("unitCount", agentCiv.units.getCivUnitsSize())
+        // Targets for declare_war/make_peace, and context for whether it's safe to act - the agent
+        // otherwise has no way to see who it knows or is at war with.
+        putJsonArray("knownCivs") {
+            for (other in agentCiv.getKnownCivs()) {
+                val diplo = agentCiv.getDiplomacyManager(other) ?: continue
+                add(buildJsonObject {
+                    put("name", other.civName)
+                    put("isCityState", other.isCityState)
+                    put("status", diplo.diplomaticStatus.name)
+                    put("relationship", diplo.relationshipLevel().name)
+                    put("atWar", diplo.diplomaticStatus == DiplomaticStatus.War)
+                })
+            }
+        }
     }
 
     fun cities(agentCiv: Civilization): JsonArray = buildJsonArray {
@@ -103,16 +121,92 @@ class GameStateView(private val visibility: VisibilityMode) {
         }
     }
 
-    fun events(agentCiv: Civilization, sinceTurns: Int): JsonObject = buildJsonObject {
+    /**
+     * [sinceLastTurn], if given, replaces the last-[sinceTurns] window with "everything logged
+     * after that turn" (the MCP server tracks the cutoff per connection - see UncivMcpServer's
+     * GameConnection.lastGistTurn) and adds a [RankingType] scalar-delta summary from
+     * [Civilization.statsHistory], so the agent gets a turn-start gist instead of re-exploring.
+     */
+    fun events(agentCiv: Civilization, gameInfo: GameInfo, sinceTurns: Int, sinceLastTurn: Int? = null, chatMessages: List<Pair<String, String>> = emptyList()): JsonObject = buildJsonObject {
+        putJsonArray("chat") {
+            for ((civName, message) in chatMessages) add(buildJsonObject {
+                put("from", civName)
+                put("message", message)
+            })
+        }
         putJsonArray("current") { agentCiv.notifications.forEach { add(notificationToJson(it)) } }
         putJsonArray("log") {
-            for (turnLog in agentCiv.notificationsLog.takeLast(sinceTurns)) {
+            val buckets = if (sinceLastTurn != null) agentCiv.notificationsLog.filter { it.turn > sinceLastTurn }
+                else agentCiv.notificationsLog.takeLast(sinceTurns)
+            for (turnLog in buckets) {
                 add(buildJsonObject {
                     put("turn", turnLog.turn)
                     putJsonArray("notifications") { turnLog.notifications.forEach { add(notificationToJson(it)) } }
                 })
             }
         }
+        if (sinceLastTurn != null) {
+            // Best-effort: statsHistory is only snapshotted at startTurn, so either turn key can
+            // be absent (e.g. the very first gist call, or an unusual gap) - just omit "deltas"
+            // rather than error; don't "fix" this by throwing on a missing entry.
+            val now = agentCiv.statsHistory[gameInfo.turns]
+            val then = agentCiv.statsHistory[sinceLastTurn]
+            if (now != null && then != null) putJsonObject("deltas") {
+                for (type in listOf(RankingType.Gold, RankingType.Technologies, RankingType.Territory,
+                        RankingType.Force, RankingType.Population, RankingType.Score)) {
+                    put(type.name, (now[type] ?: 0) - (then[type] ?: 0))
+                }
+            }
+        }
+    }
+
+    /**
+     * Comparative standing a human sees via Rankings/Demographics + Global Politics.
+     * Ranking values are [Civilization.statsHistory] turn-start snapshots (matching
+     * VictoryScreenDemographics) and, in RESTRICTED mode, only shown when a human could
+     * (VictoryScreen.canViewCivStats); unmet civs are named "unknown".
+     * ponytail: spy-gated intel (enemy production/stealable tech) is never revealed - no spy model exposed.
+     */
+    fun civIntel(agentCiv: Civilization, gameInfo: GameInfo): JsonObject = buildJsonObject {
+        val majors = gameInfo.civilizations.filter { it.isMajorCiv() && it.isAlive() }
+        putJsonObject("rankings") {
+            for (type in RankingType.entries) {
+                putJsonArray(type.name) {
+                    for (civ in majors) {
+                        val canSee = visibility == VisibilityMode.FULL ||
+                            VictoryScreen.canViewCivStats(gameInfo, agentCiv, civ)
+                        if (!canSee && civ != agentCiv) continue
+                        val known = civ == agentCiv || visibility == VisibilityMode.FULL || agentCiv.knows(civ)
+                        add(buildJsonObject {
+                            put("civ", if (known) civ.civName else "unknown")
+                            put("value", statSnapshot(civ, type, gameInfo))
+                        })
+                    }
+                }
+            }
+        }
+        putJsonArray("knownCivs") {
+            val others = if (visibility == VisibilityMode.FULL) majors.filter { it != agentCiv }
+                else agentCiv.getKnownCivs().filter { it.isMajorCiv() }.toList()
+            for (other in others) {
+                add(buildJsonObject {
+                    put("name", other.civName)
+                    put("era", other.tech.era.name)
+                    put("score", other.calculateTotalScore())
+                    putJsonArray("atWarWith") {
+                        for (third in other.getKnownCivs())
+                            if ((visibility == VisibilityMode.FULL || agentCiv.knows(third)) && other.isAtWarWith(third))
+                                add(JsonPrimitive(third.civName))
+                    }
+                })
+            }
+        }
+    }
+
+    /** Turn-start snapshot for [type], falling back to latest snapshot then live (as demographics does). */
+    private fun statSnapshot(civ: Civilization, type: RankingType, gameInfo: GameInfo): Int {
+        val snap = civ.statsHistory[gameInfo.turns] ?: civ.statsHistory.maxByOrNull { it.key }?.value
+        return snap?.get(type) ?: civ.getStatForRanking(type)
     }
 
     private fun tileToJson(tile: Tile, agentCiv: Civilization): JsonObject? {
@@ -123,6 +217,19 @@ class GameStateView(private val visibility: VisibilityMode) {
             put("baseTerrain", tile.baseTerrain)
             put("improvement", tile.getShownImprovement(agentCiv))
             put("visible", visible)
+            // A human remembers enemy cities they've seen even under fog: name, pop, religion, capital,
+            // owner, defensive strength (CityButton.update / CityTable). Health only when the tile is
+            // actively visible; production/buildings are spy-gated, so never shown here.
+            val city = tile.getCity()
+            if (city != null && tile.isCityCenter()) putJsonObject("city") {
+                put("name", city.name)
+                put("owner", city.civ.civName)
+                put("population", city.population.population)
+                put("isCapital", city.isCapital())
+                put("majorityReligion", city.religion.getMajorityReligionName())
+                put("defensiveStrength", com.unciv.logic.battle.CityCombatant(city).getDefendingStrength(null))
+                if (visible) put("health", city.health)
+            }
             if (visible) {
                 put("resource", tile.resource)
                 put("owningCity", tile.getCity()?.name)
@@ -155,7 +262,10 @@ class GameStateView(private val visibility: VisibilityMode) {
         if (!unit.isAutomated() && unit.hasMovement()) add(UnitActionType.Automate.name)
     }
 
-    private fun notificationToJson(notification: Notification): JsonElement = JsonPrimitive(notification.text)
+    private fun notificationToJson(notification: Notification): JsonElement = buildJsonObject {
+        put("text", notification.text)
+        put("category", notification.category.name)
+    }
 
     private fun positionOf(tile: Tile): JsonObject = buildJsonObject {
         put("x", tile.position.x)

--- a/desktop/src/com/unciv/app/desktop/mcp/GameStateView.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/GameStateView.kt
@@ -1,12 +1,14 @@
 package com.unciv.app.desktop.mcp
 
 import com.unciv.logic.GameInfo
+import com.unciv.logic.battle.Battle
+import com.unciv.logic.battle.TargetHelper
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.Notification
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
-import com.unciv.models.UnitActionType
+import com.unciv.logic.trade.TradeOffer
 import com.unciv.ui.screens.victoryscreen.RankingType
 import com.unciv.ui.screens.victoryscreen.VictoryScreen
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
@@ -100,6 +102,20 @@ class GameStateView(private val visibility: VisibilityMode) {
                 put("movementLeft", unit.currentMovement)
                 putJsonArray("availableActions") {
                     availableActions(unit).forEach { add(JsonPrimitive(it)) }
+                }
+                // Valid names for promote_unit - the agent otherwise has to guess.
+                putJsonArray("availablePromotions") {
+                    unit.promotions.getAvailablePromotions().forEach { add(JsonPrimitive(it.name)) }
+                }
+                // Valid (x, y) targets for attack - the agent otherwise has to probe blindly.
+                if (unit.canAttack()) putJsonArray("attackableTiles") {
+                    for (target in TargetHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())) {
+                        add(buildJsonObject {
+                            put("x", target.tileToAttack.position.x)
+                            put("y", target.tileToAttack.position.y)
+                            put("defender", Battle.getMapCombatantOfTile(target.tileToAttack)?.getName())
+                        })
+                    }
                 }
             })
         }
@@ -203,6 +219,29 @@ class GameStateView(private val visibility: VisibilityMode) {
         }
     }
 
+    /** Trade requests and popup alerts a human would see and answer via the respond_to_trade/resolve_alert tools. */
+    fun pendingDecisions(agentCiv: Civilization): JsonObject = buildJsonObject {
+        putJsonArray("tradeRequests") {
+            for (request in agentCiv.tradeRequests) {
+                add(buildJsonObject {
+                    put("requestingCiv", agentCiv.gameInfo.getCivilizationOrNull(request.requestingCiv)?.civName ?: request.requestingCiv)
+                    // Naming from TradeRequest's own doc: "their" offers are what's offered to us, "our" offers are what's wanted from us.
+                    putJsonArray("offeredToUs") { request.trade.theirOffers.forEach { add(tradeOfferJson(it)) } }
+                    putJsonArray("wantedFromUs") { request.trade.ourOffers.forEach { add(tradeOfferJson(it)) } }
+                })
+            }
+        }
+        putJsonArray("alerts") {
+            agentCiv.popupAlerts.forEachIndexed { index, alert ->
+                add(buildJsonObject {
+                    put("index", index)
+                    put("type", alert.type.name)
+                    put("value", alert.value)
+                })
+            }
+        }
+    }
+
     /** Turn-start snapshot for [type], falling back to latest snapshot then live (as demographics does). */
     private fun statSnapshot(civ: Civilization, type: RankingType, gameInfo: GameInfo): Int {
         val snap = civ.statsHistory[gameInfo.turns] ?: civ.statsHistory.maxByOrNull { it.key }?.value
@@ -213,9 +252,10 @@ class GameStateView(private val visibility: VisibilityMode) {
         if (visibility == VisibilityMode.RESTRICTED && !tile.isExplored(agentCiv)) return null
         val visible = visibility == VisibilityMode.FULL || tile.isVisible(agentCiv)
         return buildJsonObject {
-            put("position", positionOf(tile))
+            put("x", tile.position.x)
+            put("y", tile.position.y)
             put("baseTerrain", tile.baseTerrain)
-            put("improvement", tile.getShownImprovement(agentCiv))
+            tile.getShownImprovement(agentCiv)?.let { put("improvement", it) }
             put("visible", visible)
             // A human remembers enemy cities they've seen even under fog: name, pop, religion, capital,
             // owner, defensive strength (CityButton.update / CityTable). Health only when the tile is
@@ -231,8 +271,8 @@ class GameStateView(private val visibility: VisibilityMode) {
                 if (visible) put("health", city.health)
             }
             if (visible) {
-                put("resource", tile.resource)
-                put("owningCity", tile.getCity()?.name)
+                tile.resource?.let { put("resource", it) }
+                city?.let { put("owningCity", it.name) }
                 tile.civilianUnit?.let { put("civilianUnit", it.name) }
                 tile.militaryUnit?.let { put("militaryUnit", it.name) }
             }
@@ -240,27 +280,12 @@ class GameStateView(private val visibility: VisibilityMode) {
     }
 
     /**
-     * [UnitActions.getUnitActions] (no type arg) enumerates every action provider, including
-     * addEscortAction/addSwapAction, which eagerly call [com.unciv.GUI.getWorldScreen] even
-     * though we're headless - that's an instant NPE, every time, for every land/sea unit.
-     * So instead of that enumerator, list only what's headless-safe to check:
-     * - mapped action types (FoundCity, ConstructImprovement, ...) via the type-filtered
-     *   overload, which invokes just that one provider - except ConnectRoad, which *also*
-     *   eagerly touches the world screen (for units that can build roads).
-     * - the common unmapped verbs (Fortify/Sleep/Explore/Automate), whose real availability
-     *   we derive from the same unit-state checks their GUI actions use internally, since
-     *   asking the crashing enumerator isn't an option.
+     * [UnitActions.getUnitActions] enumerates every action provider - addEscortAction/
+     * addSwapAction (the two that used to call [com.unciv.GUI.getWorldScreen] eagerly during
+     * enumeration) now guard on [com.unciv.GUI.isWorldLoaded], so this is headless-safe.
      */
-    private fun availableActions(unit: MapUnit): List<String> = buildList {
-        for (type in UnitActions.mappedActionTypes) {
-            if (type == UnitActionType.ConnectRoad) continue
-            if (UnitActions.getUnitActions(unit, type).any { it.action != null }) add(type.name)
-        }
-        if (unit.canFortify() && unit.hasMovement()) add(UnitActionType.Fortify.name)
-        if (!unit.isFortified() && !unit.canFortify() && !unit.isGuarding() && unit.hasMovement()) add(UnitActionType.Sleep.name)
-        if (!unit.baseUnit.movesLikeAirUnits && !unit.isExploring()) add(UnitActionType.Explore.name)
-        if (!unit.isAutomated() && unit.hasMovement()) add(UnitActionType.Automate.name)
-    }
+    private fun availableActions(unit: MapUnit): List<String> =
+        UnitActions.getUnitActions(unit).filter { it.action != null }.map { it.type.name }.distinct().toList()
 
     private fun notificationToJson(notification: Notification): JsonElement = buildJsonObject {
         put("text", notification.text)
@@ -271,4 +296,11 @@ class GameStateView(private val visibility: VisibilityMode) {
         put("x", tile.position.x)
         put("y", tile.position.y)
     }
+}
+
+/** Shared by [GameStateView.pendingDecisions] and UncivMcpServer's get_trade_options tool. */
+fun tradeOfferJson(offer: TradeOffer): JsonObject = buildJsonObject {
+    put("type", offer.type.name)
+    put("name", offer.name)
+    put("amount", offer.amount)
 }

--- a/desktop/src/com/unciv/app/desktop/mcp/McpAgentLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/McpAgentLauncher.kt
@@ -36,6 +36,9 @@ object McpAgentLauncher {
         UncivGame.Current.settings = GameSettings().apply {
             showTutorials = false
             turnsBetweenAutosaves = 10000
+            // Default 5 (GameSettings.notificationsLogMaxTurns) drops history if the agent goes
+            // more than 5 turns between calls to get_events(sinceMyLastTurn=true).
+            notificationsLogMaxTurns = 50
         }
 
         // Loading logs go through println (e.g. RulesetCache's "Loaded N rulesets" banner);

--- a/desktop/src/com/unciv/app/desktop/mcp/McpAgentLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/McpAgentLauncher.kt
@@ -1,0 +1,78 @@
+package com.unciv.app.desktop.mcp
+
+import com.badlogic.gdx.ApplicationAdapter
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.backends.headless.HeadlessApplication
+import com.unciv.UncivGame
+import com.unciv.app.desktop.DesktopLogBackend
+import com.unciv.logic.multiplayer.Multiplayer
+import com.unciv.logic.multiplayer.storage.UncivServerFileStorage
+import com.unciv.models.metadata.GameSettings
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.skins.SkinCache
+import com.unciv.models.tilesets.TileSetCache
+import com.unciv.utils.Log
+import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.asSink
+import kotlinx.io.asSource
+import kotlinx.io.buffered
+import java.io.PrintStream
+
+/**
+ * Headless boot for the LLM counterparty MCP agent - mirrors [com.unciv.app.desktop.ConsoleLauncher]'s
+ * cache-loading sequence, but hosts an MCP server over stdio instead of running a simulation.
+ *
+ * Must not print anything to stdout: this process speaks MCP JSON-RPC there. All Unciv logging
+ * goes through [Log], routed to stderr by [DesktopLogBackend].
+ */
+object McpAgentLauncher {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        Log.backend = DesktopLogBackend()
+
+        UncivGame.Current = UncivGame(true)
+        UncivGame.Current.settings = GameSettings().apply {
+            showTutorials = false
+            turnsBetweenAutosaves = 10000
+        }
+
+        // Loading logs go through println (e.g. RulesetCache's "Loaded N rulesets" banner);
+        // stdout is reserved for MCP JSON-RPC once the transport connects, so redirect it here.
+        val realStdout = System.out
+        System.setOut(PrintStream(object : java.io.OutputStream() { override fun write(b: Int) {} }))
+        try {
+            RulesetCache.loadRulesets(consoleMode = true)
+            TileSetCache.loadTileSetConfigs(consoleMode = true)
+            SkinCache.loadSkinConfigs(consoleMode = true)
+        } finally {
+            System.setOut(realStdout)
+        }
+        UncivServerFileStorage.timeout = 30000
+
+        // Chat (ChatStore.relayGlobalMessage etc.) calls Gdx.app.postRunnable, and
+        // Multiplayer()'s constructor needs Gdx.files (via UncivGame.Current.files) to list
+        // local save files - neither is set up by isConsoleMode=true. HeadlessApplication sets
+        // Gdx.app/files/net/audio/graphics/input to real (mock, where relevant) implementations;
+        // this is the same setup GdxTestRunner.kt uses for headless JUnit tests.
+        HeadlessApplication(object : ApplicationAdapter() {})
+        UncivGame.Current.files = com.unciv.logic.files.UncivFiles(Gdx.files)
+        // Multiplayer's background game-list refresher reads UncivGame.Current.gameInfo, which we
+        // never set (we always operate on freshly downloaded GameInfo instances), so it's a no-op.
+        UncivGame.Current.onlineMultiplayer = Multiplayer()
+
+        val mcpServer = UncivMcpServer()
+        val transport = StdioServerTransport(
+            inputStream = System.`in`.asSource().buffered(),
+            outputStream = System.out.asSink().buffered(),
+        )
+
+        runBlocking {
+            val session = mcpServer.server.createSession(transport)
+            val done = Job()
+            session.onClose { done.complete() }
+            done.join()
+        }
+    }
+}

--- a/desktop/src/com/unciv/app/desktop/mcp/UncivMcpServer.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/UncivMcpServer.kt
@@ -4,8 +4,11 @@ import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.automation.unit.UnitAutomation
 import com.unciv.logic.civilization.PlayerType
+import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
+import com.unciv.logic.city.CityFocus
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.movement.UnitMovement
+import com.unciv.logic.multiplayer.chat.ChatStore
 import com.unciv.logic.multiplayer.chat.ChatWebSocket
 import com.unciv.logic.multiplayer.chat.Message
 import com.unciv.logic.multiplayer.isUsersTurn
@@ -13,6 +16,8 @@ import com.unciv.logic.multiplayer.storage.AuthStatus
 import com.unciv.logic.multiplayer.storage.MultiplayerServer
 import com.unciv.logic.multiplayer.storage.UncivServerFileStorage
 import com.unciv.models.UnitActionType
+import com.unciv.models.ruleset.INonPerpetualConstruction
+import com.unciv.models.stats.Stat
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
@@ -22,10 +27,12 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
 /**
@@ -41,7 +48,14 @@ class UncivMcpServer {
         val gameId: String,
         val civId: String,
         val visibility: VisibilityMode,
-    )
+    ) {
+        /** Turn number last served to get_events(sinceMyLastTurn=true) - the engine has no
+         *  per-agent turn memory, so the server tracks this itself (see registerReadTools). */
+        var lastGistTurn: Int = 0
+        /** Index into ChatStore.Chat.messagesSince up to which get_events has already returned
+         *  chat messages - so repeated calls don't re-show the same lines. */
+        var lastChatIndex: Int = 0
+    }
 
     val server: Server = Server(
         serverInfo = Implementation(name = "unciv", version = "1.0.0"),
@@ -64,27 +78,36 @@ class UncivMcpServer {
 
     private fun errorResult(message: String) = CallToolResult(content = listOf(TextContent(message)), isError = true)
 
+    // Error messages that list what IS valid, so the agent can recover without another round-trip.
+    private fun unknownCityError(civ: com.unciv.logic.civilization.Civilization, cityName: String) =
+        "No city named $cityName; valid: ${civ.cities.joinToString { it.name }}"
+    private fun unknownUnitError(civ: com.unciv.logic.civilization.Civilization, unitId: Int) =
+        "No unit with id $unitId; valid ids: ${civ.units.getCivUnits().joinToString { "${it.id} (${it.name})" }}"
+    private fun unknownCivError(gameInfo: GameInfo, civName: String) =
+        "No civilization named $civName; valid: ${gameInfo.civilizations.joinToString { it.civName }}"
+
     private fun Server.registerConnectGame() {
         addTool(
             name = "connect_game",
-            description = "Connect to a running Unciv multiplayer game as the agent's civilization. Must be called before any other tool.",
+            description = "Connect to a running Unciv multiplayer game as the agent's civilization. Must be called before any other tool. " +
+                "civName is optional - if omitted, the civilization is looked up by playerId (the human slot the agent occupies).",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("serverUrl") { put("type", "string"); put("description", "Base URL of the UncivServer, e.g. http://localhost:8080") }
                     putJsonObject("gameId") { put("type", "string") }
                     putJsonObject("playerId") { put("type", "string"); put("description", "This agent's multiplayer user id") }
-                    putJsonObject("civName") { put("type", "string"); put("description", "civID of the civilization this agent controls") }
+                    putJsonObject("civName") { put("type", "string"); put("description", "civID of the civilization this agent controls; omit to auto-detect from playerId") }
                     putJsonObject("password") { put("type", "string") }
                     putJsonObject("visibilityMode") { put("type", "string"); put("description", "FULL or RESTRICTED") }
                 },
-                required = listOf("serverUrl", "gameId", "playerId", "civName", "password"),
+                required = listOf("serverUrl", "gameId", "playerId", "password"),
             ),
         ) { request ->
             val args = request.arguments ?: return@addTool errorResult("Missing arguments")
             val serverUrl = args["serverUrl"]?.jsonPrimitive?.content ?: return@addTool errorResult("serverUrl required")
             val gameId = args["gameId"]?.jsonPrimitive?.content ?: return@addTool errorResult("gameId required")
             val playerId = args["playerId"]?.jsonPrimitive?.content ?: return@addTool errorResult("playerId required")
-            val civName = args["civName"]?.jsonPrimitive?.content ?: return@addTool errorResult("civName required")
+            val requestedCivName = args["civName"]?.jsonPrimitive?.content
             val password = args["password"]?.jsonPrimitive?.content ?: return@addTool errorResult("password required")
             val visibility = when (args["visibilityMode"]?.jsonPrimitive?.content?.uppercase()) {
                 "RESTRICTED" -> VisibilityMode.RESTRICTED
@@ -114,14 +137,22 @@ class UncivMcpServer {
             // auto-plays AI civs (we'd never get a turn) and AI civs never populate notifications
             // (get_events would silently stay empty), so this must hold for the agent to work at all.
             val gameInfo = MultiplayerServer().tryDownloadGame(gameId)
-            val civ = gameInfo.getCivilizationOrNull(civName)
-                ?: return@addTool errorResult("No civilization named $civName in game $gameId")
-            if (civ.playerType != PlayerType.Human) {
-                return@addTool errorResult("$civName is an AI-controlled civ; the agent must occupy a Human slot")
+            val civ = if (requestedCivName != null) {
+                val named = gameInfo.getCivilizationOrNull(requestedCivName)
+                    ?: return@addTool errorResult(unknownCivError(gameInfo, requestedCivName))
+                if (named.playerType != PlayerType.Human) {
+                    return@addTool errorResult("$requestedCivName is an AI-controlled civ; the agent must occupy a Human slot")
+                }
+                if (named.playerId != playerId) {
+                    return@addTool errorResult("$requestedCivName's slot belongs to playerId '${named.playerId}', not '$playerId'")
+                }
+                named
+            } else {
+                gameInfo.civilizations.firstOrNull { it.playerType == PlayerType.Human && it.playerId == playerId }
+                    ?: return@addTool errorResult("No human-controlled civilization in game $gameId belongs to playerId '$playerId'; " +
+                        "human civs: ${gameInfo.civilizations.filter { it.playerType == PlayerType.Human }.joinToString { it.civName }}")
             }
-            if (civ.playerId != playerId) {
-                return@addTool errorResult("$civName's slot belongs to playerId '${civ.playerId}', not '$playerId'")
-            }
+            val civName = civ.civName
 
             connection = GameConnection(gameId, civName, visibility)
             ChatWebSocket.requestMessageSend(Message.Join(listOf(gameId)))
@@ -195,15 +226,57 @@ class UncivMcpServer {
         }
         addTool(
             name = "get_events",
-            description = "Read notifications: the current turn's events plus a recent per-turn archive - what happened while it wasn't the agent's turn.",
+            description = "Read notifications and chat: the current turn's events plus a recent per-turn archive - what happened while it wasn't the agent's turn - " +
+                "and any chat messages received since the last get_events call. " +
+                "Pass sinceMyLastTurn=true for a turn-start gist: only notifications logged since this tool was last called that way, plus score/gold/tech/etc deltas. " +
+                "Call that mode once at the start of your turn, not while polling for it to start - each call advances the cutoff.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
-                    putJsonObject("turnsOfHistory") { put("type", "integer"); put("description", "How many past turns of the notification log to include, default 3") }
+                    putJsonObject("turnsOfHistory") { put("type", "integer"); put("description", "How many past turns of the notification log to include, default 3 (ignored if sinceMyLastTurn is true)") }
+                    putJsonObject("sinceMyLastTurn") { put("type", "boolean"); put("description", "Return only what's new since the last sinceMyLastTurn=true call, plus stat deltas") }
                 },
             ),
         ) { request ->
+            val conn = requireConnection()
             val turns = request.arguments?.get("turnsOfHistory")?.jsonPrimitive?.int ?: 3
-            withGame { gameInfo, civ, view -> jsonResult(view.events(civ, turns)) }
+            val sinceMyLastTurn = request.arguments?.get("sinceMyLastTurn")?.jsonPrimitive?.boolean ?: false
+            val chat = ChatStore.getChatByGameId(conn.gameId)
+            val newChatMessages = chat.messagesSince(conn.lastChatIndex)
+            withGame { gameInfo, civ, view ->
+                val cutoff = if (sinceMyLastTurn) conn.lastGistTurn else null
+                val result = jsonResult(view.events(civ, gameInfo, turns, cutoff, newChatMessages))
+                if (sinceMyLastTurn) conn.lastGistTurn = gameInfo.turns
+                conn.lastChatIndex = chat.length
+                result
+            }
+        }
+
+        addTool(
+            name = "get_chat",
+            description = "Read the full chat log for this game (get_events only shows messages new since the last call).",
+        ) {
+            val conn = requireConnection()
+            val chat = ChatStore.getChatByGameId(conn.gameId)
+            jsonResult(buildJsonObject {
+                putJsonArray("messages") {
+                    chat.messagesSince(0).forEach { (civName, message) ->
+                        add(buildJsonObject {
+                            put("from", civName)
+                            put("message", message)
+                        })
+                    }
+                }
+            })
+        }
+
+        addTool(
+            name = "get_civ_intel",
+            description = "Comparative standing a human sees: per-metric rankings (score, gold, military " +
+                "force, tech count, population, …) of the major civs, plus each met civ's era, score, and " +
+                "who they're at war with. Stats are turn-start snapshots; in RESTRICTED mode they obey the " +
+                "host's hide-other-civ-stats setting and unmet civs show as 'unknown'.",
+        ) {
+            withGame { gameInfo, civ, view -> jsonResult(view.civIntel(civ, gameInfo)) }
         }
     }
 
@@ -245,7 +318,7 @@ class UncivMcpServer {
             val construction = args["construction"]?.jsonPrimitive?.content ?: return@addTool errorResult("construction required")
             mutateGame { gameInfo, civ ->
                 val city = civ.cities.firstOrNull { it.name == cityName }
-                    ?: return@mutateGame errorResult("No city named $cityName")
+                    ?: return@mutateGame errorResult(unknownCityError(civ, cityName))
                 val ruleset = gameInfo.ruleset
                 val isKnown = ruleset.buildings.containsKey(construction) ||
                     ruleset.units.containsKey(construction) ||
@@ -274,7 +347,7 @@ class UncivMcpServer {
             val y = args["y"]?.jsonPrimitive?.int ?: return@addTool errorResult("y required")
             mutateGame { gameInfo, civ ->
                 val unit = civ.units.getCivUnits().firstOrNull { it.id == unitId }
-                    ?: return@mutateGame errorResult("No unit with id $unitId")
+                    ?: return@mutateGame errorResult(unknownUnitError(civ, unitId))
                 val destination = gameInfo.tileMap.getOrNull(x, y)
                     ?: return@mutateGame errorResult("No tile at ($x, $y)")
                 try {
@@ -304,7 +377,7 @@ class UncivMcpServer {
                 ?: return@addTool errorResult("Unknown action type $actionName")
             mutateGame { gameInfo, civ ->
                 val unit: MapUnit = civ.units.getCivUnits().firstOrNull { it.id == unitId }
-                    ?: return@mutateGame errorResult("No unit with id $unitId")
+                    ?: return@mutateGame errorResult(unknownUnitError(civ, unitId))
                 // Fortify/Sleep/Explore/Automate aren't in UnitActions' mapped-provider table, so
                 // invokeUnitAction would fall back to enumerating every provider - including
                 // addEscortAction/addSwapAction, which crash headless (see GameStateView.units()).
@@ -341,6 +414,169 @@ class UncivMcpServer {
                         if (!invoked) return@mutateGame errorResult("Action $actionName is not available for unit $unitId right now")
                     }
                 }
+                null
+            }
+        }
+
+        addTool(
+            name = "purchase_construction",
+            description = "Buy a unit/building/wonder in a city immediately with Gold (default) or Faith, instead of waiting for production.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("cityName") { put("type", "string") }
+                    putJsonObject("construction") { put("type", "string") }
+                    putJsonObject("stat") { put("type", "string"); put("description", "Gold or Faith, default Gold") }
+                },
+                required = listOf("cityName", "construction"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val cityName = args["cityName"]?.jsonPrimitive?.content ?: return@addTool errorResult("cityName required")
+            val construction = args["construction"]?.jsonPrimitive?.content ?: return@addTool errorResult("construction required")
+            val statName = args["stat"]?.jsonPrimitive?.content ?: "Gold"
+            mutateGame { gameInfo, civ ->
+                val city = civ.cities.firstOrNull { it.name == cityName }
+                    ?: return@mutateGame errorResult(unknownCityError(civ, cityName))
+                val stat = runCatching { Stat.valueOf(statName) }.getOrNull()
+                    ?: return@mutateGame errorResult("Unknown stat $statName; use Gold or Faith")
+                if (stat != Stat.Gold && stat != Stat.Faith)
+                    return@mutateGame errorResult("Can only purchase with Gold or Faith")
+                val constr = (gameInfo.ruleset.buildings[construction] ?: gameInfo.ruleset.units[construction]) as? INonPerpetualConstruction
+                    ?: return@mutateGame errorResult("$construction is not a purchasable building or unit; buildable in $cityName: " +
+                        (city.cityConstructions.getBuildableBuildings().map { it.name } + city.cityConstructions.getConstructableUnits().map { it.name }).joinToString())
+                val cost = constr.getStatBuyCost(city, stat)
+                    ?: return@mutateGame errorResult("$construction cannot be bought with $statName")
+                if (!city.cityConstructions.isConstructionPurchaseAllowed(constr, stat, cost))
+                    return@mutateGame errorResult("Cannot purchase $construction in $cityName right now (cost $cost $statName, reserve ${city.getStatReserve(stat)})")
+                if (!city.cityConstructions.purchaseConstruction(construction, queuePosition = -1, automatic = false, stat = stat))
+                    return@mutateGame errorResult("Purchase of $construction failed (could not place unit?)")
+                null
+            }
+        }
+
+        addTool(
+            name = "modify_production_queue",
+            description = "Reorder or remove an entry in a city's production queue (use set_city_production to add).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("cityName") { put("type", "string") }
+                    putJsonObject("index") { put("type", "integer") }
+                    putJsonObject("op") { put("type", "string"); put("description", "remove|top|end|raise|lower") }
+                },
+                required = listOf("cityName", "index", "op"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val cityName = args["cityName"]?.jsonPrimitive?.content ?: return@addTool errorResult("cityName required")
+            val index = args["index"]?.jsonPrimitive?.int ?: return@addTool errorResult("index required")
+            val op = args["op"]?.jsonPrimitive?.content ?: return@addTool errorResult("op required")
+            mutateGame { gameInfo, civ ->
+                val city = civ.cities.firstOrNull { it.name == cityName }
+                    ?: return@mutateGame errorResult(unknownCityError(civ, cityName))
+                val cc = city.cityConstructions
+                if (index !in cc.constructionQueue.indices)
+                    return@mutateGame errorResult("index $index out of range (queue size ${cc.constructionQueue.size})")
+                when (op) {
+                    "remove" -> cc.removeFromQueue(index, automatic = false)
+                    "top" -> cc.moveEntryToTop(index)
+                    "end" -> cc.moveEntryToEnd(index)
+                    "raise" -> cc.raisePriority(index)
+                    "lower" -> cc.lowerPriority(index)
+                    else -> return@mutateGame errorResult("Unknown op $op; use remove|top|end|raise|lower")
+                }
+                null
+            }
+        }
+
+        addTool(
+            name = "set_city_focus",
+            description = "Set a city's citizen-management focus (e.g. ProductionFocus, GoldFocus) and immediately reassign worked tiles/specialists.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("cityName") { put("type", "string") }
+                    putJsonObject("focus") { put("type", "string") }
+                },
+                required = listOf("cityName", "focus"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val cityName = args["cityName"]?.jsonPrimitive?.content ?: return@addTool errorResult("cityName required")
+            val focus = args["focus"]?.jsonPrimitive?.content ?: return@addTool errorResult("focus required")
+            mutateGame { gameInfo, civ ->
+                val city = civ.cities.firstOrNull { it.name == cityName }
+                    ?: return@mutateGame errorResult(unknownCityError(civ, cityName))
+                val focusEnum = runCatching { CityFocus.valueOf(focus) }.getOrNull()
+                    ?: return@mutateGame errorResult("Unknown focus $focus; valid: ${CityFocus.entries.joinToString { it.name }}")
+                city.setCityFocus(focusEnum)
+                city.reassignPopulation()
+                null
+            }
+        }
+
+        addTool(
+            name = "adopt_policy",
+            description = "Adopt a social policy, spending stored culture (or a free policy slot if available).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject { putJsonObject("policyName") { put("type", "string") } },
+                required = listOf("policyName"),
+            ),
+        ) { request ->
+            val policyName = request.arguments?.get("policyName")?.jsonPrimitive?.content
+                ?: return@addTool errorResult("policyName required")
+            mutateGame { gameInfo, civ ->
+                val policy = gameInfo.ruleset.policies[policyName]
+                    ?: return@mutateGame errorResult("Unknown policy $policyName; valid: ${gameInfo.ruleset.policies.keys.joinToString()}")
+                if (!civ.policies.canAdoptPolicy())
+                    return@mutateGame errorResult("Cannot adopt any policy right now (need ${civ.policies.getCultureNeededForNextPolicy()} culture, have ${civ.policies.storedCulture})")
+                if (!civ.policies.isAdoptable(policy))
+                    return@mutateGame errorResult("$policyName is not adoptable (prerequisites/era not met, or already adopted)")
+                civ.policies.adopt(policy)
+                null
+            }
+        }
+
+        addTool(
+            name = "declare_war",
+            description = "Declare war on a civilization the agent has met.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject { putJsonObject("targetCivName") { put("type", "string") } },
+                required = listOf("targetCivName"),
+            ),
+        ) { request ->
+            val targetCivName = request.arguments?.get("targetCivName")?.jsonPrimitive?.content
+                ?: return@addTool errorResult("targetCivName required")
+            mutateGame { gameInfo, civ ->
+                val target = gameInfo.getCivilizationOrNull(targetCivName)
+                    ?: return@mutateGame errorResult(unknownCivError(gameInfo, targetCivName))
+                if (target == civ) return@mutateGame errorResult("Cannot target your own civilization")
+                val diplo = civ.getDiplomacyManager(target)
+                    ?: return@mutateGame errorResult("Have not met $targetCivName; known civs: ${civ.getKnownCivs().joinToString { it.civName }}")
+                if (!diplo.canDeclareWar())
+                    return@mutateGame errorResult("Cannot declare war on $targetCivName right now (already at war, or a peace treaty is in effect)")
+                diplo.declareWar()
+                null
+            }
+        }
+
+        addTool(
+            name = "make_peace",
+            description = "Immediately make mutual peace with a civilization the agent is at war with (not a negotiated peace treaty).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject { putJsonObject("targetCivName") { put("type", "string") } },
+                required = listOf("targetCivName"),
+            ),
+        ) { request ->
+            val targetCivName = request.arguments?.get("targetCivName")?.jsonPrimitive?.content
+                ?: return@addTool errorResult("targetCivName required")
+            mutateGame { gameInfo, civ ->
+                val target = gameInfo.getCivilizationOrNull(targetCivName)
+                    ?: return@mutateGame errorResult(unknownCivError(gameInfo, targetCivName))
+                if (target == civ) return@mutateGame errorResult("Cannot target your own civilization")
+                val diplo = civ.getDiplomacyManager(target)
+                    ?: return@mutateGame errorResult("Have not met $targetCivName; known civs: ${civ.getKnownCivs().joinToString { it.civName }}")
+                if (diplo.diplomaticStatus != DiplomaticStatus.War)
+                    return@mutateGame errorResult("Not at war with $targetCivName")
+                diplo.makePeace()
                 null
             }
         }

--- a/desktop/src/com/unciv/app/desktop/mcp/UncivMcpServer.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/UncivMcpServer.kt
@@ -2,8 +2,16 @@ package com.unciv.app.desktop.mcp
 
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
-import com.unciv.logic.automation.unit.UnitAutomation
+import com.unciv.logic.battle.Battle
+import com.unciv.logic.battle.CityCombatant
+import com.unciv.logic.battle.MapUnitCombatant
+import com.unciv.logic.battle.TargetHelper
+import com.unciv.logic.civilization.AlertType
+import com.unciv.logic.civilization.NotificationCategory
+import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PlayerType
+import com.unciv.logic.civilization.diplomacy.Demand
+import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.city.CityFocus
 import com.unciv.logic.map.mapunit.MapUnit
@@ -15,6 +23,11 @@ import com.unciv.logic.multiplayer.isUsersTurn
 import com.unciv.logic.multiplayer.storage.AuthStatus
 import com.unciv.logic.multiplayer.storage.MultiplayerServer
 import com.unciv.logic.multiplayer.storage.UncivServerFileStorage
+import com.unciv.logic.trade.TradeLogic
+import com.unciv.logic.trade.TradeOffer
+import com.unciv.logic.trade.TradeOfferType
+import com.unciv.logic.trade.TradeOffersList
+import com.unciv.logic.trade.TradeRequest
 import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.stats.Stat
@@ -26,6 +39,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
@@ -37,9 +51,9 @@ import kotlinx.serialization.json.putJsonObject
 
 /**
  * MCP tool surface for the LLM counterparty. One [Server] per process, one connected game.
- * Each tool re-downloads the [GameInfo] fresh from the multiplayer server before mutating it,
- * mirroring [com.unciv.logic.multiplayer.Multiplayer.skipCurrentPlayerTurn] - see the plan doc
- * for why we never cache a GameInfo across calls or clone before nextTurn().
+ * Unciv multiplayer is strictly turn-based - while it's our turn nothing else can write the
+ * save - so [GameInfo] is downloaded once and held in [GameConnection.heldGame] for the rest
+ * of the turn (see [holdGame]); [Server.registerEndTurn] is the only tool that uploads.
  */
 class UncivMcpServer {
     private var connection: GameConnection? = null
@@ -55,6 +69,10 @@ class UncivMcpServer {
         /** Index into ChatStore.Chat.messagesSince up to which get_events has already returned
          *  chat messages - so repeated calls don't re-show the same lines. */
         var lastChatIndex: Int = 0
+        /** Held while it's our turn - nothing else can write the save then. Flushed by end_turn.
+         *  ponytail: lost on process death; the server still holds the pre-turn state, so the
+         *  failure is "agent didn't move", never a corrupt save. Add a periodic flush if that bites. */
+        var heldGame: GameInfo? = null
     }
 
     val server: Server = Server(
@@ -154,7 +172,10 @@ class UncivMcpServer {
             }
             val civName = civ.civName
 
-            connection = GameConnection(gameId, civName, visibility)
+            val conn = GameConnection(gameId, civName, visibility)
+            // Don't report ChatStore's seeded INITIAL_MESSAGE as a real first chat line.
+            conn.lastChatIndex = ChatStore.getChatByGameId(gameId).length
+            connection = conn
             ChatWebSocket.requestMessageSend(Message.Join(listOf(gameId)))
 
             textResult("Connected to game $gameId as $civName")
@@ -182,13 +203,14 @@ class UncivMcpServer {
             description = "End the agent's turn, advancing the game (auto-plays any AI civs) until the next human's turn.",
         ) {
             val conn = requireConnection()
-            val multiplayerServer = MultiplayerServer()
-            val gameInfo = multiplayerServer.tryDownloadGame(conn.gameId)
+            val gameInfo = holdGame(conn)
             if (gameInfo.currentPlayer != conn.civId) {
+                conn.heldGame = null
                 return@addTool errorResult("It is not ${conn.civId}'s turn (current: ${gameInfo.currentPlayer})")
             }
             gameInfo.nextTurn()
-            multiplayerServer.uploadGame(gameInfo, withPreview = true)
+            MultiplayerServer().uploadGame(gameInfo, withPreview = true)
+            conn.heldGame = null
             textResult("Turn ended. Now turn ${gameInfo.turns}, current player: ${gameInfo.currentPlayer}")
         }
     }
@@ -278,6 +300,36 @@ class UncivMcpServer {
         ) {
             withGame { gameInfo, civ, view -> jsonResult(view.civIntel(civ, gameInfo)) }
         }
+
+        addTool(
+            name = "get_pending_decisions",
+            description = "Trade requests and alerts (demands, declarations of friendship, and informational events) " +
+                "raised by other civs that need a response. Use respond_to_trade / resolve_alert to answer them.",
+        ) {
+            withGame { gameInfo, civ, view -> jsonResult(view.pendingDecisions(civ)) }
+        }
+
+        addTool(
+            name = "get_trade_options",
+            description = "What can be offered to, and asked of, a civilization in a trade - resource/gold amounts are the maximum tradable. " +
+                "Use the (type, name) pairs from here in propose_trade.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject { putJsonObject("targetCivName") { put("type", "string") } },
+                required = listOf("targetCivName"),
+            ),
+        ) { request ->
+            val targetCivName = request.arguments?.get("targetCivName")?.jsonPrimitive?.content
+                ?: return@addTool errorResult("targetCivName required")
+            withGame { gameInfo, civ, view ->
+                val target = gameInfo.getCivilizationOrNull(targetCivName)
+                    ?: return@withGame errorResult(unknownCivError(gameInfo, targetCivName))
+                val tradeLogic = TradeLogic(civ, target)
+                jsonResult(buildJsonObject {
+                    putJsonArray("weCanOffer") { tradeLogic.ourAvailableOffers.forEach { add(tradeOfferJson(it)) } }
+                    putJsonArray("weCanRequest") { tradeLogic.theirAvailableOffers.forEach { add(tradeOfferJson(it)) } }
+                })
+            }
+        }
     }
 
     private fun Server.registerActionTools() {
@@ -360,8 +412,64 @@ class UncivMcpServer {
         }
 
         addTool(
+            name = "attack",
+            description = "Attack an enemy unit or city, moving into range first if needed. " +
+                "Use the attackableTiles on get_units' units for valid (x, y) targets.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("unitId") { put("type", "integer") }
+                    putJsonObject("x") { put("type", "integer"); put("description", "Position of the tile to attack, not the tile to attack from") }
+                    putJsonObject("y") { put("type", "integer") }
+                },
+                required = listOf("unitId", "x", "y"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val unitId = args["unitId"]?.jsonPrimitive?.int ?: return@addTool errorResult("unitId required")
+            val x = args["x"]?.jsonPrimitive?.int ?: return@addTool errorResult("x required")
+            val y = args["y"]?.jsonPrimitive?.int ?: return@addTool errorResult("y required")
+            mutateGame { gameInfo, civ ->
+                val unit = civ.units.getCivUnits().firstOrNull { it.id == unitId }
+                    ?: return@mutateGame errorResult(unknownUnitError(civ, unitId))
+                if (!unit.canAttack()) return@mutateGame errorResult("Unit $unitId can't attack right now")
+                val targets = TargetHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
+                val target = targets.firstOrNull { it.tileToAttack.position.x == x && it.tileToAttack.position.y == y }
+                    ?: return@mutateGame errorResult("No attackable target at ($x, $y) for unit $unitId; valid: " +
+                        targets.joinToString { "(${it.tileToAttack.position.x}, ${it.tileToAttack.position.y})" })
+                Battle.moveAndAttack(MapUnitCombatant(unit), target)
+                null
+            }
+        }
+
+        addTool(
+            name = "bombard",
+            description = "Bombard the strongest attackable enemy in range from a city (cities with a garrison and enough population can bombard without a unit).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject { putJsonObject("cityName") { put("type", "string") } },
+                required = listOf("cityName"),
+            ),
+        ) { request ->
+            val cityName = request.arguments?.get("cityName")?.jsonPrimitive?.content
+                ?: return@addTool errorResult("cityName required")
+            mutateGame { gameInfo, civ ->
+                val city = civ.cities.firstOrNull { it.name == cityName }
+                    ?: return@mutateGame errorResult(unknownCityError(civ, cityName))
+                if (!city.canBombard()) return@mutateGame errorResult("$cityName can't bombard right now (already attacked, or no target in range)")
+                val targets = TargetHelper.getBombardableTiles(city)
+                    .mapNotNull { Battle.getMapCombatantOfTile(it) }
+                    .filterNot { it is MapUnitCombatant && it.isCivilian() }
+                    .toList()
+                if (targets.isEmpty()) return@mutateGame errorResult("No bombardable target in range of $cityName")
+                val target = targets.maxByOrNull { com.unciv.logic.battle.BattleDamage.calculateDamageToDefender(CityCombatant(city), it) }!!
+                Battle.attack(CityCombatant(city), target)
+                null
+            }
+        }
+
+        addTool(
             name = "unit_action",
-            description = "Invoke a named unit action (e.g. FoundCity, Fortify, Sleep, Explore, Upgrade, ConstructImprovement) on a unit.",
+            description = "Invoke a named unit action (e.g. FoundCity, Fortify, Sleep, Explore, Upgrade, DisbandUnit, ConstructImprovement) on a unit. " +
+                "Use promote_unit for Promote - it needs a promotion name.",
             inputSchema = ToolSchema(
                 properties = buildJsonObject {
                     putJsonObject("unitId") { put("type", "integer") }
@@ -378,42 +486,51 @@ class UncivMcpServer {
             mutateGame { gameInfo, civ ->
                 val unit: MapUnit = civ.units.getCivUnits().firstOrNull { it.id == unitId }
                     ?: return@mutateGame errorResult(unknownUnitError(civ, unitId))
-                // Fortify/Sleep/Explore/Automate aren't in UnitActions' mapped-provider table, so
-                // invokeUnitAction would fall back to enumerating every provider - including
-                // addEscortAction/addSwapAction, which crash headless (see GameStateView.units()).
-                // Mutate the same unit state their GUI actions do, directly, instead.
+                // Promote/DisbandUnit/Skip's real actions open a screen or popup - GUI calls that
+                // stay crashy headless even with GUI.isWorldLoaded() guards, since there's no
+                // world screen to open them on at all. Handle their headless-equivalent directly;
+                // everything else is a plain, pure mutation invokeUnitAction can run as-is.
                 when (actionType) {
-                    UnitActionType.Fortify -> {
-                        if (!unit.canFortify() || !unit.hasMovement()) return@mutateGame errorResult("Unit $unitId can't fortify right now")
-                        unit.fortify()
+                    UnitActionType.Promote -> return@mutateGame errorResult("Use promote_unit to promote unit $unitId (needs a promotion name)")
+                    UnitActionType.DisbandUnit -> {
+                        if (!unit.hasMovement()) return@mutateGame errorResult("Unit $unitId can't disband right now")
+                        unit.disband()
+                        unit.civ.updateStatsForNextTurn()
                     }
-                    UnitActionType.Sleep -> {
-                        if (unit.isFortified() || unit.canFortify() || unit.isGuarding() || !unit.hasMovement())
-                            return@mutateGame errorResult("Unit $unitId can't sleep right now")
-                        unit.action = UnitActionType.Sleep.value
-                    }
-                    UnitActionType.Explore -> {
-                        if (unit.baseUnit.movesLikeAirUnits) return@mutateGame errorResult("Air units can't explore")
-                        unit.action = UnitActionType.Explore.value
-                        if (unit.hasMovement()) UnitAutomation.automatedExplore(unit)
-                    }
-                    UnitActionType.Automate -> {
-                        if (!unit.hasMovement()) return@mutateGame errorResult("Unit $unitId can't automate right now")
-                        unit.automated = true
-                        UnitAutomation.automateUnitMoves(unit)
+                    UnitActionType.Skip -> {
+                        if (!unit.hasMovement()) return@mutateGame errorResult("Unit $unitId can't skip right now")
+                        unit.due = !unit.due
                     }
                     else -> {
-                        // Mapped types (FoundCity, ConstructImprovement, ...) are headless-safe.
-                        // Any other unmapped type would still hit the enumerator crash - catch it
-                        // rather than let the whole call NPE.
-                        val invoked = try {
-                            UnitActions.invokeUnitAction(unit, actionType)
-                        } catch (e: Exception) {
-                            return@mutateGame errorResult("Action $actionName isn't supported for unit $unitId in a headless session")
-                        }
-                        if (!invoked) return@mutateGame errorResult("Action $actionName is not available for unit $unitId right now")
+                        if (!UnitActions.invokeUnitAction(unit, actionType))
+                            return@mutateGame errorResult("Action $actionName is not available for unit $unitId right now")
                     }
                 }
+                null
+            }
+        }
+
+        addTool(
+            name = "promote_unit",
+            description = "Apply a promotion to a unit (spends accumulated XP).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("unitId") { put("type", "integer") }
+                    putJsonObject("promotionName") { put("type", "string") }
+                },
+                required = listOf("unitId", "promotionName"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val unitId = args["unitId"]?.jsonPrimitive?.int ?: return@addTool errorResult("unitId required")
+            val promotionName = args["promotionName"]?.jsonPrimitive?.content ?: return@addTool errorResult("promotionName required")
+            mutateGame { gameInfo, civ ->
+                val unit: MapUnit = civ.units.getCivUnits().firstOrNull { it.id == unitId }
+                    ?: return@mutateGame errorResult(unknownUnitError(civ, unitId))
+                val available = unit.promotions.getAvailablePromotions().map { it.name }.toList()
+                if (promotionName !in available)
+                    return@mutateGame errorResult("$promotionName is not available for unit $unitId; valid: $available")
+                unit.promotions.addPromotion(promotionName)
                 null
             }
         }
@@ -580,7 +697,141 @@ class UncivMcpServer {
                 null
             }
         }
+
+        addTool(
+            name = "respond_to_trade",
+            description = "Accept or decline a pending trade request from get_pending_decisions.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("requestingCivName") { put("type", "string") }
+                    putJsonObject("accept") { put("type", "boolean") }
+                },
+                required = listOf("requestingCivName", "accept"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val requestingCivName = args["requestingCivName"]?.jsonPrimitive?.content ?: return@addTool errorResult("requestingCivName required")
+            val accept = args["accept"]?.jsonPrimitive?.boolean ?: return@addTool errorResult("accept required")
+            mutateGame { gameInfo, civ ->
+                val requestingCiv = gameInfo.getCivilizationOrNull(requestingCivName)
+                    ?: return@mutateGame errorResult(unknownCivError(gameInfo, requestingCivName))
+                val tradeRequest = civ.tradeRequests.firstOrNull { it.requestingCiv == requestingCiv.civID }
+                    ?: return@mutateGame errorResult("No pending trade request from $requestingCivName")
+                // Mirrors TradePopup's Sounds-good/Not-this-time buttons, including the notification the human sees.
+                if (accept) {
+                    val tradeLogic = TradeLogic(civ, requestingCiv)
+                    tradeLogic.currentTrade.set(tradeRequest.trade)
+                    tradeLogic.acceptTrade()
+                    requestingCiv.addNotification("[${civ.civName}] has accepted your trade request", NotificationCategory.Trade, civ.civName, NotificationIcon.Trade)
+                } else {
+                    tradeRequest.decline(civ)
+                    requestingCiv.addNotification("[${civ.civName}] has denied your trade request", NotificationCategory.Trade, civ.civName, NotificationIcon.Trade)
+                }
+                civ.tradeRequests.remove(tradeRequest)
+                null
+            }
+        }
+
+        addTool(
+            name = "propose_trade",
+            description = "Propose a trade to a civilization: ourOffers is what we give, theirOffers is what we want back. " +
+                "Each offer is {type, name, amount} using (type, name) pairs from get_trade_options; amount only matters for Gold/Gold_Per_Turn/resources.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("targetCivName") { put("type", "string") }
+                    putJsonObject("ourOffers") { put("type", "array") }
+                    putJsonObject("theirOffers") { put("type", "array") }
+                },
+                required = listOf("targetCivName", "ourOffers", "theirOffers"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val targetCivName = args["targetCivName"]?.jsonPrimitive?.content ?: return@addTool errorResult("targetCivName required")
+            val ourOffersArg = args["ourOffers"] as? JsonArray ?: return@addTool errorResult("ourOffers required (array of {type, name, amount})")
+            val theirOffersArg = args["theirOffers"] as? JsonArray ?: return@addTool errorResult("theirOffers required (array of {type, name, amount})")
+            val ourSpecs = ourOffersArg.map { it as JsonObject }
+            val theirSpecs = theirOffersArg.map { it as JsonObject }
+            mutateGame { gameInfo, civ ->
+                val target = gameInfo.getCivilizationOrNull(targetCivName)
+                    ?: return@mutateGame errorResult(unknownCivError(gameInfo, targetCivName))
+                if (target == civ) return@mutateGame errorResult("Cannot target your own civilization")
+                val tradeLogic = TradeLogic(civ, target)
+
+                fun resolveOffer(spec: JsonObject, available: TradeOffersList): TradeOffer {
+                    val type = spec["type"]?.jsonPrimitive?.content
+                        ?: throw OfferError("Each offer needs a type")
+                    val name = spec["name"]?.jsonPrimitive?.content
+                        ?: throw OfferError("Each offer needs a name")
+                    val offerType = runCatching { TradeOfferType.valueOf(type) }.getOrNull()
+                        ?: throw OfferError("Unknown offer type $type")
+                    val avail = available.firstOrNull { it.type == offerType && it.name == name }
+                        ?: throw OfferError("$type $name is not available; call get_trade_options for valid entries")
+                    if (avail.type.numberType == TradeOfferType.TradeTypeNumberType.None) return avail.copy()
+                    val amount = spec["amount"]?.jsonPrimitive?.int ?: avail.amount
+                    if (amount !in 1..avail.amount) throw OfferError("$type $name amount must be between 1 and ${avail.amount}")
+                    return avail.copy(amount = amount)
+                }
+
+                try {
+                    ourSpecs.forEach { tradeLogic.currentTrade.ourOffers.add(resolveOffer(it, tradeLogic.ourAvailableOffers)) }
+                    theirSpecs.forEach { tradeLogic.currentTrade.theirOffers.add(resolveOffer(it, tradeLogic.theirAvailableOffers)) }
+                } catch (e: OfferError) {
+                    return@mutateGame errorResult(e.message!!)
+                }
+
+                // From the recipient's perspective their "their offers" are our "our offers" - see TradeTable's offer button.
+                target.tradeRequests.add(TradeRequest(civ.civID, tradeLogic.currentTrade.reverse()))
+                null
+            }
+        }
+
+        addTool(
+            name = "resolve_alert",
+            description = "Respond to a pending alert from get_pending_decisions by its index. accept matters only for " +
+                "demands (DemandToStopSettlingCitiesNear, DemandToStopSpreadingReligion, DemandToStopSpyingOnUs, " +
+                "DemandToNotAttackUs) and DeclarationOfFriendship; other alert types are purely informational and just get dismissed.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("index") { put("type", "integer") }
+                    putJsonObject("accept") { put("type", "boolean"); put("description", "Default true") }
+                },
+                required = listOf("index"),
+            ),
+        ) { request ->
+            val index = request.arguments?.get("index")?.jsonPrimitive?.int ?: return@addTool errorResult("index required")
+            val accept = request.arguments?.get("accept")?.jsonPrimitive?.boolean ?: true
+            mutateGame { gameInfo, civ ->
+                if (index !in civ.popupAlerts.indices)
+                    return@mutateGame errorResult("index $index out of range (${civ.popupAlerts.size} pending alerts)")
+                val alert = civ.popupAlerts[index]
+                val otherCiv = gameInfo.getCivilizationOrNull(alert.value)
+                val diplo = otherCiv?.let { civ.getDiplomacyManager(it) }
+                val demand = when (alert.type) {
+                    AlertType.DemandToStopSettlingCitiesNear -> Demand.DoNotSettleNearUs
+                    AlertType.DemandToStopSpreadingReligion -> Demand.DoNotSpreadReligion
+                    AlertType.DemandToStopSpyingOnUs -> Demand.DontSpyOnUs
+                    AlertType.DemandToNotAttackUs -> Demand.DoNotAttackUs
+                    else -> null
+                }
+                // Mirrors AlertPopup's addDemand/addDeclarationOfFriendship button actions; everything
+                // else (wonder built, tech researched, first contact, ...) has no state to apply - dismissing is the whole response.
+                if (demand != null && diplo != null) {
+                    if (accept) diplo.agreeToDemand(demand)
+                    else {
+                        diplo.refuseDemand(demand)
+                        if (demand == Demand.DoNotAttackUs) diplo.declareWar()
+                    }
+                } else if (alert.type == AlertType.DeclarationOfFriendship && diplo != null) {
+                    if (accept) diplo.signDeclarationOfFriendship()
+                    else diplo.otherCivDiplomacy().setFlag(DiplomacyFlags.DeclinedDeclarationOfFriendship, 20)
+                }
+                civ.popupAlerts.removeAt(index)
+                null
+            }
+        }
     }
+
+    private class OfferError(message: String) : Exception(message)
 
     private fun Server.registerChat() {
         addTool(
@@ -599,31 +850,39 @@ class UncivMcpServer {
         }
     }
 
-    /** Read-only helper: download, look up the agent's civ, hand it to [block]. */
+    /** Downloads and holds [GameInfo] for the rest of the turn, or returns the held copy - see
+     *  [GameConnection.heldGame]. Only holds if it's actually our turn; a stale download when
+     *  it isn't just gets re-fetched next call instead of being cached. */
+    private suspend fun holdGame(conn: GameConnection): GameInfo {
+        conn.heldGame?.let { return it }
+        val gameInfo = MultiplayerServer().tryDownloadGame(conn.gameId)
+        if (gameInfo.currentPlayer == conn.civId) conn.heldGame = gameInfo
+        return gameInfo
+    }
+
+    /** Read-only helper: use the held game (downloading it if needed), look up the agent's civ, hand it to [block]. */
     private suspend fun withGame(block: (GameInfo, com.unciv.logic.civilization.Civilization, GameStateView) -> CallToolResult): CallToolResult {
         val conn = requireConnection()
-        val gameInfo = MultiplayerServer().tryDownloadGame(conn.gameId)
+        val gameInfo = holdGame(conn)
         val civ = gameInfo.getCivilizationOrNull(conn.civId)
             ?: return errorResult("Civilization ${conn.civId} not found in game")
         return block(gameInfo, civ, GameStateView(conn.visibility))
     }
 
     /**
-     * Mutate-and-upload helper for act tools: download fresh, apply [block], upload without
-     * calling nextTurn() (only end_turn advances the game). [block] returns an error result to
-     * short-circuit, or null on success.
+     * Mutate helper for act tools: use the held game, apply [block], keep holding it - only
+     * end_turn uploads. [block] returns an error result to short-circuit, or null on success.
      */
     private suspend fun mutateGame(block: (GameInfo, com.unciv.logic.civilization.Civilization) -> CallToolResult?): CallToolResult {
         val conn = requireConnection()
-        val multiplayerServer = MultiplayerServer()
-        val gameInfo = multiplayerServer.tryDownloadGame(conn.gameId)
+        val gameInfo = holdGame(conn)
         val civ = gameInfo.getCivilizationOrNull(conn.civId)
             ?: return errorResult("Civilization ${conn.civId} not found in game")
         if (gameInfo.currentPlayer != conn.civId) {
+            conn.heldGame = null
             return errorResult("It is not ${conn.civId}'s turn (current: ${gameInfo.currentPlayer})")
         }
         block(gameInfo, civ)?.let { return it }
-        multiplayerServer.uploadGame(gameInfo, withPreview = true)
         return textResult("Applied")
     }
 }

--- a/desktop/src/com/unciv/app/desktop/mcp/UncivMcpServer.kt
+++ b/desktop/src/com/unciv/app/desktop/mcp/UncivMcpServer.kt
@@ -1,0 +1,393 @@
+package com.unciv.app.desktop.mcp
+
+import com.unciv.UncivGame
+import com.unciv.logic.GameInfo
+import com.unciv.logic.automation.unit.UnitAutomation
+import com.unciv.logic.civilization.PlayerType
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.logic.map.mapunit.movement.UnitMovement
+import com.unciv.logic.multiplayer.chat.ChatWebSocket
+import com.unciv.logic.multiplayer.chat.Message
+import com.unciv.logic.multiplayer.isUsersTurn
+import com.unciv.logic.multiplayer.storage.AuthStatus
+import com.unciv.logic.multiplayer.storage.MultiplayerServer
+import com.unciv.logic.multiplayer.storage.UncivServerFileStorage
+import com.unciv.models.UnitActionType
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * MCP tool surface for the LLM counterparty. One [Server] per process, one connected game.
+ * Each tool re-downloads the [GameInfo] fresh from the multiplayer server before mutating it,
+ * mirroring [com.unciv.logic.multiplayer.Multiplayer.skipCurrentPlayerTurn] - see the plan doc
+ * for why we never cache a GameInfo across calls or clone before nextTurn().
+ */
+class UncivMcpServer {
+    private var connection: GameConnection? = null
+
+    private class GameConnection(
+        val gameId: String,
+        val civId: String,
+        val visibility: VisibilityMode,
+    )
+
+    val server: Server = Server(
+        serverInfo = Implementation(name = "unciv", version = "1.0.0"),
+        options = ServerOptions(capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = false))),
+    ) {
+        registerConnectGame()
+        registerTurnStatus()
+        registerEndTurn()
+        registerReadTools()
+        registerActionTools()
+        registerChat()
+    }
+
+    private fun requireConnection(): GameConnection =
+        connection ?: error("Not connected. Call connect_game first.")
+
+    private fun textResult(text: String) = CallToolResult(content = listOf(TextContent(text)))
+
+    private fun jsonResult(json: JsonObject) = textResult(json.toString())
+
+    private fun errorResult(message: String) = CallToolResult(content = listOf(TextContent(message)), isError = true)
+
+    private fun Server.registerConnectGame() {
+        addTool(
+            name = "connect_game",
+            description = "Connect to a running Unciv multiplayer game as the agent's civilization. Must be called before any other tool.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("serverUrl") { put("type", "string"); put("description", "Base URL of the UncivServer, e.g. http://localhost:8080") }
+                    putJsonObject("gameId") { put("type", "string") }
+                    putJsonObject("playerId") { put("type", "string"); put("description", "This agent's multiplayer user id") }
+                    putJsonObject("civName") { put("type", "string"); put("description", "civID of the civilization this agent controls") }
+                    putJsonObject("password") { put("type", "string") }
+                    putJsonObject("visibilityMode") { put("type", "string"); put("description", "FULL or RESTRICTED") }
+                },
+                required = listOf("serverUrl", "gameId", "playerId", "civName", "password"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val serverUrl = args["serverUrl"]?.jsonPrimitive?.content ?: return@addTool errorResult("serverUrl required")
+            val gameId = args["gameId"]?.jsonPrimitive?.content ?: return@addTool errorResult("gameId required")
+            val playerId = args["playerId"]?.jsonPrimitive?.content ?: return@addTool errorResult("playerId required")
+            val civName = args["civName"]?.jsonPrimitive?.content ?: return@addTool errorResult("civName required")
+            val password = args["password"]?.jsonPrimitive?.content ?: return@addTool errorResult("password required")
+            val visibility = when (args["visibilityMode"]?.jsonPrimitive?.content?.uppercase()) {
+                "RESTRICTED" -> VisibilityMode.RESTRICTED
+                else -> VisibilityMode.FULL
+            }
+
+            val settings = UncivGame.Current.settings.multiplayer
+            settings.setServer(serverUrl)
+            settings.setUserId(playerId)
+            settings.setCurrentServerPassword(password)
+            // MultiplayerServer() re-derives serverUrl from these settings on every call
+            // (see MultiplayerServer.fileStorage()), but checkAuthStatus/authenticate below call
+            // UncivServerFileStorage directly, which does NOT go through that - it needs its own
+            // serverUrl set, or SimpleHttp builds "http:///auth" (empty host) and the JVM throws
+            // "Failed to select a proxy" trying to resolve a proxy for a null host.
+            UncivServerFileStorage.serverUrl = serverUrl
+
+            val authStatus = UncivServerFileStorage.checkAuthStatus(playerId, password)
+            when (authStatus) {
+                AuthStatus.UNREGISTERED -> UncivServerFileStorage.authenticate(playerId, password)
+                AuthStatus.UNAUTHORIZED -> return@addTool errorResult("Authentication failed: invalid credentials")
+                AuthStatus.UNKNOWN -> return@addTool errorResult("Could not reach server at $serverUrl")
+                AuthStatus.VERIFIED -> {}
+            }
+
+            // Verify civName/playerId actually refer to the same, human-controlled slot: nextTurn()
+            // auto-plays AI civs (we'd never get a turn) and AI civs never populate notifications
+            // (get_events would silently stay empty), so this must hold for the agent to work at all.
+            val gameInfo = MultiplayerServer().tryDownloadGame(gameId)
+            val civ = gameInfo.getCivilizationOrNull(civName)
+                ?: return@addTool errorResult("No civilization named $civName in game $gameId")
+            if (civ.playerType != PlayerType.Human) {
+                return@addTool errorResult("$civName is an AI-controlled civ; the agent must occupy a Human slot")
+            }
+            if (civ.playerId != playerId) {
+                return@addTool errorResult("$civName's slot belongs to playerId '${civ.playerId}', not '$playerId'")
+            }
+
+            connection = GameConnection(gameId, civName, visibility)
+            ChatWebSocket.requestMessageSend(Message.Join(listOf(gameId)))
+
+            textResult("Connected to game $gameId as $civName")
+        }
+    }
+
+    private fun Server.registerTurnStatus() {
+        addTool(
+            name = "get_turn_status",
+            description = "Check whether it is currently the agent's turn. Call this before acting; if isMyTurn is false, wait and poll again.",
+        ) {
+            val conn = requireConnection()
+            val preview = MultiplayerServer().tryDownloadGamePreview(conn.gameId)
+            jsonResult(buildJsonObject {
+                put("turn", preview.turns)
+                put("currentPlayer", preview.currentPlayer)
+                put("isMyTurn", preview.isUsersTurn())
+            })
+        }
+    }
+
+    private fun Server.registerEndTurn() {
+        addTool(
+            name = "end_turn",
+            description = "End the agent's turn, advancing the game (auto-plays any AI civs) until the next human's turn.",
+        ) {
+            val conn = requireConnection()
+            val multiplayerServer = MultiplayerServer()
+            val gameInfo = multiplayerServer.tryDownloadGame(conn.gameId)
+            if (gameInfo.currentPlayer != conn.civId) {
+                return@addTool errorResult("It is not ${conn.civId}'s turn (current: ${gameInfo.currentPlayer})")
+            }
+            gameInfo.nextTurn()
+            multiplayerServer.uploadGame(gameInfo, withPreview = true)
+            textResult("Turn ended. Now turn ${gameInfo.turns}, current player: ${gameInfo.currentPlayer}")
+        }
+    }
+
+    private fun Server.registerReadTools() {
+        addTool(name = "get_my_civ", description = "Read the agent's civilization: gold, income, research, policies, counts.") {
+            withGame { gameInfo, civ, view -> jsonResult(view.civSummary(civ)) }
+        }
+        addTool(name = "get_cities", description = "List the agent's cities with population, health, and production queues.") {
+            withGame { gameInfo, civ, view -> jsonResult(buildJsonObject { put("cities", view.cities(civ)) }) }
+        }
+        addTool(name = "get_units", description = "List the agent's units with position, health, movement, and available actions.") {
+            withGame { gameInfo, civ, view -> jsonResult(buildJsonObject { put("units", view.units(civ)) }) }
+        }
+        addTool(
+            name = "get_map",
+            description = "Read the map, filtered by the connection's visibility mode. Defaults to the whole map; " +
+                "pass centerX/centerY/radius to limit output for large maps.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("centerX") { put("type", "integer") }
+                    putJsonObject("centerY") { put("type", "integer") }
+                    putJsonObject("radius") { put("type", "integer"); put("description", "Hex distance from center, used only if center is given") }
+                },
+            ),
+        ) { request ->
+            val args = request.arguments
+            val centerX = args?.get("centerX")?.jsonPrimitive?.int
+            val centerY = args?.get("centerY")?.jsonPrimitive?.int
+            val radius = args?.get("radius")?.jsonPrimitive?.int ?: 5
+            withGame { gameInfo, civ, view ->
+                val tiles = if (centerX != null && centerY != null) view.map(civ, gameInfo, centerX, centerY, radius) else view.map(civ, gameInfo)
+                jsonResult(buildJsonObject { put("tiles", tiles) })
+            }
+        }
+        addTool(
+            name = "get_events",
+            description = "Read notifications: the current turn's events plus a recent per-turn archive - what happened while it wasn't the agent's turn.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("turnsOfHistory") { put("type", "integer"); put("description", "How many past turns of the notification log to include, default 3") }
+                },
+            ),
+        ) { request ->
+            val turns = request.arguments?.get("turnsOfHistory")?.jsonPrimitive?.int ?: 3
+            withGame { gameInfo, civ, view -> jsonResult(view.events(civ, turns)) }
+        }
+    }
+
+    private fun Server.registerActionTools() {
+        addTool(
+            name = "set_research",
+            description = "Set the technology research queue (replaces the current queue).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("techNames") { put("type", "array") }
+                },
+                required = listOf("techNames"),
+            ),
+        ) { request ->
+            val techNames = request.arguments?.get("techNames")?.let { arg ->
+                (arg as? kotlinx.serialization.json.JsonArray)?.map { it.jsonPrimitive.content }
+            } ?: return@addTool errorResult("techNames required")
+            mutateGame { gameInfo, civ ->
+                val unknown = techNames.filterNot { gameInfo.ruleset.technologies.containsKey(it) }
+                if (unknown.isNotEmpty()) return@mutateGame errorResult("Unknown tech(s): $unknown")
+                civ.tech.techsToResearch = ArrayList(techNames)
+                null
+            }
+        }
+
+        addTool(
+            name = "set_city_production",
+            description = "Queue a building/unit/wonder for construction in a city.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("cityName") { put("type", "string") }
+                    putJsonObject("construction") { put("type", "string") }
+                },
+                required = listOf("cityName", "construction"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val cityName = args["cityName"]?.jsonPrimitive?.content ?: return@addTool errorResult("cityName required")
+            val construction = args["construction"]?.jsonPrimitive?.content ?: return@addTool errorResult("construction required")
+            mutateGame { gameInfo, civ ->
+                val city = civ.cities.firstOrNull { it.name == cityName }
+                    ?: return@mutateGame errorResult("No city named $cityName")
+                val ruleset = gameInfo.ruleset
+                val isKnown = ruleset.buildings.containsKey(construction) ||
+                    ruleset.units.containsKey(construction) ||
+                    com.unciv.models.ruleset.PerpetualConstruction.isNamePerpetual(construction)
+                if (!isKnown) return@mutateGame errorResult("$construction is not a known building, unit, or wonder")
+                city.cityConstructions.addToQueue(construction)
+                null
+            }
+        }
+
+        addTool(
+            name = "move_unit",
+            description = "Move a unit towards a tile (multi-turn pathing if it can't be reached this turn).",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("unitId") { put("type", "integer") }
+                    putJsonObject("x") { put("type", "integer") }
+                    putJsonObject("y") { put("type", "integer") }
+                },
+                required = listOf("unitId", "x", "y"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val unitId = args["unitId"]?.jsonPrimitive?.int ?: return@addTool errorResult("unitId required")
+            val x = args["x"]?.jsonPrimitive?.int ?: return@addTool errorResult("x required")
+            val y = args["y"]?.jsonPrimitive?.int ?: return@addTool errorResult("y required")
+            mutateGame { gameInfo, civ ->
+                val unit = civ.units.getCivUnits().firstOrNull { it.id == unitId }
+                    ?: return@mutateGame errorResult("No unit with id $unitId")
+                val destination = gameInfo.tileMap.getOrNull(x, y)
+                    ?: return@mutateGame errorResult("No tile at ($x, $y)")
+                try {
+                    unit.movement.headTowards(destination)
+                } catch (e: UnitMovement.UnreachableDestinationException) {
+                    return@mutateGame errorResult("Unit $unitId can't reach ($x, $y) this turn")
+                }
+                null
+            }
+        }
+
+        addTool(
+            name = "unit_action",
+            description = "Invoke a named unit action (e.g. FoundCity, Fortify, Sleep, Explore, Upgrade, ConstructImprovement) on a unit.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("unitId") { put("type", "integer") }
+                    putJsonObject("action") { put("type", "string") }
+                },
+                required = listOf("unitId", "action"),
+            ),
+        ) { request ->
+            val args = request.arguments ?: return@addTool errorResult("Missing arguments")
+            val unitId = args["unitId"]?.jsonPrimitive?.int ?: return@addTool errorResult("unitId required")
+            val actionName = args["action"]?.jsonPrimitive?.content ?: return@addTool errorResult("action required")
+            val actionType = UnitActionType.entries.firstOrNull { it.name == actionName }
+                ?: return@addTool errorResult("Unknown action type $actionName")
+            mutateGame { gameInfo, civ ->
+                val unit: MapUnit = civ.units.getCivUnits().firstOrNull { it.id == unitId }
+                    ?: return@mutateGame errorResult("No unit with id $unitId")
+                // Fortify/Sleep/Explore/Automate aren't in UnitActions' mapped-provider table, so
+                // invokeUnitAction would fall back to enumerating every provider - including
+                // addEscortAction/addSwapAction, which crash headless (see GameStateView.units()).
+                // Mutate the same unit state their GUI actions do, directly, instead.
+                when (actionType) {
+                    UnitActionType.Fortify -> {
+                        if (!unit.canFortify() || !unit.hasMovement()) return@mutateGame errorResult("Unit $unitId can't fortify right now")
+                        unit.fortify()
+                    }
+                    UnitActionType.Sleep -> {
+                        if (unit.isFortified() || unit.canFortify() || unit.isGuarding() || !unit.hasMovement())
+                            return@mutateGame errorResult("Unit $unitId can't sleep right now")
+                        unit.action = UnitActionType.Sleep.value
+                    }
+                    UnitActionType.Explore -> {
+                        if (unit.baseUnit.movesLikeAirUnits) return@mutateGame errorResult("Air units can't explore")
+                        unit.action = UnitActionType.Explore.value
+                        if (unit.hasMovement()) UnitAutomation.automatedExplore(unit)
+                    }
+                    UnitActionType.Automate -> {
+                        if (!unit.hasMovement()) return@mutateGame errorResult("Unit $unitId can't automate right now")
+                        unit.automated = true
+                        UnitAutomation.automateUnitMoves(unit)
+                    }
+                    else -> {
+                        // Mapped types (FoundCity, ConstructImprovement, ...) are headless-safe.
+                        // Any other unmapped type would still hit the enumerator crash - catch it
+                        // rather than let the whole call NPE.
+                        val invoked = try {
+                            UnitActions.invokeUnitAction(unit, actionType)
+                        } catch (e: Exception) {
+                            return@mutateGame errorResult("Action $actionName isn't supported for unit $unitId in a headless session")
+                        }
+                        if (!invoked) return@mutateGame errorResult("Action $actionName is not available for unit $unitId right now")
+                    }
+                }
+                null
+            }
+        }
+    }
+
+    private fun Server.registerChat() {
+        addTool(
+            name = "send_chat",
+            description = "Send a chat message to the human player.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject { putJsonObject("message") { put("type", "string") } },
+                required = listOf("message"),
+            ),
+        ) { request ->
+            val conn = requireConnection()
+            val message = request.arguments?.get("message")?.jsonPrimitive?.content
+                ?: return@addTool errorResult("message required")
+            ChatWebSocket.requestMessageSend(Message.Chat(conn.civId, message, conn.gameId))
+            textResult("Sent")
+        }
+    }
+
+    /** Read-only helper: download, look up the agent's civ, hand it to [block]. */
+    private suspend fun withGame(block: (GameInfo, com.unciv.logic.civilization.Civilization, GameStateView) -> CallToolResult): CallToolResult {
+        val conn = requireConnection()
+        val gameInfo = MultiplayerServer().tryDownloadGame(conn.gameId)
+        val civ = gameInfo.getCivilizationOrNull(conn.civId)
+            ?: return errorResult("Civilization ${conn.civId} not found in game")
+        return block(gameInfo, civ, GameStateView(conn.visibility))
+    }
+
+    /**
+     * Mutate-and-upload helper for act tools: download fresh, apply [block], upload without
+     * calling nextTurn() (only end_turn advances the game). [block] returns an error result to
+     * short-circuit, or null on success.
+     */
+    private suspend fun mutateGame(block: (GameInfo, com.unciv.logic.civilization.Civilization) -> CallToolResult?): CallToolResult {
+        val conn = requireConnection()
+        val multiplayerServer = MultiplayerServer()
+        val gameInfo = multiplayerServer.tryDownloadGame(conn.gameId)
+        val civ = gameInfo.getCivilizationOrNull(conn.civId)
+            ?: return errorResult("Civilization ${conn.civId} not found in game")
+        if (gameInfo.currentPlayer != conn.civId) {
+            return errorResult("It is not ${conn.civId}'s turn (current: ${gameInfo.currentPlayer})")
+        }
+        block(gameInfo, civ)?.let { return it }
+        multiplayerServer.uploadGame(gameInfo, withPreview = true)
+        return textResult("Applied")
+    }
+}

--- a/docs/Developers/MCP-agent.md
+++ b/docs/Developers/MCP-agent.md
@@ -1,0 +1,127 @@
+# The LLM counterparty MCP agent
+
+`desktop/src/com/unciv/app/desktop/mcp/` hosts a headless Unciv that speaks the
+[Model Context Protocol](https://modelcontextprotocol.io) over stdio. It occupies a **human**
+slot in a multiplayer game, so an LLM client can play as a counterparty to an actual human
+player - trading, fighting, chatting - rather than as a scripted AI civ.
+
+`McpAgentLauncher.kt` boots the engine the same way `ConsoleLauncher` does (load rulesets,
+tilesets, skins), then hands a `StdioServerTransport` to `UncivMcpServer`. **Nothing may reach
+stdout except MCP JSON-RPC traffic** - all Unciv logging is routed to stderr via `Log`. If you
+add a `println` anywhere on this path, you will corrupt the protocol stream; use `Log.debug`
+instead.
+
+## Setup
+
+1. Run an `UncivServer` and start (or open) a multiplayer game with a second **human** slot for
+   the agent to occupy. Note that slot's `playerId` and the server password.
+2. Wire up a client - see below. All three configs in this repo call
+   `desktop/mcp-agent.sh`, which works around one local quirk: Gradle can't configure the
+   `:android` module on JDK 24+, so the script prefers a JDK 17 via `/usr/libexec/java_home` if
+   `JAVA_HOME` isn't already set. On Linux, or if you already export `JAVA_HOME`, it's a no-op.
+3. Call `connect_game` with the server URL, game ID, the agent's `playerId`/password, and
+   optionally `civName` (auto-detected from `playerId` if omitted). Everything else needs a live
+   connection first.
+
+Verified by `./gradlew :tests:test` (`tests/src/com/unciv/logic/unit/UnitActionsHeadlessTest.kt`
+covers headless action enumeration and combat targeting) and by running the agent directly:
+`./desktop/mcp-agent.sh < /dev/null` should produce no stdout output.
+
+### Claude Code
+
+Already configured via the repo's `.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "unciv": { "command": "./desktop/mcp-agent.sh" }
+  }
+}
+```
+
+### opencode
+
+Already configured via the repo's `opencode.json`.
+
+### Codex
+
+Codex only reads MCP servers from the global `~/.codex/config.toml`, so there's nothing to
+commit - add this yourself, with an absolute path (Codex's working directory isn't the repo):
+```toml
+[mcp_servers.unciv]
+command = "/absolute/path/to/Unciv/desktop/mcp-agent.sh"
+args = []
+env = {}
+```
+
+## Tool reference
+
+**Connection & turn**
+- `connect_game` - connect as the agent's civ. Call first.
+- `get_turn_status` - poll whether it's currently the agent's turn.
+- `end_turn` - end the turn, auto-playing any AI civs until the next human's turn.
+
+**Reading state**
+- `get_my_civ` - gold, income, research, policies, counts, known civs.
+- `get_cities` - population, health, production queue per city.
+- `get_units` - position, health, movement, available actions, promotions, attackable tiles.
+- `get_map` - the map, filtered by visibility mode; pass `centerX`/`centerY`/`radius` on large maps.
+- `get_events` - notifications and chat since last call, or a turn-start gist via `sinceMyLastTurn`.
+- `get_chat` - the full chat log.
+- `get_civ_intel` - comparative rankings and known-civ diplomatic state.
+
+**Cities & economy**
+- `set_research` - replace the tech queue.
+- `set_city_production` / `modify_production_queue` - queue and reorder construction.
+- `purchase_construction` - buy with Gold or Faith.
+- `set_city_focus` - citizen-management focus, reassigns tiles immediately.
+- `adopt_policy` - adopt a social policy.
+
+**Units & combat**
+- `move_unit` - multi-turn pathing towards a tile.
+- `attack` - attack an enemy unit/city, moving into range first.
+- `bombard` - city bombardment of the strongest reachable target.
+- `unit_action` - invoke any other named `UnitActionType` (Fortify, Explore, Upgrade, ...).
+- `promote_unit` - apply a promotion (not reachable via `unit_action`, see below).
+
+**Diplomacy & trade**
+- `declare_war` / `make_peace`
+- `get_pending_decisions` - trade requests and popup alerts awaiting a response.
+- `get_trade_options` - what can be offered to / requested from a civ.
+- `propose_trade` / `respond_to_trade`
+- `resolve_alert` - dismiss a popup alert, or answer a demand / declaration of friendship.
+
+**Chat**
+- `send_chat` - message the human player.
+
+## How it behaves
+
+- **One download, one upload per turn.** `UncivMcpServer.holdGame` downloads `GameInfo` once and
+  holds it in memory for the rest of the agent's turn; every read and mutation after that uses
+  the held copy. `end_turn` is the only tool that uploads. If the process dies mid-turn, the
+  server still has the pre-turn state - the failure mode is "the agent didn't move," never a
+  corrupted save.
+- **Two visibility modes** (`GameStateView.VisibilityMode`, set via `connect_game`'s
+  `visibilityMode`): `FULL` returns the whole game state; `RESTRICTED` filters tiles and units
+  through fog of war exactly as the human client would.
+- **Errors are recoverable without a round trip.** Unknown-name errors (city, unit, civ, ...)
+  list the valid names/ids in the same response, so the agent doesn't need a follow-up read.
+
+## Not implemented
+
+- **Conquered-city disposition.** `resolve_alert` dismisses `CityConquered`/`CityTraded`/
+  `DiplomaticMarriage` alerts without choosing annex/puppet/raze/liberate
+  (compare `AlertPopup.addCityConquered`). This is the biggest gap: an agent that takes a city
+  gets whatever state the dismiss leaves it in.
+- Espionage and spies.
+- City-state gifts, quests, and bullying.
+- Manual work-tile assignment and tile purchase - only `set_city_focus`'s automatic reassignment.
+- Religion: founding, belief selection, and the free-tech/free-policy choice popups.
+- Nukes and air interception - `attack` covers neither.
+- Victory-condition progress reporting.
+- `EscortFormation`/`StopEscortFormation`/`SwapUnits` - deliberately inert headless, since they
+  depend on which units are selected in the (nonexistent) world screen
+  (`UnitActions.addEscortAction`/`addSwapAction`).
+- `Promote` via `unit_action` is rejected on purpose - use `promote_unit`, which needs a
+  promotion name `unit_action` has no way to pass.
+- `get_map` with no `centerX`/`centerY` returns the entire map - several thousand tiles on a
+  standard-size game. Prefer the radius-limited form unless you actually need it all.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ discord = "v2.0.1"
 
 jna = "5.17.0"
 ktor = "3.2.3"
+mcp = "0.9.0"
 logback = "1.5.21"
 clikt = "5.0.3"
 
@@ -69,6 +70,8 @@ clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt
 
 jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 jna-platform = { group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna" }
+
+mcp-sdk-server = { group = "io.modelcontextprotocol", name = "kotlin-sdk-server", version.ref = "mcp" }
 
 android-ktx-core = { group = "androidx.core", name = "core-ktx", version.ref = "ktxCore" }
 android-desugar = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar" }

--- a/opencode.json
+++ b/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "unciv": {
       "type": "local",
-      "command": ["./gradlew", "-q", ":desktop:runMcpAgent"],
+      "command": ["./desktop/mcp-agent.sh"],
       "enabled": true
     }
   }

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "unciv": {
+      "type": "local",
+      "command": ["./gradlew", "-q", ":desktop:runMcpAgent"],
+      "enabled": true
+    }
+  }
+}

--- a/tests/src/com/unciv/logic/unit/UnitActionsHeadlessTest.kt
+++ b/tests/src/com/unciv/logic/unit/UnitActionsHeadlessTest.kt
@@ -1,0 +1,63 @@
+package com.unciv.logic.unit
+
+import com.unciv.GUI
+import com.unciv.logic.battle.TargetHelper
+import com.unciv.logic.civilization.Civilization
+import com.unciv.models.UnitActionType
+import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Covers the two things the headless MCP agent relies on: enumerating unit actions with no
+ *  world screen loaded, and picking a combat target the same way the `attack` tool does. */
+@RunWith(GdxTestRunner::class)
+class UnitActionsHeadlessTest {
+    private lateinit var attackerCiv: Civilization
+    private lateinit var defenderCiv: Civilization
+
+    private val testGame = TestGame()
+
+    @Before
+    fun setUp() {
+        testGame.makeHexagonalMap(6)
+        attackerCiv = testGame.addCiv(isPlayer = true)
+        defenderCiv = testGame.addCiv()
+        attackerCiv.diplomacyFunctions.makeCivilizationsMeet(defenderCiv)
+        attackerCiv.diplomacy[defenderCiv.civName]?.declareWar()
+    }
+
+    @Test
+    fun `enumerates unit actions headless and includes Promote and DisbandUnit`() {
+        assertFalse("Test should run with no world screen loaded", GUI.isWorldLoaded())
+
+        val promotion = testGame.createUnitPromotion()
+        val unit = testGame.addUnit("Warrior", attackerCiv, testGame.getTile(0, 0))
+        promotion.unitTypes = listOf(unit.type.name)
+        unit.promotions.XP = 999 // enough XP to be promotable regardless of ruleset cost
+
+        val actionTypes = UnitActions.getUnitActions(unit).map { it.type }.toList()
+
+        assertTrue(UnitActionType.Promote in actionTypes)
+        assertTrue(UnitActionType.DisbandUnit in actionTypes)
+    }
+
+    @Test
+    fun `attack tool target matching finds an adjacent enemy`() {
+        val attackerUnit = testGame.addUnit("Warrior", attackerCiv, testGame.getTile(0, 0))
+        attackerUnit.currentMovement = attackerUnit.getMaxMovement().toFloat()
+        val defenderTile = testGame.getTile(1, 0)
+        testGame.addUnit("Warrior", defenderCiv, defenderTile)
+
+        val targets = TargetHelper.getAttackableEnemies(attackerUnit, attackerUnit.movement.getDistanceToTiles())
+        // Same lookup the `attack` MCP tool does with the caller-supplied (x, y).
+        val target = targets.firstOrNull { it.tileToAttack.position.x == defenderTile.position.x && it.tileToAttack.position.y == defenderTile.position.y }
+
+        assertEquals(defenderTile, target?.tileToAttack)
+    }
+}


### PR DESCRIPTION
Adds a headless Unciv process that occupies a **human** slot in a multiplayer game and speaks the [Model Context Protocol](https://modelcontextprotocol.io) over stdio, so an LLM can play as a real counterparty to a human player — not a scripted AI civ — via any MCP client (Claude Code, Codex, opencode).

**What's included**
- `McpAgentLauncher` + `UncivMcpServer`: boots the engine headlessly and
exposes 29 tools
  covering connection/turns, reading game state (civ, cities, units, map,
events, intel),
  city/economy management, unit movement and combat, diplomacy/trade, alert
resolution, and
  chat — filtered through the same fog-of-war a human client would see
(`RESTRICTED` mode),
  or unfiltered (`FULL`) for testing.
- Turn-scoped `GameInfo` caching: one download and one upload per turn, so
a crash mid-turn
  loses the agent's moves but never corrupts the save.
- Human-parity guards on world-screen-only unit actions (escort/swap) so
headless calls fail
  safely instead of crashing.
- `desktop/mcp-agent.sh` launcher shared by all client configs, plus
`.mcp.json` (Claude
  Code) and `opencode.json` wiring.
- `docs/Developers/MCP-agent.md`: setup, full tool reference, and an
explicit list of
  known gaps (biggest one: `resolve_alert` can't choose
annex/puppet/raze/liberate on a
  conquered city yet).
- A headless test (`UnitActionsHeadlessTest`) covering action enumeration
and combat
  targeting.

**Not in scope for this PR**: closing the documented gaps (espionage,
religion, city-state
diplomacy, nukes, etc.) — config/tooling and docs only beyond the core
agent.