### PR TITLE
Add conditional: within N tiles of a unit

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -169,7 +169,7 @@
             {
                 "name": "Discipline",
                 "uniques": [
-                    "[+15]% Strength <for [Melee] units> <when adjacent to a [Melee] unit>"
+                    "[+15]% Strength <for [Melee] units> <when adjacent to a [{Friendly} {Melee}] unit>"
                 ],
                 "row": 1,
                 "column": 4

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -167,7 +167,7 @@
             {
                 "name": "Discipline",
                 "uniques": [
-                    "[+10]% Strength <for [Melee] units> <when adjacent to a [Melee] unit>"
+                    "[+10]% Strength <for [Melee] units> <when adjacent to a [{Friendly} {Melee}] unit>"
                 ],
                 "row": 1,
                 "column": 4

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -646,6 +646,9 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     @Readonly
     private fun matchesSingleFilter(filter: String, state: GameContext = GameContext.EmptyState): Boolean {
+        // Prefer caller-provided state so civFilters like Friendly/Hostile are relative to the querying civ
+        // (e.g. "when adjacent to a [{Friendly} {Melee}] unit"), not this unit's own civ.
+        val filterState = if (state.civInfo != null) state else cache.state
         return when (filter) {
             "other" -> state.unit != this
             Constants.wounded, "wounded units" -> health < 100
@@ -654,9 +657,9 @@ class MapUnit : IsPartOfGameInfoSerialization {
             Constants.embarked -> isEmbarked()
             "Non-City" -> true
             else -> {
-                if (baseUnit.matchesFilter(filter, cache.state, false)) return true
-                if (civ.matchesFilter(filter, cache.state, false)) return true
-                if (nonUnitUniquesMap.hasUnique(filter, cache.state)) return true
+                if (baseUnit.matchesFilter(filter, filterState, false)) return true
+                if (civ.matchesFilter(filter, filterState, false)) return true
+                if (nonUnitUniquesMap.hasUnique(filter, filterState)) return true
                 if (promotions.promotions.contains(filter)) return true
                 if (hasStatus(filter)) return true
                 return false

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -316,6 +316,17 @@ object Conditionals {
                                 it.matchesFilter(conditional.params[0])
                         }
                     }
+            UniqueType.ConditionalNearUnit ->
+                state.relevantCiv != null &&
+                    state.relevantUnit != null &&
+                    state.relevantTile != null &&
+                    state.relevantTile!!.getTilesInDistance(conditional.params[0].toInt()).any { tile ->
+                        tile.getUnits().any {
+                            it != state.relevantUnit &&
+                                it.civ == state.relevantCiv &&
+                                it.matchesFilter(conditional.params[1])
+                        }
+                    }
 
             UniqueType.ConditionalNeighborTiles ->
                 state.relevantTile != null

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -315,8 +315,7 @@ object Conditionals {
                     state.relevantTile != null &&
                     state.relevantTile!!.neighbors.any { tile ->
                         tile.getUnits().any {
-                            it != state.relevantUnit &&
-                                it.matchesFilter(conditional.params[0], state = state)
+                            it.matchesFilter(conditional.params[0], state = state)
                         }
                     }
             UniqueType.ConditionalNearUnit ->

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -277,10 +277,14 @@ object Conditionals {
             UniqueType.ConditionalHasNotUsedOtherActions ->
                 state.unit == null || // So we get the action as a valid action in BaseUnit.hasUnique()
                     state.unit.abilityToTimesUsed.isEmpty()
-            UniqueType.ConditionalStackedWithUnit -> state.relevantUnit != null && 
-                    state.relevantUnit!!.getTile().getUnits().any { it != state.relevantUnit && it.matchesFilter(conditional.params[0]) }
+            UniqueType.ConditionalStackedWithUnit -> state.relevantUnit != null &&
+                    state.relevantUnit!!.getTile().getUnits().any {
+                        it != state.relevantUnit && it.matchesFilter(conditional.params[0], state = state)
+                    }
             UniqueType.ConditionalNotStackedWithUnit -> state.relevantUnit == null ||
-                    !state.relevantUnit!!.getTile().getUnits().any { it != state.relevantUnit && it.matchesFilter(conditional.params[0]) }
+                    !state.relevantUnit!!.getTile().getUnits().any {
+                        it != state.relevantUnit && it.matchesFilter(conditional.params[0], state = state)
+                    }
 
             UniqueType.ConditionalInTiles ->
                 state.relevantTile?.matchesFilter(conditional.params[0], state.relevantCiv) == true
@@ -307,24 +311,21 @@ object Conditionals {
                     )
             }
             UniqueType.ConditionalAdjacentUnit ->
-                state.relevantCiv != null &&
-                        state.relevantUnit != null &&
-                        state.relevantTile!!.neighbors.any {
-                        it.getUnits().any {
+                state.relevantUnit != null &&
+                    state.relevantTile != null &&
+                    state.relevantTile!!.neighbors.any { tile ->
+                        tile.getUnits().any {
                             it != state.relevantUnit &&
-                                it.civ == state.relevantCiv &&
-                                it.matchesFilter(conditional.params[0])
+                                it.matchesFilter(conditional.params[0], state = state)
                         }
                     }
             UniqueType.ConditionalNearUnit ->
-                state.relevantCiv != null &&
-                    state.relevantUnit != null &&
+                state.relevantUnit != null &&
                     state.relevantTile != null &&
                     state.relevantTile!!.getTilesInDistance(conditional.params[0].toInt()).any { tile ->
                         tile.getUnits().any {
                             it != state.relevantUnit &&
-                                it.civ == state.relevantCiv &&
-                                it.matchesFilter(conditional.params[1])
+                                it.matchesFilter(conditional.params[1], state = state)
                         }
                     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -852,6 +852,7 @@ enum class UniqueType(
     ConditionalFightingInTiles("when fighting in [tileFilter] tiles", UniqueTarget.Conditional),
     ConditionalForeignContinent("on foreign continents", UniqueTarget.Conditional),
     ConditionalAdjacentUnit("when adjacent to a [mapUnitFilter] unit", UniqueTarget.Conditional),
+    ConditionalNearUnit("within [positiveAmount] tiles of a [mapUnitFilter] unit", UniqueTarget.Conditional),
     ConditionalAboveHP("when above [positiveAmount] HP", UniqueTarget.Conditional),
     ConditionalBelowHP("when below [positiveAmount] HP", UniqueTarget.Conditional),
     ConditionalBelowMovement("when below [positiveAmount] movement", UniqueTarget.Conditional),


### PR DESCRIPTION
## Summary
- Engine support for **RekMOD Akkad** (Strength near a Great General when attacking cities).
- Add conditional `within [positiveAmount] tiles of a [mapUnitFilter] unit`.
- Matches any civ's units via `mapUnitFilter`; same-civ / friendly limits belong in the filter (e.g. `[{Friendly} {Great General}]`).
- Migrated `when adjacent to a [mapUnitFilter] unit` the same way; Discipline uses `[{Friendly} {Melee}]`.
- `MapUnit.matchesFilter` uses caller `GameContext` for civFilters so `Friendly`/`Hostile` are relative to the querying civ.

## Test plan
- [ ] `[+15]% Strength <for [Military] units> <vs cities> <when attacking> <within [2] tiles of a [{Friendly} {Great General}] unit>` applies near own GG.
- [ ] Does not apply near an enemy GG when filter requires Friendly.
- [ ] Without Friendly in the filter, any civ's GG matches.
- [ ] Discipline: melee next to own melee still gets the bonus.