### PR TITLE
Add [stats] from every Friend/Ally City-State unique

### DIFF
--- a/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
@@ -182,18 +182,26 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
         //City-States bonuses
         for (otherCiv in civInfo.getKnownCivs()) {
             if (!otherCiv.isCityState) continue
-            if (otherCiv.getDiplomacyManager(civInfo)!!.relationshipIgnoreAfraid() != RelationshipLevel.Ally)
+            val relationship = otherCiv.getDiplomacyManager(civInfo)!!.relationshipIgnoreAfraid()
+            if (relationship == RelationshipLevel.Ally) {
+                for (unique in civInfo.getMatchingUniques(UniqueType.CityStateStatPercent)) {
+                    val stats = Stats()
+                    stats.add(
+                        Stat.valueOf(unique.params[0]),
+                        otherCiv.stats.statsForNextTurn[Stat.valueOf(unique.params[0])] * unique.params[1].toFloat() / 100f
+                    )
+                    statMap.add(
+                        Constants.cityStates,
+                        stats
+                    )
+                }
+            }
+            if (relationship != RelationshipLevel.Friend && relationship != RelationshipLevel.Ally)
                 continue
-            for (unique in civInfo.getMatchingUniques(UniqueType.CityStateStatPercent)) {
-                val stats = Stats()
-                stats.add(
-                    Stat.valueOf(unique.params[0]),
-                    otherCiv.stats.statsForNextTurn[Stat.valueOf(unique.params[0])] * unique.params[1].toFloat() / 100f
-                )
-                statMap.add(
-                    Constants.cityStates,
-                    stats
-                )
+            val relationshipName = relationship.name // Friend or Ally
+            for (unique in civInfo.getMatchingUniques(UniqueType.CityStateRelationshipStats)) {
+                if (unique.params[1] != relationshipName) continue
+                statMap.add(Constants.cityStates, unique.stats)
             }
         }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -214,6 +214,14 @@ enum class UniqueParameterType(
         override val staticKnownValues = Stat.statsWithCivWideField.map { it.name }.toSet()
     },
 
+    /** [UniqueType.CityStateRelationshipStats] — City-State Friend / Ally (exact level, not ≥) */
+    CityStateRelationship("relationship", "Friend",
+        "City-State relationship level: `Friend` or `Ally`. Ally bonuses do not also apply Friend bonuses.",
+        severityDefault = UniqueType.UniqueParameterErrorSeverity.RulesetInvariant
+    ) {
+        override val staticKnownValues = setOf("Friend", "Ally")
+    },
+
     /** Implemented by [Civ.matchesFilter][com.unciv.logic.civilization.Civilization.matchesFilter] */
     CivFilter("civFilter", Constants.cityStates) {
         override val staticKnownValues = setOf(Constants.aiPlayer, Constants.humanPlayer, "Open Borders", "Friendly", "Hostile", "Known")

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -104,6 +104,11 @@ enum class UniqueType(
     CityStateRestingPoint("Resting point for Influence with City-States is increased by [amount]", UniqueTarget.Global),
 
     CityStateStatPercent("Allied City-States provide [stat] equal to [relativeAmount]% of what they produce for themselves", UniqueTarget.Global),
+    CityStateRelationshipStats(
+        "[stats] from every [relationship] City-State",
+        UniqueTarget.Global,
+        docDescription = "Flat yields per known City-State at that relationship. Use `Friend` or `Ally` (Ally does not also apply Friend). Stack with era conditionals for LekMOD-style Scholasticism."
+    ),
     CityStateResources("[relativeAmount]% resources gifted by City-States",  UniqueTarget.Global),
     CityStateLuxuryHappiness("[relativeAmount]% Happiness from luxury resources gifted by City-States", UniqueTarget.Global),
     CityStateInfluenceRecoversTwiceNormalRate("City-State Influence recovers at twice the normal rate", UniqueTarget.Global),


### PR DESCRIPTION
## Summary
- New unique: `[stats] from every [relationship] City-State` (`Friend` or `Ally`).
- Applied in `CivInfoStatsForNextTurn`: exact relationship only (Ally does **not** also get Friend rows).
- Vanilla `Allied City-States provide [stat] equal to [relativeAmount]%…` unchanged.
- Intended for LekMOD/RekMOD Scholasticism: flat Science by era for Friends and a higher Ally table.

## Test plan
- [ ] Policy with `[+2 Science] from every [Friend] City-State`: Friend CS → +2 Science; Ally CS → **0** from this unique.
- [ ] Same with Ally unique: Ally → bonus; Friend-only → 0.
- [ ] Stacked `<starting from the [era]>` conditionals accumulate by current era.
- [ ] Existing Scholasticism 25% Ally unique still works in G&K/Vanilla.
