### PR TITLE
fix: preserve carrier payloads during paradrop and transform

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -459,18 +459,29 @@ class UnitMovement(val unit: MapUnit) {
                 unit.action = null
             unit.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
 
-            // bring along the payloads
-            val payloadUnits = origin.getUnits().filter { it.isTransported && unit.canTransport(it) }.toList()
-            for (payload in payloadUnits) {
-                payload.removeFromTile()
-                payload.putInTile(allowedTile)
-                payload.isTransported = true // restore the flag to not leave the payload in the city
-                payload.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
-            }
+            teleportTransportedUnitsTo(origin, allowedTile)
         }
         // it's possible that there is no close tile, and all the guy's cities are full.
         // Nothing we can do.
         else unit.destroy()
+    }
+
+    /**
+     * Moves the units [unit] is carrying from [origin] to [destination], keeping them transported.
+     *
+     * Deliberately not [MapUnit.canTransport]: that rejects a unit once the carrier is at capacity,
+     * which is true of every payload already aboard a full carrier. These are not new passengers.
+     */
+    fun teleportTransportedUnitsTo(origin: Tile, destination: Tile) {
+        val payloadUnits = origin.getUnits()
+            .filter { it.isTransported && it.owner == unit.owner && unit.isTransportTypeOf(it) }
+            .toList()
+        for (payload in payloadUnits) {
+            payload.removeFromTile()
+            payload.putInTile(destination)
+            payload.isTransported = true // restore the flag to not leave the payload in the city
+            payload.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
+        }
     }
 
     fun moveToTile(destination: Tile, considerZoneOfControl: Boolean = true): Unit = timeThis<Unit>("moveToTile") {
@@ -496,13 +507,7 @@ class UnitMovement(val unit: MapUnit) {
             unit.putInTile(destination)
             unit.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
 
-            val payloadUnits = origin.getUnits().filter { it.isTransported && unit.canTransport(it) }.toList()
-            for (payload in payloadUnits) {
-                payload.removeFromTile()
-                payload.putInTile(destination)
-                payload.isTransported = true
-                payload.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
-            }
+            teleportTransportedUnitsTo(origin, destination)
 
             unit.useMovementPoints(1f)
             unit.attacksThisTurn += 1

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -490,10 +490,20 @@ class UnitMovement(val unit: MapUnit) {
         }
 
         if (unit.isPreparingParadrop()) { // paradropping units move differently
+            val origin = unit.getTile()
             unit.action = null
             unit.removeFromTile()
             unit.putInTile(destination)
             unit.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
+
+            val payloadUnits = origin.getUnits().filter { it.isTransported && unit.canTransport(it) }.toList()
+            for (payload in payloadUnits) {
+                payload.removeFromTile()
+                payload.putInTile(destination)
+                payload.isTransported = true
+                payload.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
+            }
+
             unit.useMovementPoints(1f)
             unit.attacksThisTurn += 1
             // Check if unit maintenance changed

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -452,6 +452,7 @@ object UnitActionsFromUniques {
                             civInfo.units.placeUnitNearTile(unitTile.position, unit.baseUnit, unit.id, copiedFrom = unit)!!
                         
                     } else { // Managed to upgrade
+                        unit.movement.teleportTransportedUnitsTo(unitTile, newUnit.currentTile)
                         // have to handle movement manually because we killed the old unit
                         // a .destroy() unit has 0 movement
                         // and a new one may have less Max Movement

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -440,7 +440,7 @@ object UnitActionsFromUniques {
                 associatedUnique = unique,
                 action = {
                     val oldMovement = unit.currentMovement
-                    unit.destroy()
+                    unit.destroy(destroyTransportedUnit = false)
                     val newUnit =
                         civInfo.units.placeUnitNearTile(unitTile.position, unitToTransformTo, unit.id, copiedFrom = unit)
 

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -18,6 +18,7 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.testing.TestRunnerFactory
 import com.unciv.testing.TestGame
+import com.unciv.ui.components.UnitMovementMemoryType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -317,6 +318,40 @@ class UnitMovementTests(private val pathfindingAlgorithm: PathfindingAlgorithm) 
             unit.currentTile.position.eq(1, 2))
         assertTrue("Payload must be teleported to the same tile",
             unit.currentTile == payload.currentTile)
+    }
+
+    @Test
+    fun paradroppingTransportKeepsPayload() {
+        val origin = testGame.tileMap[0,0]
+        val destination = testGame.tileMap[1,0]
+        origin.baseTerrain = Constants.coast
+        origin.setTransients()
+        destination.baseTerrain = Constants.coast
+        destination.setTransients()
+
+        val transportBaseUnit = testGame.createBaseUnit(
+            "Aircraft Carrier",
+            "Can carry [2] [Aircraft] units",
+            "May Paradrop to [Water] tiles up to [2] tiles away"
+        ).apply {
+            movement = 2
+            strength = 1
+        }
+        val transport = testGame.addUnit(transportBaseUnit.name, civInfo, origin)
+        val payload = testGame.addUnit("Fighter", civInfo, origin)
+        val untransportedAirUnit = testGame.addUnit("Fighter", civInfo, origin)
+        untransportedAirUnit.isTransported = false
+
+        transport.action = UnitActionType.Paradrop.value
+        transport.movement.moveToTile(destination)
+
+        assertEquals(destination, transport.currentTile)
+        assertEquals(destination, payload.currentTile)
+        assertTrue(payload.isTransported)
+        assertEquals(UnitMovementMemoryType.UnitTeleported, transport.mostRecentMoveType)
+        assertEquals(UnitMovementMemoryType.UnitTeleported, payload.mostRecentMoveType)
+        assertEquals(origin, untransportedAirUnit.currentTile)
+        assertFalse(untransportedAirUnit.isTransported)
     }
     
     @Test

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomacyManager
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
+import com.unciv.models.UnitActionType
 import com.unciv.models.metadata.GameSettings.PathfindingAlgorithm
 import com.unciv.models.metadata.GameSettings.PathfindingAlgorithm.ClassicPathfinding
 import com.unciv.models.metadata.GameSettings.PathfindingAlgorithm.AStarPathfinding
@@ -338,18 +339,24 @@ class UnitMovementTests(private val pathfindingAlgorithm: PathfindingAlgorithm) 
             strength = 1
         }
         val transport = testGame.addUnit(transportBaseUnit.name, civInfo, origin)
-        val payload = testGame.addUnit("Fighter", civInfo, origin)
+        // Freed from the carrier first, so the two real payloads can fill it to capacity below -
+        // a full carrier is exactly the case that used to lose its payloads.
         val untransportedAirUnit = testGame.addUnit("Fighter", civInfo, origin)
         untransportedAirUnit.isTransported = false
+        val payload = testGame.addUnit("Fighter", civInfo, origin)
+        val secondPayload = testGame.addUnit("Fighter", civInfo, origin)
 
         transport.action = UnitActionType.Paradrop.value
         transport.movement.moveToTile(destination)
 
         assertEquals(destination, transport.currentTile)
         assertEquals(destination, payload.currentTile)
+        assertEquals(destination, secondPayload.currentTile)
         assertTrue(payload.isTransported)
+        assertTrue(secondPayload.isTransported)
         assertEquals(UnitMovementMemoryType.UnitTeleported, transport.mostRecentMoveType)
         assertEquals(UnitMovementMemoryType.UnitTeleported, payload.mostRecentMoveType)
+        assertEquals(UnitMovementMemoryType.UnitTeleported, secondPayload.mostRecentMoveType)
         assertEquals(origin, untransportedAirUnit.currentTile)
         assertFalse(untransportedAirUnit.isTransported)
     }

--- a/tests/src/com/unciv/uniques/UnitUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/UnitUniquesTests.kt
@@ -1,5 +1,6 @@
 package com.unciv.uniques
 
+import com.unciv.Constants
 import com.unciv.json.json
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.mapunit.UnitTurnManager
@@ -205,5 +206,38 @@ class UnitUniquesTests {
             promotionNode2.parents.any { it.promotion == promotionTestBranchA } &&
             promotionNode2.parents.any { it.promotion == promotionBranch2 }
         )
+    }
+
+    @Test
+    fun `transforming carrier keeps payload`() {
+        val tile = game.getTile(HexCoord.Zero)
+        tile.baseTerrain = Constants.coast
+        tile.setTransients()
+        val civ = game.addCiv()
+        val transformedBaseUnit = game.createBaseUnit(
+            "Aircraft Carrier",
+            "Can carry [2] [Aircraft] units"
+        ).apply {
+            movement = 2
+            strength = 1
+        }
+        val originalBaseUnit = game.createBaseUnit(
+            "Aircraft Carrier",
+            "Can carry [2] [Aircraft] units",
+            "Can transform to [${transformedBaseUnit.name}]"
+        ).apply {
+            movement = 2
+            strength = 1
+        }
+        val original = game.addUnit(originalBaseUnit.name, civ, tile)
+        val payload = game.addUnit("Fighter", civ, tile)
+
+        UnitActionsFromUniques.getTransformActions(original, tile).single().action!!.invoke()
+
+        val transformed = civ.units.getCivUnits().single { it.baseUnit == transformedBaseUnit }
+        Assert.assertTrue(original.isDestroyed)
+        Assert.assertFalse(payload.isDestroyed)
+        Assert.assertTrue(payload.isTransported)
+        Assert.assertEquals(transformed.currentTile, payload.currentTile)
     }
 }

