### PR TITLE
Allow land/water units to be carried via Can carry

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -443,6 +443,8 @@ class MapUnit : IsPartOfGameInfoSerialization {
     fun canAttack(): Boolean {
         if (!hasMovement()) return false
         if (isCivilian()) return false
+        // Air units may attack from a carrier; land/water cargo may not
+        if (isTransported && !baseUnit.movesLikeAirUnits) return false
         return attacksThisTurn < maxAttacksPerTurn()
     }
 
@@ -602,8 +604,8 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun isTransportTypeOf(mapUnit: MapUnit): Boolean {
-        // Currently, only missiles and airplanes can be carried
-        if (!mapUnit.baseUnit.movesLikeAirUnits) return false
+        // Nested carriers are not supported (cargo would fight the carrier for the military slot)
+        if (mapUnit.hasUnique(UniqueType.CarryAirUnits)) return false
         return getMatchingUniques(UniqueType.CarryAirUnits).any { mapUnit.matchesFilter(it.params[1]) }
     }
 
@@ -1002,11 +1004,26 @@ class MapUnit : IsPartOfGameInfoSerialization {
                 throw IllegalStateException("Unit $name of ${civ.civID} at $currentTile can't be put in tile $tile, reason: ${movement.getCannotMoveToReason(tile)}")
             }
             baseUnit.movesLikeAirUnits -> tile.airUnits.add(this)
-            isCivilian() -> tile.civilianUnit = this
-            else -> tile.militaryUnit = this
+            // Land/water cargo boards the military unit on this tile — never overwrite militaryUnit/civilianUnit
+            tile.militaryUnit != null && tile.militaryUnit !== this && tile.militaryUnit!!.canTransport(this) -> {
+                tile.airUnits.add(this)
+                isTransported = true
+            }
+            isCivilian() -> {
+                if (tile.civilianUnit != null && tile.civilianUnit !== this)
+                    throw IllegalStateException("Unit $name of ${civ.civID} would overwrite civilian on $tile")
+                isTransported = false
+                tile.civilianUnit = this
+            }
+            else -> {
+                if (tile.militaryUnit != null && tile.militaryUnit !== this)
+                    throw IllegalStateException("Unit $name of ${civ.civID} would overwrite military on $tile")
+                isTransported = false
+                tile.militaryUnit = this
+            }
         }
         // this check is here in order to not load the fresh built unit into carrier right after the build
