### PR TITLE
AI: workers take into account future adjacencies for improvements

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -502,9 +502,11 @@ class WorkerAutomation(
         @LocalState val stats = tile.stats.getStatDiffForImprovement(improvement, civInfo, tile.getCity(), currentTileStats)
 
         for (unique in improvement.getMatchingUniques(UniqueType.ImprovementStatsForAdjacencies)) {
-                if (unique.params[1] == improvement.name) //for Moai-like improvements, add the yields of future self-adjacencies
-                    stats.add(unique.stats * tile.neighbors.count { (it.tileImprovement != improvement && it.improvementFunctions.canBuildImprovement(improvement, gameContext = civInfo.state)) })
+            val adjacencyProvider = unique.params[1] //for Moai-like improvements, add the yields of future adjacencies
+            if (ruleSet.tileImprovements[adjacencyProvider] != null) {
+                stats.add(unique.stats * tile.neighbors.count { (it.tileImprovement?.name != adjacencyProvider && it.improvementFunctions.canBuildImprovement(ruleSet.tileImprovements[adjacencyProvider]!!, gameContext = civInfo.state)) })
             }
+        }
 
         var isResourceImprovedByNewImprovement = tile.tileResource.let { civInfo.canSeeResource(it) && it.isImprovedBy(improvement.name) }
 

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -501,12 +501,10 @@ class WorkerAutomation(
 
         @LocalState val stats = tile.stats.getStatDiffForImprovement(improvement, civInfo, tile.getCity(), currentTileStats)
 
-        for (unique in improvement.getMatchingUniques(UniqueType.ImprovementStatsForAdjacencies)) {
-            val adjacencyProvider = unique.params[1] //for Moai-like improvements, add the yields of future adjacencies
-            if (ruleSet.tileImprovements[adjacencyProvider] != null) {
-                stats.add(unique.stats * tile.neighbors.count { (it.tileImprovement?.name != adjacencyProvider && it.improvementFunctions.canBuildImprovement(ruleSet.tileImprovements[adjacencyProvider]!!, gameContext = civInfo.state)) })
+         for (unique in improvement.getMatchingUniques(UniqueType.ImprovementStatsForAdjacencies)) {
+                if (unique.params[1] == improvement.name) //for Moai-like improvements, add the yields of future self-adjacencies
+                    stats.add(unique.stats * tile.neighbors.count { (it.tileImprovement != improvement && it.improvementFunctions.canBuildImprovement(improvement, gameContext = civInfo.state)) })
             }
-        }
 
         var isResourceImprovedByNewImprovement = tile.tileResource.let { civInfo.canSeeResource(it) && it.isImprovedBy(improvement.name) }
 

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -501,6 +501,11 @@ class WorkerAutomation(
 
         @LocalState val stats = tile.stats.getStatDiffForImprovement(improvement, civInfo, tile.getCity(), currentTileStats)
 
+        for (unique in improvement.getMatchingUniques(UniqueType.ImprovementStatsForAdjacencies)) {
+                if (unique.params[1] == improvement.name) //for Moai-like improvements, add the yields of future self-adjacencies
+                    stats.add(unique.stats * tile.neighbors.count { (it.tileImprovement != improvement && it.improvementFunctions.canBuildImprovement(improvement, gameContext = civInfo.state)) })
+            }
+
         var isResourceImprovedByNewImprovement = tile.tileResource.let { civInfo.canSeeResource(it) && it.isImprovedBy(improvement.name) }
 
         if (improvement.name.startsWith(Constants.remove)) {


### PR DESCRIPTION
It's counting strategic/luxury resource tiles here which won't be improved by base game Moai, not sure if it's worth taking that into account.

Mostly to let the AI perform better in mods: https://discord.com/channels/586194543280390151/1023975744839352330/1534986246747590766
Unsure if this is good for base game Polynesia, but democracy is thing: https://discord.com/channels/586194543280390151/618491418859798539/1535225043297247242 (it might be desirable to adjust the value of (non-food/production) stats to curb excessive Moai building)