--- a/tests/src/com/unciv/uniques/UnitUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/UnitUniquesTests.kt
@@ -10,6 +10,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.testing.BaseTestRunner
 import com.unciv.testing.TestGame
+import com.unciv.ui.components.UnitMovementMemoryType
 import com.unciv.ui.screens.pickerscreens.PromotionTree
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsFromUniques
@@ -210,12 +211,13 @@ class UnitUniquesTests {
 
     @Test
     fun `transforming carrier keeps payload`() {
+        game.makeHexagonalMap(1)
         val tile = game.getTile(HexCoord.Zero)
         tile.baseTerrain = Constants.coast
         tile.setTransients()
         val civ = game.addCiv()
         val transformedBaseUnit = game.createBaseUnit(
-            "Aircraft Carrier",
+            "Melee",
             "Can carry [2] [Aircraft] units"
         ).apply {
             movement = 2
@@ -231,13 +233,20 @@ class UnitUniquesTests {
         }
         val original = game.addUnit(originalBaseUnit.name, civ, tile)
         val payload = game.addUnit("Fighter", civ, tile)
+        val secondPayload = game.addUnit("Fighter", civ, tile)
 
-        UnitActionsFromUniques.getTransformActions(original, tile).single().action!!.invoke()
+        Assert.assertTrue(UnitActions.invokeUnitAction(original, UnitActionType.Transform))
 
         val transformed = civ.units.getCivUnits().single { it.baseUnit == transformedBaseUnit }
         Assert.assertTrue(original.isDestroyed)
         Assert.assertFalse(payload.isDestroyed)
         Assert.assertTrue(payload.isTransported)
+        Assert.assertNotEquals(tile, transformed.currentTile)
         Assert.assertEquals(transformed.currentTile, payload.currentTile)
+        Assert.assertEquals(UnitMovementMemoryType.UnitTeleported, payload.mostRecentMoveType)
+        Assert.assertFalse(secondPayload.isDestroyed)
+        Assert.assertTrue(secondPayload.isTransported)
+        Assert.assertEquals(transformed.currentTile, secondPayload.currentTile)
+        Assert.assertEquals(UnitMovementMemoryType.UnitTeleported, secondPayload.mostRecentMoveType)
     }
 }


### PR DESCRIPTION
In `UnitMovement.moveToTile`, extend the paradrop production path so transported units accepted by the carrier are captured from the origin and relocated to the paradrop destination before the early return, retaining their transported state and teleport movement memory in line with existing carrier teleport behavior. Modded units that combine air-transport capacity with paradrop or transform actions do not keep their transported aircraft attached.

Paradrop a carrier with a transported fighter to another valid tile; the carrier and fighter both end on the destination, the fighter remains transported, and both record teleport-style movement; Paradrop a carrier from a tile that also contains an untransported air unit; only the carrier's transported payload follows it.

Fixes #15274
