### PR TITLE
Add upon converting a city's majority religion trigger

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1015,6 +1015,7 @@ enum class UniqueType(
     TriggerUponFoundingPantheon("upon founding a Pantheon", UniqueTarget.TriggerCondition),
     TriggerUponFoundingReligion("upon founding a Religion", UniqueTarget.TriggerCondition),
     TriggerUponEnhancingReligion("upon enhancing a Religion", UniqueTarget.TriggerCondition),
+    TriggerUponConvertingCityMajorityReligion("upon converting a city's majority religion", UniqueTarget.TriggerCondition, UniqueTarget.UnitTriggerCondition),
 
     //endregion
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -7,7 +7,9 @@ import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueTarget
+import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.ui.components.extensions.toPercent
@@ -110,6 +112,12 @@ object UnitActionsReligion {
                     city.religion.removeAllPressuresExceptFor(unit.religion!!)
                 
                 val newReligion = city.religion.getMajorityReligion()
+                if (previousReligion != newReligion && newReligion != null && newReligion.name == unit.religion) {
+                    val convertContext = GameContext(civInfo = unit.civ, city = city, unit = unit, tile = tile)
+                    for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponConvertingCityMajorityReligion, convertContext)
+                            + unit.civ.getTriggeredUniques(UniqueType.TriggerUponConvertingCityMajorityReligion, convertContext))
+                        UniqueTriggerActivation.triggerUnique(unique, unit.civ, city = city, unit = unit)
+                }
                 if (previousReligion != newReligion && newReligion != null && city.civ != unit.civ) {
                     city.civ.addNotification("[${unit.civ.civName}]'s [${unit.name}] has converted [${city.name}] to [${newReligion.name}]!", NotificationCategory.Religion)
                 }


### PR DESCRIPTION
## Summary
- Engine support for **RekMOD Maurya / Ashoka's Envoy** (UU Missionary: burst yields when a spread flips city majority).
- Replaces closed #15355 (dedicated `When spreading… gain [stats]` UniqueType).
- New trigger: `upon converting a city's majority religion` (`TriggerCondition` + `UnitTriggerCondition`).
- Fired after a successful religion spread that changes majority **to the spreading unit's religion**.
- Compose as e.g. `[+4 Gold, +4 Science, +4 Culture, +4 Faith] <upon converting a city's majority religion>`.
- Existing `StatsWhenSpreading` (per other-religion followers) unchanged.

## Test plan
- [ ] `Gain [stats] <upon converting a city's majority religion>`: spread that flips majority → stats once.
- [ ] Spread that does not flip majority → trigger does not fire.
- [ ] Foreign-city convert notification still fires as before.