### PR TITLE
TEMP Don't send for review to allow upload to google play until we solve this debacle

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -156,6 +156,7 @@ jobs:
           releaseFiles: android/build/outputs/bundle/release/Unciv-release.aab
           track: production
           whatsNewDirectory: whatsNewDirectory
+          changesNotSentForReview: true # TEMP for version 4.21.7 patches, to allow GP upload
 
 
       - name: Sign APK for Github upload


### PR DESCRIPTION
Context: https://github.com/yairm210/Unciv/actions/runs/31461671629/job/93686276375

Error: Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.

Apparently since I broke it once they won't allow autoupdates :/
Which means that their automation is also a bit broken IMO, auto-catching errors but not auto-catching fixes sounds iffy to me