### PR TITLE
allow spectator to select city

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/citybutton/CityButton.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/citybutton/CityButton.kt
@@ -192,7 +192,8 @@ class CityButton(val cityView: ForeignCityView, private val tileGroup: TileGroup
                 enterCityOrInfoPopup()
             } else {
                 moveButtonDown()
-                if ((unitTable.selectedUnit == null || !unitTable.selectedUnit!!.hasMovement()) && belongsToViewingCiv())
+                if ((unitTable.selectedUnit == null || !unitTable.selectedUnit!!.hasMovement())
+                        && (belongsToViewingCiv() || viewingPlayer.isSpectator()))
                     unitTable.citySelected(cityView.getCity())
             }
         }


### PR DESCRIPTION
I found while testing with the latest version that spectator clicking on a city does not select it, which was not the behavior in the previous version I was playing. This felt quite unnatural, as clicking on any units do select them as spectator. Also I checked the past changes and this behavior didn't seem intentional, hence this PR to fix it.