-        if (baseUnit.movesLikeAirUnits){
+        if (baseUnit.movesLikeAirUnits) {
             if (!tile.isCityCenter()) isTransported = true
             else {
                 val currentUntransportedUnits = tile.getUnits().count { it.type.isAirUnit() && !it.isTransported }

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -734,6 +734,11 @@ class UnitMovement(val unit: MapUnit) {
             && !unit.getOtherEscortUnit()!!.movement.canMoveTo(tile, assumeCanPassThrough, allowSwap, includeOtherEscortUnit = false))
             return CannotMoveToReason.EscortCannotMove
 
+        // Same idea as air units: enter a tile whose military unit can transport us (land/water cargo)
+        val carrier = tile.militaryUnit
+        if (carrier != null && carrier !== unit && carrier.canTransport(unit))
+            return null
+
         val tileIsEmpty = if (unit.isCivilian())
             (tile.civilianUnit == null || (allowSwap && tile.civilianUnit!!.owner == unit.owner))
                 && (tile.militaryUnit == null || tile.militaryUnit!!.owner == unit.owner)
@@ -741,9 +746,9 @@ class UnitMovement(val unit: MapUnit) {
         // can skip checking for airUnit since not a city
             (tile.militaryUnit == null || (allowSwap && tile.militaryUnit!!.owner == unit.owner))
                 && (tile.civilianUnit == null || tile.civilianUnit!!.owner == unit.owner || unit.civ.isAtWarWith(tile.civilianUnit!!.civ))
-        
+
         if (!tileIsEmpty) return CannotMoveToReason.TileIsNotEmpty
-        
+
         return null
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -507,7 +507,8 @@ enum class UniqueType(
     CanSeeOverObstacles("Can see over obstacles", UniqueTarget.Unit),
 
     // Carrying
-    CarryAirUnits("Can carry [amount] [mapUnitFilter] units", UniqueTarget.Unit),
+    CarryAirUnits("Can carry [amount] [mapUnitFilter] units", UniqueTarget.Unit,
+        docDescription = "Works for air units and, when the filter matches, land/water units. Non-air cargo uses the same transported slot as air units. Carriers cannot carry other carriers."),
     CarryExtraAirUnits("Can carry [amount] extra [mapUnitFilter] units", UniqueTarget.Unit, UniqueTarget.Building,
         docDescription = "For buildings, supports using `Air` for `mapUnitFilter` to increase city air unit capacity."),
     CannotBeCarriedBy("Cannot be carried by [mapUnitFilter] units", UniqueTarget.Unit),

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -419,4 +419,103 @@ class UnitMovementTests(private val pathfindingAlgorithm: PathfindingAlgorithm) 
         assertEquals(warrior1, settler2.getOtherEscortUnit())
         assertEquals(warrior2, settler1.getOtherEscortUnit())
     }
+
+    @Test
+    fun landUnitCanBoardCarrierWithoutOverwritingMilitarySlot() {
+        testGame.makeHexagonalMap(3)
+        tile = testGame.tileMap[0, 0]
+        val water = testGame.tileMap[1, 0]
+        water.baseTerrain = Constants.coast
+        water.setTransients()
+
+        val transportBase = testGame.createBaseUnit(
+            "Melee Water",
+            "Can carry [1] [Land] units"
+        ).apply {
+            movement = 4
+            strength = 10
+        }
+        val transport = testGame.addUnit(transportBase.name, civInfo, water)
+        val warrior = testGame.addUnit("Warrior", civInfo, tile)
+
+        assertTrue("Land unit should be allowed to board a matching carrier", warrior.movement.canMoveTo(water))
+        warrior.movement.moveToTile(water)
+
+        assertEquals("Carrier must keep the military slot", transport, water.militaryUnit)
+        assertTrue("Land cargo must be stored as transported", water.airUnits.contains(warrior))
+        assertTrue(warrior.isTransported)
+        assertFalse("Land cargo must not attack while carried", warrior.canAttack())
+    }
+
+    @Test
+    fun landUnitCannotEnterTileOccupiedByNonCarrierMilitary() {
+        val blocker = testGame.addUnit("Warrior", civInfo, tile)
+        val other = testGame.addUnit("Warrior", civInfo, testGame.tileMap[1, 0])
+
+        assertFalse(
+            "Military units must not enter a tile whose military slot is taken by a non-carrier",
+            other.movement.canMoveTo(tile)
+        )
+        assertEquals(blocker, tile.militaryUnit)
+    }
+
+    @Test
+    fun carrierMoveKeepsLandPayload() {
+        testGame.makeHexagonalMap(3)
+        tile = testGame.tileMap[0, 0]
+        val origin = testGame.tileMap[1, 0]
+        origin.baseTerrain = Constants.coast
+        origin.setTransients()
+        val destination = testGame.tileMap[1, 1]
+        destination.baseTerrain = Constants.coast
+        destination.setTransients()
+
+        val transportBase = testGame.createBaseUnit(
+            "Melee Water",
+            "Can carry [1] [Land] units"
+        ).apply {
+            movement = 4
+            strength = 10
+        }
+        val transport = testGame.addUnit(transportBase.name, civInfo, origin)
+        val warrior = testGame.addUnit("Warrior", civInfo, tile)
+        warrior.movement.moveToTile(origin)
+
+        assertTrue(warrior.isTransported)
+        transport.movement.moveToTile(destination)
+
+        assertEquals(destination, transport.currentTile)
+        assertEquals(destination, warrior.currentTile)
+        assertEquals(transport, destination.militaryUnit)
+        assertTrue(warrior.isTransported)
+        assertTrue(destination.airUnits.contains(warrior))
+    }
+
+    @Test
+    fun landCargoReceivesTransferMovementWhileCarried() {
+        testGame.makeHexagonalMap(3)
+        tile = testGame.tileMap[0, 0]
+        val water = testGame.tileMap[1, 0]
+        water.baseTerrain = Constants.coast
+        water.setTransients()
+
+        val transportBase = testGame.createBaseUnit(
+            "Melee Water",
+            "Can carry [1] [Land] units",
+            "Transfer Movement to [Embarked]"
+        ).apply {
+            movement = 5
+            strength = 10
+        }
+        val transport = testGame.addUnit(transportBase.name, civInfo, water)
+        val warrior = testGame.addUnit("Warrior", civInfo, tile)
+        warrior.movement.moveToTile(water)
+
+        assertTrue(warrior.isEmbarked())
+        assertEquals(
+            "Carried embarked land unit should receive Transfer Movement from the carrier",
+            transport.getMaxMovement(),
+            warrior.getMaxMovement()
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Removes the air-only restriction on `Can carry [amount] [mapUnitFilter] units` so matching land/water units can board (no new unique).
- Boarding mirrors air units: `canMoveTo` accepts a friendly carrier with capacity; `putInTile` stores cargo in the transported slot and never overwrites `militaryUnit` / `civilianUnit`.
- Nested carriers are rejected; non-air cargo cannot attack while transported.
- Existing `Transfer Movement to [Embarked]` works for carried land units on water (e.g. Longship-style escorts).

Related: builds on the approach in #14299 / #14254, focused on the tile-slot overwrite concern raised in review.

## Test plan
- [x] `UnitMovementTests` (boarding keeps carrier in military slot, non-carrier still blocks, carrier move keeps land payload, Transfer Movement while carried)
- [ ] Manual: water transport with `Can carry [1] [Land] units` — land unit boards, carrier keeps military slot, cargo follows on move
- [ ] Manual: vanilla Carrier + Fighter still works as before

Made with [Cursor](https://cursor.com)