### PR TITLE
Non vanilla ranking types

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -443,6 +443,7 @@ Show Rankings =
 Show Demographics = 
 Show Charts = 
 Restrict to own civilization = 
+Show additional stat types = 
 Victory Conditions = 
 Scientific = 
 Domination = 
@@ -1338,6 +1339,8 @@ Happiness =
 Culture = 
 Science = 
 Faith = 
+
+Tiles Explored = 
 
 Growth = 
 Territory = 

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -863,6 +863,9 @@ class Civilization : IsPartOfGameInfoSerialization {
                 RankingType.Happiness -> getHappiness()
                 RankingType.Technologies -> tech.researchedTechnologies.size
                 RankingType.Culture -> policies.adoptedPolicies.count { !Policy.isBranchCompleteByName(it) }
+            
+                // Non vanilla ranking types
+                RankingType.TilesExplored -> gameInfo.tileMap.values.count { it.isExplored(this) }
         }
     }
 

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -50,6 +50,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var showRankings = true
     var showCharts = true
     var hideOtherCivilizationStats = false
+    var showAdditionalRankingTypes = false
 
     // Multiplayer parameters
     var isOnlineMultiplayer = false
@@ -99,6 +100,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
         parameters.showRankings = showRankings
         parameters.showCharts = showCharts
         parameters.hideOtherCivilizationStats = hideOtherCivilizationStats
+        parameters.showAdditionalRankingTypes = showAdditionalRankingTypes
         parameters.isOnlineMultiplayer = isOnlineMultiplayer
         parameters.multiplayerServerUrl = multiplayerServerUrl
         parameters.anyoneCanSpectate = anyoneCanSpectate

--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -145,6 +145,7 @@ class GameOptionsTable(
                     addShowChartsCheckbox()
                     addShowDemographicsCheckbox()
                     addCensorStatsCheckbox()
+                    addShowAdditionalRankingTypesCheckbox()
                 }
                 it.add(statsTable).left()
             }
