### PR TITLE
Add Friend/Ally City-States countables

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -307,7 +307,7 @@ enum class Countables(
             return civ.getKnownCivs().count { other ->
                 other.isCityState && other.isAlive() &&
                     other.getDiplomacyManager(civ)!!.isRelationshipLevelEQ(
-                        com.unciv.logic.civilization.diplomacy.RelationshipLevel.Friend
+                        RelationshipLevel.Friend
                     )
             }
         }
@@ -325,7 +325,7 @@ enum class Countables(
             return civ.getKnownCivs().count { other ->
                 other.isCityState && other.isAlive() &&
                     other.getDiplomacyManager(civ)!!.relationshipIgnoreAfraid() ==
-                        com.unciv.logic.civilization.diplomacy.RelationshipLevel.Ally
+                        RelationshipLevel.Ally
             }
         }
     },

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -1,5 +1,6 @@
 package com.unciv.models.ruleset.unique
 
+import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Countables.Stats
 import com.unciv.models.ruleset.unique.Countables.TileResources
@@ -292,6 +293,41 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
             UniqueParameterType.CivFilter.getKnownValuesForAutocomplete(ruleset)
                 .map { text.fillPlaceholders(it) }.toSet()
+    },
+
+    FriendCityStates("Friend City-States",
+        shortDocumentation = "City-States at exact Friend relationship with the relevant Civilization"
+    ) {
+        override val documentationStrings = listOf(
+            "Exact Friend only — Ally City-States are not counted.",
+            "Use with `[stats] <for every [Friend City-States]>` (e.g. Scholasticism)."
+        )
+        override fun eval(parameterText: String, gameContext: GameContext): Int? {
+            val civ = gameContext.civInfo ?: return null
+            return civ.getKnownCivs().count { other ->
+                other.isCityState && other.isAlive() &&
+                    other.getDiplomacyManager(civ)!!.isRelationshipLevelEQ(
+                        com.unciv.logic.civilization.diplomacy.RelationshipLevel.Friend
+                    )
+            }
+        }
+    },
+
+    AllyCityStates("Ally City-States",
+        shortDocumentation = "City-States at exact Ally relationship with the relevant Civilization"
+    ) {
+        override val documentationStrings = listOf(
+            "Exact Ally only — Friend City-States are not counted.",
+            "Uses the same Ally check as Allied City-State yield uniques (ignores Afraid)."
+        )
+        override fun eval(parameterText: String, gameContext: GameContext): Int? {
+            val civ = gameContext.civInfo ?: return null
+            return civ.getKnownCivs().count { other ->
+                other.isCityState && other.isAlive() &&
+                    other.getDiplomacyManager(civ)!!.relationshipIgnoreAfraid() ==
+                        com.unciv.logic.civilization.diplomacy.RelationshipLevel.Ally
+            }
+        }
     },
 
     WorkedTilesCity("Worked [tileFilter] Tiles in this city") {


### PR DESCRIPTION
## Summary
- Engine support for **RekMOD Scholasticism** (Patronage: flat Science from Friend / Ally City-States by era).
- Replaces closed #15356 approach (dedicated relationship UniqueType).
- New countables: `Friend City-States` and `Ally City-States` (exact relationship; Ally does not count as Friend).
- Compose with existing `[stats] <for every [countable]>`, e.g. `[+2 Science] <for every [Friend City-States]>`.
- Vanilla `Allied City-States provide [stat] equal to [relativeAmount]%…` unchanged.

## Test plan
- [ ] `[+2 Science] <for every [Friend City-States]>`: Friend CS → +2 each; Ally CS → 0 from this unique.
- [ ] `[+N Science] <for every [Ally City-States]>`: Ally → bonus; Friend-only → 0.
- [ ] Era conditionals still multiply via existing unique machinery.
- [ ] Existing Scholasticism 25% Ally unique still works.