### PR TITLE
Add upon liberating a city trigger

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -586,6 +586,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
             // more performant than "in Constants.all" - see https://medium.com/@yairm210/kotlin-when-string-optimization-e15c6eea2734
             Constants.lowercaseAll -> true
             Constants.uppercaseAll -> true
+            "any" -> true // nicer than "all" in "upon liberating [any] cities"
             "in your cities", "Your" -> viewingCiv == civ
             "in all coastal cities", "Coastal" -> isCoastal()
             "in capital", "Capital" -> isCapital()

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -241,6 +241,9 @@ class CityConquestFunctions(val city: City) {
             if (!unit.movement.canPassThrough(unit.currentTile))
                 unit.movement.teleportToClosestMoveableTile()
 
+        val liberateContext = GameContext(conqueringCiv, city)
+        for (unique in conqueringCiv.getTriggeredUniques(UniqueType.TriggerUponLiberatingCity, liberateContext))
+            UniqueTriggerActivation.triggerUnique(unique, conqueringCiv, city)
     }
 
 

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -242,7 +242,8 @@ class CityConquestFunctions(val city: City) {
                 unit.movement.teleportToClosestMoveableTile()
 
         val liberateContext = GameContext(civInfo = conqueringCiv, city = city)
-        for (unique in conqueringCiv.getTriggeredUniques(UniqueType.TriggerUponLiberatingCity, liberateContext))
+        for (unique in conqueringCiv.getTriggeredUniques(UniqueType.TriggerUponLiberatingCity, liberateContext)
+                { city.matchesFilter(it.params[0], conqueringCiv) })
             UniqueTriggerActivation.triggerUnique(unique, conqueringCiv, city)
     }
 

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -241,7 +241,7 @@ class CityConquestFunctions(val city: City) {
             if (!unit.movement.canPassThrough(unit.currentTile))
                 unit.movement.teleportToClosestMoveableTile()
 
-        val liberateContext = GameContext(conqueringCiv, city)
+        val liberateContext = GameContext(civInfo = conqueringCiv, city = city)
         for (unique in conqueringCiv.getTriggeredUniques(UniqueType.TriggerUponLiberatingCity, liberateContext))
             UniqueTriggerActivation.triggerUnique(unique, conqueringCiv, city)
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -250,6 +250,7 @@ enum class UniqueParameterType(
         override val staticKnownValues = setOf(
             "in this city",
             "in all cities",
+            "any", // nicer than "all" in "upon liberating [any] cities"
             "in your cities", "Your",
             "in all coastal cities", "Coastal",
             "in capital", "Capital",

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1000,6 +1000,7 @@ enum class UniqueType(
     TriggerUpponEndingGoldenAge("upon ending a Golden Age", UniqueTarget.TriggerCondition),
     /** Can be placed upon both units and as global */
     TriggerUponConqueringCity("upon conquering a city", UniqueTarget.TriggerCondition, UniqueTarget.UnitTriggerCondition),
+    TriggerUponLiberatingCity("upon liberating a city", UniqueTarget.TriggerCondition),
     TriggerUponLosingCity("upon losing a city", UniqueTarget.TriggerCondition),
     TriggerUponFoundingCity("upon founding a city", UniqueTarget.TriggerCondition),
     TriggerUponBuildingImprovement("upon building a [improvementFilter] improvement", UniqueTarget.TriggerCondition, UniqueTarget.UnitTriggerCondition),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1000,7 +1000,7 @@ enum class UniqueType(
     TriggerUpponEndingGoldenAge("upon ending a Golden Age", UniqueTarget.TriggerCondition),
     /** Can be placed upon both units and as global */
     TriggerUponConqueringCity("upon conquering a city", UniqueTarget.TriggerCondition, UniqueTarget.UnitTriggerCondition),
-    TriggerUponLiberatingCity("upon liberating a city", UniqueTarget.TriggerCondition),
+    TriggerUponLiberatingCity("upon liberating [cityFilter] cities", UniqueTarget.TriggerCondition),
     TriggerUponLosingCity("upon losing a city", UniqueTarget.TriggerCondition),
     TriggerUponFoundingCity("upon founding a city", UniqueTarget.TriggerCondition),
     TriggerUponBuildingImprovement("upon building a [improvementFilter] improvement", UniqueTarget.TriggerCondition, UniqueTarget.UnitTriggerCondition),

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -129,7 +129,7 @@ Allowed values:
 cityFilters allow us to choose the range of cities affected by this unique:
 
 - `in this city`
-- `in all cities`, `All`, `all` - Generally applies to all cities owned by the relevant civ
+- `in all cities`, `All`, `all`, `any` - Generally applies to all cities owned by the relevant civ (`any` reads better e.g. in `upon liberating [any] cities`)
 - `in your cities`, `Your`
 - `in all coastal cities`, `Coastal`
 - `in capital`, `Capital`


### PR DESCRIPTION
## Summary
- Engine support for **RekMOD Romania** (Golden Age points on liberate).
- New trigger: `upon liberating [cityFilter] cities` (`UniqueTarget.TriggerCondition`).
- Fired at the end of `CityConquestFunctions.liberateCity` for the liberating civ, filtered against the liberated city (e.g. `[any]`).
- `any` accepted as a cityFilter (alongside `all`/`All`) so the phrasing reads naturally.
- Compose as `Instantly gain [N] [Golden Age points] <upon liberating [any] cities>`.

## Test plan
- [ ] Civ with liberate GAP unique: liberate a city → GAP granted once.
- [ ] Narrower filter only fires for matching liberated cities.
- [ ] Conquer/puppet/annex without liberate → this trigger does not fire.
- [ ] Existing conquer triggers unchanged.