### PR TITLE
Display players' average turn times in MP preview

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -762,7 +762,7 @@ Could not skip turn - current player is [actualCivName], not [expectedCivName] =
 The game was out of sync with the server = 
 
 Last refresh: [duration] ago = 
-Current Turn: [civName] since [duration] ago = 
+Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
 Seconds = 
 Minutes = 
 Hours = 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -373,6 +373,13 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         var player = currentPlayerCiv
         var playerIndex = civilizations.indexOf(player)
 
+        if (player.isHuman() && player.isAlive()) {
+            player.totalTurnTimeSeconds +=
+                Duration.between(Instant.ofEpochMilli(currentTurnStartTime), Instant.now())
+                    .toSeconds().toInt()
+            player.turnsPlayedAsHuman++
+        }
+        
         if (gameParameters.isOnlineMultiplayer) updateMinutesBeforeForceResign(player, shouldGainTime)
         // We rotate Players in cycle: 1,2...N,1,2...
         fun setNextPlayer() {

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -47,6 +47,7 @@ import kotlin.math.roundToInt
 import kotlin.math.sqrt
 import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.civilization.managers.quests.QuestManager
+import kotlin.text.toFloat
 
 enum class Proximity : IsPartOfGameInfoSerialization {
     None, // ie no cities
@@ -136,6 +137,11 @@ class Civilization : IsPartOfGameInfoSerialization {
     var playerId = ""
     /** Used in online multiplayer, if a player exceed this time to complete their turn, others can force them to resign*/
     var playerMinutesBeforeForceResign = 3 * 24 * 60
+    /** Total number of minutes spent on their turn. Recorded at the end of each turn. */
+    var totalTurnTimeSeconds = 0
+    /** To calculate average turn time, we only count turns when controlled by a human. Additionally, offers backward compatibility. */
+    var turnsPlayedAsHuman = 0
+    
     /** The Civ's gold reserves. Public get, private set - please use [addGold] method to modify. */
     var gold = 0
         private set
@@ -300,6 +306,8 @@ class Civilization : IsPartOfGameInfoSerialization {
         toReturn.playerType = playerType
         toReturn.playerId = playerId
         toReturn.playerMinutesBeforeForceResign = playerMinutesBeforeForceResign
+        toReturn.totalTurnTimeSeconds = totalTurnTimeSeconds
+        toReturn.turnsPlayedAsHuman = turnsPlayedAsHuman
         toReturn.civName = civName
         toReturn.civID = civID
         toReturn.tech = tech.clone()
@@ -1295,6 +1303,8 @@ class CivilizationInfoPreview() {
     var playerType = PlayerType.AI
     var playerId = ""
     var playerMinutesBeforeForceResign = 60*24*3
+    var totalTurnTimeSeconds = 0
+    var turnsPlayedAsHuman = 0
     @Readonly fun isPlayerCivilization() = playerType == PlayerType.Human
 
     /**
@@ -1306,6 +1316,8 @@ class CivilizationInfoPreview() {
         playerType = civilization.playerType
         playerId = civilization.playerId
         playerMinutesBeforeForceResign = civilization.playerMinutesBeforeForceResign
+        totalTurnTimeSeconds = civilization.totalTurnTimeSeconds
+        turnsPlayedAsHuman = civilization.turnsPlayedAsHuman
     }
 }
 

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
@@ -60,11 +60,10 @@ object MultiplayerHelpers {
                 playerText += "{ }({$playerDescriptor})"
 
             val currentTurnTime = Duration.between(currentTurnStartTime, Instant.now())
-            descriptionText.appendLine("Current Turn: [$playerText] since [${currentTurnTime.formatShort()}] ago".tr())
-            descriptionText.appendLine("Time to play the turn: [${Duration.ofMinutes(currentPlayer.playerMinutesBeforeForceResign.toLong()).formatShort()}]".tr())
             val updatedTotalTurnTime = Duration.ofSeconds(currentPlayer.totalTurnTimeSeconds.toLong()) + currentTurnTime
-            val averageTurnTime = updatedTotalTurnTime.dividedBy(currentPlayer.turnsPlayedAsHuman + 1L) // +1 to include current turn and avoid div 0
-            descriptionText.appendLine("Average turn time: [${averageTurnTime.formatShort()}]".tr())
+            val averageTurnTime = updatedTotalTurnTime.dividedBy(currentPlayer.turnsPlayedAsHuman + 1L) // +1 to include current turn and avoid div by 0
+            descriptionText.appendLine("Current Turn: [$playerText] since [${currentTurnTime.formatShort()}] ago (average: [${averageTurnTime.formatShort()}])".tr())
+            descriptionText.appendLine("Time to play the turn: [${Duration.ofMinutes(currentPlayer.playerMinutesBeforeForceResign.toLong()).formatShort()}]".tr())
 
             val playerCivName = preview.civilizations
                 .firstOrNull{ it.playerId == UncivGame.Current.settings.multiplayer.getUserId() }?.civName ?: "Unknown"

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
@@ -59,8 +59,12 @@ object MultiplayerHelpers {
             if (playerDescriptor != null)
                 playerText += "{ }({$playerDescriptor})"
 
-            descriptionText.appendLine("Current Turn: [$playerText] since [${Duration.between(currentTurnStartTime, Instant.now()).formatShort()}] ago".tr())
+            val currentTurnTime = Duration.between(currentTurnStartTime, Instant.now())
+            descriptionText.appendLine("Current Turn: [$playerText] since [${currentTurnTime.formatShort()}] ago".tr())
             descriptionText.appendLine("Time to play the turn: [${Duration.ofMinutes(currentPlayer.playerMinutesBeforeForceResign.toLong()).formatShort()}]".tr())
+            val updatedTotalTurnTime = Duration.ofSeconds(currentPlayer.totalTurnTimeSeconds.toLong()) + currentTurnTime
+            val averageTurnTime = updatedTotalTurnTime.dividedBy(currentPlayer.turnsPlayedAsHuman + 1L) // +1 to include current turn and avoid div 0
+            descriptionText.appendLine("Average turn time: [${averageTurnTime.formatShort()}]".tr())
 
             val playerCivName = preview.civilizations
                 .firstOrNull{ it.playerId == UncivGame.Current.settings.multiplayer.getUserId() }?.civName ?: "Unknown"


### PR DESCRIPTION
In the multiplayer game preview, display a player's average time spent on their turns throughout the game.

Allows MP hosts (me) to identify slowpokes without constantly monitoring the game state.
Mostly relevant in games with more than a few players.

For each Civ, it tracks the number of turns submitted as `PlayerType.Human` (& non spectator), and the total time spent on such turns.
The average time is the latter divided by the former (plus one for the current unsubmitted turn).
Consequently it is backwards compatible, as both variables default to 0. It also ensures that players who enter the game late (or have resigned and reentered) are counted properly.

<img width="813" height="188" alt="image" src="https://github.com/user-attachments/assets/c5c935da-148a-4761-969d-1c3bd6b1f106" />

Works from the first turn:
<img width="813" height="188" alt="image" src="https://github.com/user-attachments/assets/333ebebb-5e25-416e-8beb-bb5ec00ef77c" />

Backwards compatible (ongoing game where past turn times have not been counted):
<img width="813" height="188" alt="image" src="https://github.com/user-attachments/assets/ff8a097e-6aa7-4cb9-93d8-c911abc4f713" />
