### PR TITLE
Add stats unique when spread converts city majority

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -458,6 +458,11 @@ enum class UniqueType(
     SpreadReligionStrength("[relativeAmount]% Spread Religion Strength", UniqueTarget.Unit, UniqueTarget.Global,
         docDescription = MULTIPLICATIVE_BONUS_EXPLANATION),
     StatsWhenSpreading("When spreading religion to a city, gain [amount] times the amount of followers of other religions as [stat]", UniqueTarget.Unit, UniqueTarget.Global),
+    StatsWhenConvertingCityMajority(
+        "When spreading religion converts the city's majority religion, gain [stats]",
+        UniqueTarget.Unit, UniqueTarget.Global,
+        docDescription = "Fires only when the spread changes which religion has majority in that city (including converting a city with no majority)."
+    ),
 
     // Attack restrictions
     CanOnlyAttackUnits("Can only attack [combatantFilter] units", UniqueTarget.Unit),

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -108,8 +108,13 @@ object UnitActionsReligion {
                 city.religion.addPressure(unit.religion!!, getPressureAddedFromSpread(unit))
                 if (unit.hasUnique(UniqueType.RemoveOtherReligions))
                     city.religion.removeAllPressuresExceptFor(unit.religion!!)
-                
+
                 val newReligion = city.religion.getMajorityReligion()
+                if (previousReligion != newReligion && newReligion != null && newReligion.name == unit.religion) {
+                    for (unique in unit.getMatchingUniques(UniqueType.StatsWhenConvertingCityMajority, checkCivInfoUniques = true)) {
+                        unit.civ.addStats(unique.stats)
+                    }
+                }
                 if (previousReligion != newReligion && newReligion != null && city.civ != unit.civ) {
                     city.civ.addNotification("[${unit.civ.civName}]'s [${unit.name}] has converted [${city.name}] to [${newReligion.name}]!", NotificationCategory.Religion)
                 }


### PR DESCRIPTION
## Summary
- New unique: `When spreading religion converts the city's majority religion, gain [stats]` (`UniqueTarget.Unit`, `UniqueTarget.Global`).
- Applied in `UnitActionsReligion` after a successful spread that changes majority **to the spreading unit's religion**.
- Complements existing `StatsWhenSpreading` (per other-religion followers). Intended for mod UU missionaries (e.g. RekMOD Ashoka's Envoy: +4 of each yield on full convert).

## Test plan
- [ ] Unit with the unique: spread that does **not** flip majority → no `[stats]` from this unique (StatsWhenSpreading still works if present).
- [ ] Spread that flips majority to the unit's religion → civ gains the listed stats once.
- [ ] Foreign-city convert notification still fires as before.
- [ ] Unit without the unique: no change.
