### PR TITLE
Add Strength for nearby enemies within radius unique

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -687,7 +687,7 @@
 	},
 	{
 		"name": "Haka War Dance", // only for Maori Warrior and subsequent upgrades
-		"uniques": ["[-10]% Strength for enemy [Military] units in adjacent [All] tiles"]
+		"uniques": ["[-10]% Strength for enemy [Military] units within [1] tiles in [All] tiles"]
 	},
 	{
 		"name": "Rejuvenation", // only for Units that have been close to Natural Wonder Fountain of Youth

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -412,7 +412,7 @@
 		"obsoleteTech": "Chivalry",
 		"promotions": ["Great Generals II"],
 		"uniques": ["Can move after attacking", "No defensive terrain bonus", "[-33]% Strength <vs cities> <when attacking>",
-			"[-10]% Strength for enemy [Military] units in adjacent [All] tiles"],
+			"[-10]% Strength for enemy [Military] units within [1] tiles in [All] tiles"],
 		"hurryCostModifier": 20,
 		"attackSound": "elephant"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -525,7 +525,7 @@
 	},
 	{
 		"name": "Haka War Dance", // only for Maori Warrior and subsequent upgrades
-		"uniques": ["[-10]% Strength for enemy [Military] units in adjacent [All] tiles"]
+		"uniques": ["[-10]% Strength for enemy [Military] units within [1] tiles in [All] tiles"]
 	},
 	{
 		"name": "Rejuvenation", // only for Units that have been close to Natural Wonder Fountain of Youth

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -2124,3 +2124,5 @@ Unit [unitName] doesn't seem to exist! =
 
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
+
+[relativeAmount]% Strength for enemy [mapUnitFilter] units within [positiveAmount] tiles in [tileFilter] tiles = 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -114,19 +114,32 @@ object BattleDamage {
         }
 
         //https://www.carlsguides.com/strategy/civilization5/war/combatbonuses.php
-        var adjacentUnits = combatant.getTile().neighbors.flatMap { it.getUnits() }
-        if (enemy.getTile() !in combatant.getTile().neighbors && tileToAttackFrom in combatant.getTile().neighbors
+        // e.g., Maori Warrior / Chile By Reason — strength malus from nearby enemy units carrying the unique
+        val combatantTile = combatant.getTile()
+        val nearbyEnemyCarriers = combatantTile.getTilesInDistance(5)
+            .asSequence()
+            .flatMap { it.getUnits() }
+            .filter { it.civ.isAtWarWith(combatant.getCivInfo()) }
+            .toMutableList()
+        // Preserve prior edge case: include the enemy unit when attacking from an adjacent tile
+        if (enemy.getTile() !in combatantTile.neighbors && tileToAttackFrom in combatantTile.neighbors
             && enemy is MapUnitCombatant
-        )
-            adjacentUnits += sequenceOf(enemy.unit)
+        ) nearbyEnemyCarriers += enemy.unit
 
-        // e.g., Maori Warrior - https://civilization.fandom.com/wiki/Maori_Warrior_(Civ5)
-        val strengthMalus = adjacentUnits.filter { it.civ.isAtWarWith(combatant.getCivInfo()) }
-            .flatMap { it.getMatchingUniques(UniqueType.StrengthForAdjacentEnemies) }
-            .filter { combatant.matchesFilter(it.params[1]) && combatant.getTile().matchesFilter(it.params[2]) }
-            .maxByOrNull { it.params[0] }
+        val strengthMalus = nearbyEnemyCarriers
+            .flatMap { carrier ->
+                val distance = carrier.currentTile.aerialDistanceTo(combatantTile)
+                val fromNearby = carrier.getMatchingUniques(UniqueType.StrengthForNearbyEnemies)
+                    .filter { distance in 1..it.params[2].toInt() }
+                    .filter { combatant.matchesFilter(it.params[1]) && combatantTile.matchesFilter(it.params[3]) }
+                val fromAdjacent = carrier.getMatchingUniques(UniqueType.StrengthForAdjacentEnemies)
+                    .filter { distance == 1 }
+                    .filter { combatant.matchesFilter(it.params[1]) && combatantTile.matchesFilter(it.params[2]) }
+                fromNearby + fromAdjacent
+            }
+            .maxByOrNull { it.params[0].toInt() }
         if (strengthMalus != null) {
-            modifiers.add("Adjacent enemy units", strengthMalus.params[0].toInt())
+            modifiers.add("Nearby enemy units", strengthMalus.params[0].toInt())
         }
         return modifiers
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -443,6 +443,10 @@ enum class UniqueType(
     StrengthNearCapital("[relativeAmount]% Strength decreasing with distance from the capital", UniqueTarget.Unit, UniqueTarget.Global),
     FlankAttackBonus("[relativeAmount]% to Flank Attack bonuses", UniqueTarget.Unit, UniqueTarget.Global,
         docDescription = MULTIPLICATIVE_BONUS_EXPLANATION),
+    StrengthForNearbyEnemies("[relativeAmount]% Strength for enemy [mapUnitFilter] units within [positiveAmount] tiles in [tileFilter] tiles", UniqueTarget.Unit,
+        docDescription = "Applies a strength modifier to matching enemy units fighting within the given aerial distance of the unit carrying this unique. " +
+            "Distance 1 is the same as adjacent."),
+    @Deprecated("As of 4.21.6", ReplaceWith("[relativeAmount]% Strength for enemy [mapUnitFilter] units within [1] tiles in [tileFilter] tiles"), DeprecationLevel.WARNING)
     StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [mapUnitFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
     StrengthBonusInRadius("[relativeAmount]% Strength bonus for [mapUnitFilter] units within [amount] tiles", UniqueTarget.Unit),
 

--- a/docs/Modders/schemas/refs/Uniques.schema.json
+++ b/docs/Modders/schemas/refs/Uniques.schema.json
@@ -220,6 +220,7 @@
       "[relativeAmount] Strength",
       "[relativeAmount]% Strength decreasing with distance from the capital",
       "[relativeAmount]% to Flank Attack bonuses",
+      "[relativeAmount]% Strength for enemy [mapUnitFilter] units within [positiveAmount] tiles in [tileFilter] tiles",
       "[relativeAmount]% Strength for enemy [mapUnitFilter] units in adjacent [tileFilter] tiles",
       "[relativeAmount]% Strength bonus for [mapUnitFilter] units within [amount] tiles",
       "[amount] additional attacks per turn",

--- a/tests/src/com/unciv/logic/battle/BattleDamageTest.kt
+++ b/tests/src/com/unciv/logic/battle/BattleDamageTest.kt
@@ -155,4 +155,47 @@ class BattleDamageTest {
         assertTrue(defenceModifiers.isEmpty())
         assertEquals(0, defenceModifiers.sumValues())
     }
+
+    @Test
+    fun `should retrieve nearby enemy strength malus within radius`() {
+        attackerCiv.getDiplomacyManager(defenderCiv)!!.declareWar()
+        defaultDefenderTile.militaryUnit = null
+        val carrierTile = testGame.getTile(3, 1)
+        testGame.addDefaultMeleeUnitWithUniques(
+            defenderCiv,
+            carrierTile,
+            "[-25]% Strength for enemy [Military] units within [2] tiles in [All] tiles"
+        )
+        val adjDefender = testGame.addUnit("Warrior", defenderCiv, defaultDefenderTile)
+
+        val attackModifiers = BattleDamage.getAttackModifiers(
+            MapUnitCombatant(defaultAttackerUnit),
+            MapUnitCombatant(adjDefender),
+            defaultAttackerTile
+        )
+
+        assertEquals(2, defaultAttackerTile.aerialDistanceTo(carrierTile))
+        assertTrue(attackModifiers.containsKey("Nearby enemy units"))
+        assertEquals(-25, attackModifiers["Nearby enemy units"])
+    }
+
+    @Test
+    fun `radius-1 nearby malus applies when adjacent`() {
+        attackerCiv.getDiplomacyManager(defenderCiv)!!.declareWar()
+        defaultDefenderTile.militaryUnit = null
+        val adjacentCarrier = testGame.addDefaultMeleeUnitWithUniques(
+            defenderCiv,
+            defaultDefenderTile,
+            "[-10]% Strength for enemy [Military] units within [1] tiles in [All] tiles"
+        )
+
+        val attackModifiers = BattleDamage.getAttackModifiers(
+            MapUnitCombatant(defaultAttackerUnit),
+            MapUnitCombatant(adjacentCarrier),
+            defaultAttackerTile
+        )
+
+        assertTrue(attackModifiers.containsKey("Nearby enemy units"))
+        assertEquals(-10, attackModifiers["Nearby enemy units"])
+    }
 }


### PR DESCRIPTION
## Summary
- New unique: `[relativeAmount]% Strength for enemy [mapUnitFilter] units within [positiveAmount] tiles in [tileFilter] tiles`.
- Deprecates (WARNING) the adjacent-only form; auto-replace uses `within [1]`.
- Stock Maori Warrior / Impi-related promotions updated to the new text with radius 1.
- Enables mod auras like Chile By Reason / By Force at 2 tiles without a one-off UniqueType.

## Test plan
- [ ] `BattleDamageTest` green (radius 2 + radius 1 cases)
- [ ] Maori Warrior still applies −10% to adjacent enemy military
- [ ] Unit with `within [2]` applies malus at aerial distance 2, not beyond