@@ -243,6 +244,10 @@ class GameOptionsTable(
     private fun Table.addCensorStatsCheckbox() =
         addCheckbox("Restrict to own civilization", gameParameters.hideOtherCivilizationStats)
         { gameParameters.hideOtherCivilizationStats = it }
+    
+    private fun Table.addShowAdditionalRankingTypesCheckbox() =
+        addCheckbox("Show additional stat types", gameParameters.showAdditionalRankingTypes)
+        { gameParameters.showAdditionalRankingTypes = it }
 
     private fun Table.addNationsSelectTextButton() {
         val button = "Select nations".toTextButton()

--- a/core/src/com/unciv/ui/screens/victoryscreen/RankingType.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/RankingType.kt
@@ -2,13 +2,15 @@ package com.unciv.ui.screens.victoryscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Image
+import com.unciv.models.metadata.GameParameters
 import com.unciv.ui.images.ImageGetter
 import yairm210.purity.annotations.Pure
 
 enum class RankingType(
     label: String?,
     val getImage: () -> Image?,
-    val idForSerialization: Char
+    val idForSerialization: Char,
+    val isVanilla: Boolean = true
 ) {
     // production, gold, happiness, and culture already have icons added when the line is `tr()`anslated
     Score({ ImageGetter.getImage("OtherIcons/Score").apply { color = Color.FIREBRICK } }, 'S'),
@@ -21,6 +23,8 @@ enum class RankingType(
     Happiness('H'),
     Technologies({ ImageGetter.getStatIcon("Science") }, 'W'),
     Culture('A'),
+    // Non vanilla ranking types
+    TilesExplored("Tiles Explored", { ImageGetter.getImage("UnitPromotionIcons/Scouting") }, 'E', false),
     ;
     val label = label ?: name
     constructor(getImage: () -> Image?, idForSerialization: Char) : this(null, getImage, idForSerialization)
@@ -29,5 +33,6 @@ enum class RankingType(
     companion object {
         @Pure fun fromIdForSerialization(char: Char): RankingType? =
                 entries.firstOrNull { it.idForSerialization == char }
+        fun filteredEntries(gameParameters: GameParameters) = entries.filter { it.isVanilla || gameParameters.showAdditionalRankingTypes }
     }
 }

--- a/core/src/com/unciv/ui/screens/victoryscreen/RankingType.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/RankingType.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.unciv.models.metadata.GameParameters
 import com.unciv.ui.images.ImageGetter
 import yairm210.purity.annotations.Pure
+import yairm210.purity.annotations.Readonly
 
 enum class RankingType(
     label: String?,
@@ -33,6 +34,7 @@ enum class RankingType(
     companion object {
         @Pure fun fromIdForSerialization(char: Char): RankingType? =
                 entries.firstOrNull { it.idForSerialization == char }
-        fun filteredEntries(gameParameters: GameParameters) = entries.filter { it.isVanilla || gameParameters.showAdditionalRankingTypes }
+        @Readonly fun filteredEntries(gameParameters: GameParameters) =
+                entries.filter { it.isVanilla || gameParameters.showAdditionalRankingTypes }
     }
 }

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -26,8 +26,7 @@ class VictoryScreenCharts(
     private val viewingCiv = worldScreen.viewingCiv
 
     private val rankingTypeSelect = TranslatedSelectBox(
-        RankingType.filteredEntries(gameInfo.gameParameters)
-            .map { it.label },
+        RankingType.filteredEntries(gameInfo.gameParameters).map { it.label },
         rankingType.name
     )
     private val civButtonsTable = Table()

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -25,7 +25,11 @@ class VictoryScreenCharts(
     private var selectedCiv = worldScreen.selectedCiv
     private val viewingCiv = worldScreen.viewingCiv
 
-    private val rankingTypeSelect = TranslatedSelectBox(RankingType.entries.map { it.label }, rankingType.name)
+    private val rankingTypeSelect = TranslatedSelectBox(
+        RankingType.filteredEntries(gameInfo.gameParameters)
+            .map { it.label },
+        rankingType.name
+    )
     private val civButtonsTable = Table()
     private val civButtonsScroll = AutoScrollPane(civButtonsTable)
     private val controlsColumn = Table()

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCivRankings.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCivRankings.kt
@@ -25,7 +25,7 @@ class VictoryScreenCivRankings(
             .filter { it.isMajorCiv() }
             .filter { targetCiv -> VictoryScreen.canViewCivStats(worldScreen.gameInfo, worldScreen.viewingCiv, targetCiv) }
 
-        for (category in RankingType.entries) {
+        for (category in RankingType.filteredEntries(worldScreen.gameInfo.gameParameters)) {
             val textAndIcon = Table()
             val columnImage = category.getImage()
             if (columnImage != null)

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
@@ -31,7 +31,7 @@ class VictoryScreenDemographics(
             row()
             add(rankLabel.name.toLabel())
 
-            for (category in RankingType.entries) {
+            for (category in RankingType.filteredEntries(playerCiv.gameInfo.gameParameters)) {
                 // Use turn-start snapshots so mid-turn army/economy changes cannot be used to
                 // probe Best/Worst values of other civilizations (see linked issue).
                 val aliveMajorCivsSorted = majorCivs.filter { it.isAlive() || it == playerCiv }
@@ -73,6 +73,8 @@ class VictoryScreenDemographics(
         add(demoLabel)
 
         for (category in RankingType.entries) {
+            if (!category.isVanilla && !playerCiv.gameInfo.gameParameters.showAdditionalRankingTypes)
+                continue
             val headers = Table().apply { defaults().pad(5f) }
             val textAndIcon = Table().apply { defaults() }
             val columnImage = category.getImage()

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
@@ -72,9 +72,7 @@ class VictoryScreenDemographics(
         demoLabel.addSeparator().fillX()
         add(demoLabel)
 
-        for (category in RankingType.entries) {
-            if (!category.isVanilla && !playerCiv.gameInfo.gameParameters.showAdditionalRankingTypes)
-                continue
+        for (category in RankingType.filteredEntries(playerCiv.gameInfo.gameParameters)) {
             val headers = Table().apply { defaults().pad(5f) }
             val textAndIcon = Table().apply { defaults() }
             val columnImage = category.getImage()


### PR DESCRIPTION
Implemented after an urge to track the number of tiles I had explored.
Does not overhaul the system like discussed in [issue](https://github.com/yairm210/Unciv/issues/14768).

Shows only when game parameter "Show additional stat types" is enabled.
Unknown ranking types appear to be ignored during deserialization. No backward compatibility issues found during testing.

<img width="1982" height="1085" alt="Screenshot from 2026-08-08 23-49-58" src="https://github.com/user-attachments/assets/6d1e7494-cab1-4c37-be9b-d70fa6304bb6" />

<img width="1982" height="1085" alt="Screenshot from 2026-08-08 23-50-09" src="https://github.com/user-attachments/assets/7ca139de-eb66-445e-8c9d-33c51bce1003" />

<img width="1982" height="1085" alt="Screenshot from 2026-08-08 23-52-24" src="https://github.com/user-attachments/assets/bfbdbfbb-49ee-414d-8d25-b30aef5c4e59" />

<img width="639" height="425" alt="image" src="https://github.com/user-attachments/assets/84386b02-5717-4d05-b224-9af54b12ee00" />
