### PR TITLE
Add unit action: annex or puppet a City-State

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -382,12 +382,37 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     }
 
+    /**
+     * Whether [buyer] can take over this City-State by consuming a unit with [UniqueType.CanAnnexOrPuppetCityState]
+     * (e.g. Merchant of Venice).
+     *
+     * Allowed when the City-State is unallied or already allied to [buyer], not at war, and not on marriage cooldown.
+     */
+    @Readonly
+    fun canBeBoughtByUnit(buyer: Civilization): Boolean {
+        return (!civInfo.isDefeated()
+                && civInfo.isCityState
+                && civInfo.cities.any()
+                && !civInfo.isAtWarWith(buyer)
+                && (civInfo.allyCiv == null || civInfo.allyCiv == buyer)
+                && !buyer.getDiplomacyManager(civInfo)!!.hasFlag(DiplomacyFlags.MarriageCooldown))
+    }
+
     fun diplomaticMarriage(otherCiv: Civilization) {
         if (!canBeMarriedBy(otherCiv))  // Just in case
             return
 
         otherCiv.addGold(-getDiplomaticMarriageCost())
+        takeOverCityState(otherCiv)
+    }
 
+    /** Take over this City-State by consuming a unit (no Gold cost). */
+    fun takeOverByUnit(buyer: Civilization) {
+        if (!canBeBoughtByUnit(buyer)) return
+        takeOverCityState(buyer)
+    }
+
+    private fun takeOverCityState(otherCiv: Civilization) {
         val notificationLocation = civInfo.getCapital()!!.location
         otherCiv.addNotification("We have married into the ruling family of [${civInfo.civName}], bringing them under our control.",
             notificationLocation,

--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -199,6 +199,8 @@ enum class UnitActionType(
         { ImageGetter.getUnitActionPortrait("HurryConstruction") }, UncivSound.Chimes),
     ConductTradeMission("{Conduct Trade Mission} (${Fonts.death})",
         { ImageGetter.getUnitActionPortrait("ConductTradeMission") }, UncivSound.Chimes),
+    BuyCityState("{Buy City-State} (${Fonts.death})",
+        { ImageGetter.getUnitActionPortrait("Present") }, UncivSound.Chimes),
     FoundReligion("Found a Religion",
         { ImageGetter.getUnitActionPortrait("FoundReligion") }, UncivSound.Choir),
     TriggerUnique("Trigger unique",

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -431,6 +431,7 @@ enum class UniqueType(
     CanHurryResearch("Can hurry technology research", UniqueTarget.Unit),
     CanHurryPolicy("Can generate a large amount of culture", UniqueTarget.Unit),
     CanTradeWithCityStateForGoldAndInfluence("Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence", UniqueTarget.Unit),
+    CanAnnexOrPuppetCityState("Can annex or puppet a City-State", UniqueTarget.UnitAction),
     CanTransform("Can transform to [unit]", UniqueTarget.UnitAction,
         docDescription = "By default consumes all movement"),
 

--- a/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
@@ -131,6 +131,7 @@ enum class KeyboardBinding(
     HurryWonder(Category.UnitActions, 'g'),
     HurryBuilding(Category.UnitActions,"Hurry Construction", 'g'),
     ConductTradeMission(Category.UnitActions, 'g'),
+    BuyCityState(Category.UnitActions, "Buy City-State", 'g'),
     FoundReligion(Category.UnitActions,"Found a Religion", 'g'),
     TriggerUnique(Category.UnitActions,"Trigger unique", 'g'),
     SpreadReligion(Category.UnitActions, 'g'),

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -89,6 +89,7 @@ object UnitActions {
         UnitActionType.HurryWonder to UnitActionsGreatPerson::getHurryWonderActions,
         UnitActionType.HurryBuilding to UnitActionsGreatPerson::getHurryBuildingActions,
         UnitActionType.ConductTradeMission to UnitActionsGreatPerson::getConductTradeMissionActions,
+        UnitActionType.BuyCityState to UnitActionsGreatPerson::getBuyCityStateActions,
         UnitActionType.FoundReligion to UnitActionsReligion::getFoundReligionActions,
         UnitActionType.EnhanceReligion to UnitActionsReligion::getEnhanceReligionActions,
         UnitActionType.CreateImprovement to UnitActionsFromUniques::getImprovementCreationActions,

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
@@ -1,7 +1,9 @@
 package com.unciv.ui.screens.worldscreen.unit.actions
 
+import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
+import com.unciv.logic.civilization.PopupAlert
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitAction
@@ -130,6 +132,34 @@ object UnitActionsGreatPerson {
                         NotificationCategory.General, tileOwningCiv.civName, NotificationIcon.Gold, NotificationIcon.Culture)
                     unit.consume()
                 }.takeIf { unit.hasMovement() && canConductTradeMission }
+            ))
+        }
+    }
+
+    internal fun getBuyCityStateActions(unit: MapUnit, tile: Tile) = sequence {
+        val cityState = tile.owningCity?.civ
+        for (unique in UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.CanAnnexOrPuppetCityState)) {
+            val canBuy = cityState != null
+                && cityState != unit.civ
+                && cityState.cityStateFunctions.canBeBoughtByUnit(unit.civ)
+            val useFrequency = getUseFrequency(unit, unique, 70f)
+
+            yield(UnitAction(
+                UnitActionType.BuyCityState, useFrequency,
+                action = {
+                    val cities = cityState!!.cities.toList()
+                    cityState.cityStateFunctions.takeOverByUnit(unit.civ)
+                    UnitActionModifiers.activateSideEffects(unit, unique)
+                    // Human players get a popup that allows them to annex instead of puppet
+                    if (unit.civ.isHuman()) {
+                        for (city in cities)
+                            unit.civ.popupAlerts.add(PopupAlert(AlertType.DiplomaticMarriage, city.id))
+                    }
+                }.takeIf {
+                    unit.hasMovement()
+                        && canBuy
+                        && UnitActionModifiers.canActivateSideEffects(unit, unique)
+                }
             ))
         }
     }


### PR DESCRIPTION
## Summary
- Engine support for **RekMOD Merchant of Venice** (Great Merchant UU that can buy a City-State by consuming the unit).
- New unit action unique: `Can annex or puppet a City-State` (typically with `<by consuming this unit>`).
- Allowed when the CS is unallied or already allied to the buyer, not at war, and not on Diplomatic Marriage cooldown.
- Shares takeover logic with Austria-style Diplomatic Marriage; Austria's Gold + Ally-turns unique is unchanged and separate.

## Test plan
- [ ] Unit with the unique on a CS tile can use Buy City-State when the CS is unallied or your ally.
- [ ] Action unavailable vs enemy Ally CS / at war / marriage cooldown.
- [ ] Consuming the unit annexes/puppets as with Diplomatic Marriage alerts for humans.