### PR TITLE
Add Movement cost in tileFilter unique

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
@@ -11,6 +11,7 @@ import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
 import yairm210.purity.annotations.Readonly
+import kotlin.math.roundToInt
 
 object MovementCost {
 
@@ -133,7 +134,9 @@ object MovementCost {
             if (!to.matchesFilter(unique.params[1], unit.civ)) continue
             result *= unique.params[0].toPercent()
         }
-        return result
+        // A-Star pathing stores movement in fixed-point base 30 (see PathingMapCache).
+        // Keep costs on that grid after percentage modifiers.
+        return (result * 30f).roundToInt() / 30f
     }
 
     @Readonly

--- a/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.ui.components.extensions.toPercent
 import yairm210.purity.annotations.Readonly
 
 object MovementCost {
@@ -68,7 +69,7 @@ object MovementCost {
         ) getEnemyMovementPenalty(toOwner, unit) else 0f
 
         if (from.getUnpillagedRoad() == RoadStatus.Railroad && to.getUnpillagedRoad() == RoadStatus.Railroad)
-            return RoadStatus.Railroad.movement + extraCost
+            return getRoadMovementCost(unit, to, RoadStatus.Railroad.movement) + extraCost
 
         // Each of these two function calls `hasUnique(UniqueType.CityStateTerritoryAlwaysFriendly)`
         // when entering territory of a city state
@@ -80,7 +81,7 @@ object MovementCost {
             from.isAdjacentToRiver() && to.isAdjacentToRiver() && from.isConnectedByRiver(to)
 
         if (areConnectedByRoad && (!areConnectedByRiver || civ.tech.roadsConnectAcrossRivers))
-            return unit.civ.tech.movementSpeedOnRoads + extraCost
+            return getRoadMovementCost(unit, to, unit.civ.tech.movementSpeedOnRoads) + extraCost
 
         if (unit.cache.ignoresTerrainCost) return 1f + extraCost
         if (areConnectedByRiver) return 100f  // Rivers take the entire turn to cross
@@ -122,6 +123,17 @@ object MovementCost {
             return terrainCost * 0.5f + extraCost
 
         return terrainCost + extraCost // no road or other movement cost reduction
+    }
+
+    @Readonly
+    private fun getRoadMovementCost(unit: MapUnit, to: Tile, baseCost: Float): Float {
+        var cost = baseCost
+        val gameContext = GameContext(unit.civ, unit = unit, tile = to)
+        for (unique in unit.getMatchingUniques(UniqueType.RoadMovementCost, gameContext, checkCivInfoUniques = true)) {
+            if (!to.matchesFilter(unique.params[1], unit.civ)) continue
+            cost *= unique.params[0].toPercent()
+        }
+        return cost
     }
 
     @Readonly

--- a/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
@@ -58,7 +58,7 @@ object MovementCost {
 
         // land units will still spend all movement points to embark even with this unique
         if (unit.cache.allTilesCosts1)
-            return 1f
+            return applyTileMovementCostUniques(unit, to, 1f)
 
         val toOwner = to.getOwner()
 
@@ -69,7 +69,7 @@ object MovementCost {
         ) getEnemyMovementPenalty(toOwner, unit) else 0f
 
         if (from.getUnpillagedRoad() == RoadStatus.Railroad && to.getUnpillagedRoad() == RoadStatus.Railroad)
-            return getRoadMovementCost(unit, to, RoadStatus.Railroad.movement) + extraCost
+            return applyTileMovementCostUniques(unit, to, RoadStatus.Railroad.movement) + extraCost
 
         // Each of these two function calls `hasUnique(UniqueType.CityStateTerritoryAlwaysFriendly)`
         // when entering territory of a city state
@@ -81,9 +81,9 @@ object MovementCost {
             from.isAdjacentToRiver() && to.isAdjacentToRiver() && from.isConnectedByRiver(to)
 
         if (areConnectedByRoad && (!areConnectedByRiver || civ.tech.roadsConnectAcrossRivers))
-            return getRoadMovementCost(unit, to, unit.civ.tech.movementSpeedOnRoads) + extraCost
+            return applyTileMovementCostUniques(unit, to, unit.civ.tech.movementSpeedOnRoads) + extraCost
 
-        if (unit.cache.ignoresTerrainCost) return 1f + extraCost
+        if (unit.cache.ignoresTerrainCost) return applyTileMovementCostUniques(unit, to, 1f) + extraCost
         if (areConnectedByRiver) return 100f  // Rivers take the entire turn to cross
 
         // Cities reduce terrain cost to 1
@@ -91,49 +91,49 @@ object MovementCost {
             else to.lastTerrain.movementCost.toFloat()
 
         if (unit.cache.noTerrainMovementUniques)
-            return terrainCost + extraCost
+            return applyTileMovementCostUniques(unit, to, terrainCost) + extraCost
 
         val gameContext = GameContext(unit.civ, unit = unit, tile = to)
 
         if (to.terrainFeatures.any { hasDoubleMovement(unit, it, MapUnitCache.DoubleMovementTerrainTarget.Feature, gameContext) })
-            return terrainCost * 0.5f + extraCost
+            return applyTileMovementCostUniques(unit, to, terrainCost * 0.5f) + extraCost
 
         if (unit.cache.roughTerrainPenalty && to.isRoughTerrain())
             return 100f // units that have to spend all movement in rough terrain, have to spend all movement in rough terrain
         // Placement of this 'if' based on testing, see #4232
 
         if (civ.nation.ignoreHillMovementCost && to.isHill())
-            return 1f + extraCost // usually hills take 2 movements, so here it is 1
+            return applyTileMovementCostUniques(unit, to, 1f) + extraCost // usually hills take 2 movements, so here it is 1
 
         if (unit.cache.noBaseTerrainOrHillDoubleMovementUniques)
-            return terrainCost + extraCost
+            return applyTileMovementCostUniques(unit, to, terrainCost) + extraCost
 
         if (hasDoubleMovement(unit, to.baseTerrain, MapUnitCache.DoubleMovementTerrainTarget.Base, gameContext))
-            return terrainCost * 0.5f + extraCost
+            return applyTileMovementCostUniques(unit, to, terrainCost * 0.5f) + extraCost
         val hillTerrain = to.getHillTerrain()
         if (hillTerrain != null && hasDoubleMovement(unit, hillTerrain.name, MapUnitCache.DoubleMovementTerrainTarget.Hill, gameContext))
-            return terrainCost * 0.5f + extraCost
+            return applyTileMovementCostUniques(unit, to, terrainCost * 0.5f) + extraCost
 
         if (unit.cache.noFilteredDoubleMovementUniques)
-            return terrainCost + extraCost
+            return applyTileMovementCostUniques(unit, to, terrainCost) + extraCost
         if (unit.cache.doubleMovementInTerrain.any {
                 hasDoubleMovement(it.value, MapUnitCache.DoubleMovementTerrainTarget.Filter, gameContext)
                     && to.matchesFilter(it.key)
             })
-            return terrainCost * 0.5f + extraCost
+            return applyTileMovementCostUniques(unit, to, terrainCost * 0.5f) + extraCost
 
-        return terrainCost + extraCost // no road or other movement cost reduction
+        return applyTileMovementCostUniques(unit, to, terrainCost) + extraCost // no road or other movement cost reduction
     }
 
     @Readonly
-    private fun getRoadMovementCost(unit: MapUnit, to: Tile, baseCost: Float): Float {
-        var cost = baseCost
+    private fun applyTileMovementCostUniques(unit: MapUnit, to: Tile, cost: Float): Float {
+        var result = cost
         val gameContext = GameContext(unit.civ, unit = unit, tile = to)
-        for (unique in unit.getMatchingUniques(UniqueType.RoadMovementCost, gameContext, checkCivInfoUniques = true)) {
+        for (unique in unit.getMatchingUniques(UniqueType.TileMovementCost, gameContext, checkCivInfoUniques = true)) {
             if (!to.matchesFilter(unique.params[1], unit.civ)) continue
-            cost *= unique.params[0].toPercent()
+            result *= unique.params[0].toPercent()
         }
-        return cost
+        return result
     }
 
     @Readonly

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -159,11 +159,7 @@ enum class UniqueType(
     /// Improvements
     // Should be replaced with moddable improvements when roads become moddable
     RoadMovementSpeed("Improves movement speed on roads",UniqueTarget.Global),
-    RoadMovementCost(
-        "[relativeAmount]% Movement cost on roads in [tileFilter] tiles",
-        UniqueTarget.Unit, UniqueTarget.Global,
-        docDescription = "Multiplicative change to road/railroad movement cost when the destination tile matches the filter (e.g. Franks on Friendly/Unowned roads)."
-    ),
+    TileMovementCost("[relativeAmount]% Movement cost in [tileFilter] tiles", UniqueTarget.Unit, UniqueTarget.Global),
     RoadsConnectAcrossRivers("Roads connect tiles across rivers", UniqueTarget.Global),
     RoadMaintenance("[relativeAmount]% maintenance on road & railroads", UniqueTarget.Global,
         docDescription = MULTIPLICATIVE_BONUS_EXPLANATION),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -159,6 +159,11 @@ enum class UniqueType(
     /// Improvements
     // Should be replaced with moddable improvements when roads become moddable
     RoadMovementSpeed("Improves movement speed on roads",UniqueTarget.Global),
+    RoadMovementCost(
+        "[relativeAmount]% Movement cost on roads in [tileFilter] tiles",
+        UniqueTarget.Unit, UniqueTarget.Global,
+        docDescription = "Multiplicative change to road/railroad movement cost when the destination tile matches the filter (e.g. Franks on Friendly/Unowned roads)."
+    ),
     RoadsConnectAcrossRivers("Roads connect tiles across rivers", UniqueTarget.Global),
     RoadMaintenance("[relativeAmount]% maintenance on road & railroads", UniqueTarget.Global,
         docDescription = MULTIPLICATIVE_BONUS_EXPLANATION),


### PR DESCRIPTION
## Summary
- Engine support for **RekMOD Franks** (faster travel on Friendly / Unowned roads).
- New unique: `[relativeAmount]% Movement cost in [tileFilter] tiles` (`Unit` / `Global`).
- Applied to destination-tile movement cost; Franks compose road limits in the filter, e.g. `[-25]% Movement cost in [{All Road} {Friendly Land}] tiles` (+ Unowned).
- After `%` modifiers, cost is quantized to `1/30` so A-Star pathing (`PathingMapCache` fixed-point) stays valid.

## Test plan
- [ ] `[-25]% Movement cost in [{All Road} {Friendly Land}] tiles`: road into friendly land costs ~75% of normal road cost (on 1/30 grid).
- [ ] Same into enemy land: unique does not apply.
- [ ] Railroad path respects the unique when the filter matches.
- [ ] No unique: costs unchanged; pathing still works with the unique enabled.