### PR TITLE
Hide average turn time until a full turn has been played

### DIFF
--- a/android/assets/jsons/translations/Afrikaans.properties
+++ b/android/assets/jsons/translations/Afrikaans.properties
@@ -985,6 +985,8 @@ Last refresh: [duration] ago =
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
  # Requires translation!
+Current Turn: [civName] since [duration] ago = 
+ # Requires translation!
 Seconds = 
  # Requires translation!
 Minutes = 

--- a/android/assets/jsons/translations/Bangla.properties
+++ b/android/assets/jsons/translations/Bangla.properties
@@ -795,6 +795,7 @@ The game was out of sync with the server = খেলাটি সার্ভা
 Last refresh: [duration] ago = সর্বশেষ লোডঃ [duration] আগে
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = বর্তমানে চালঃ [civName], [duration] আগে থেকে
 Seconds = সেকেন্ড
 Minutes = মিনিট
 Hours = ঘন্টা

--- a/android/assets/jsons/translations/Belarusian.properties
+++ b/android/assets/jsons/translations/Belarusian.properties
@@ -861,6 +861,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Апошняе абнаўленне: [duration] таму
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Гэты ход: [civName] з [duration] таму
 Seconds = сек.
 Minutes = мін.
 Hours = гадз.

--- a/android/assets/jsons/translations/Bosnian.properties
+++ b/android/assets/jsons/translations/Bosnian.properties
@@ -1217,6 +1217,8 @@ Last refresh: [duration] ago =
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
  # Requires translation!
+Current Turn: [civName] since [duration] ago = 
+ # Requires translation!
 Seconds = 
  # Requires translation!
 Minutes = 

--- a/android/assets/jsons/translations/Brazilian_Portuguese.properties
+++ b/android/assets/jsons/translations/Brazilian_Portuguese.properties
@@ -762,6 +762,7 @@ The game was out of sync with the server = O jogo estava dessincronizado com o s
 
 Last refresh: [duration] ago = Ultima atualização: [duration] atrás
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = Turno atual: [civName] há [duration] atrás (média: [averageDuration])
+Current Turn: [civName] since [duration] ago = Turno Atual: [civName] desde [duration] atrás
 Seconds = Segundos
 Minutes = Minutos
 Hours = Horas

--- a/android/assets/jsons/translations/Bulgarian.properties
+++ b/android/assets/jsons/translations/Bulgarian.properties
@@ -888,6 +888,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Последно опресняване: преди [duration] 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Текущ Ход: [civName] от преди [duration]
 Seconds = Секунди
 Minutes = Минути
 Hours = Часове

--- a/android/assets/jsons/translations/Catalan.properties
+++ b/android/assets/jsons/translations/Catalan.properties
@@ -765,6 +765,7 @@ The game was out of sync with the server = La partida esta dessincronitzada amb 
 Last refresh: [duration] ago = Última actualització fa [duration].
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Torn actual de [civName] des de fa [duration].
 Seconds = segons
 Minutes = minuts
 Hours = hores

--- a/android/assets/jsons/translations/Croatian.properties
+++ b/android/assets/jsons/translations/Croatian.properties
@@ -818,6 +818,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Posljednje osvježenje: prije [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Trenutačni Potez: [civName] od prije [duration]
 Seconds = Sekundi
 Minutes = Minuta
 Hours = Sati

--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -847,6 +847,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Poslední obnovení: před [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Právě na tahu: [civName] od doby před [duration]
 Seconds = sekundami
 Minutes = minutami
 Hours = hodinami

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -790,6 +790,7 @@ The game was out of sync with the server = Het spel was uit sync met de server
 Last refresh: [duration] ago = Laatste keer herladen: [duration] geleden
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Huidige beurt: [civName] sinds [duration]
 Seconds = Seconden
 Minutes = Minuten
 Hours = Uren

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -1384,6 +1384,8 @@ Last refresh: [duration] ago =
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
  # Requires translation!
+Current Turn: [civName] since [duration] ago = 
+ # Requires translation!
 Seconds = 
  # Requires translation!
 Minutes = 

--- a/android/assets/jsons/translations/Esperanto.properties
+++ b/android/assets/jsons/translations/Esperanto.properties
@@ -773,6 +773,7 @@ The game was out of sync with the server = La ludo ne plu estis sinkronigita kun
 Last refresh: [duration] ago = Lasta refreŝigo: antaŭ [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Nuna vico: [civName] ekde antaŭ [duration]
 Seconds = Sekundoj
 Minutes = Minutoj
 Hours = Horoj

--- a/android/assets/jsons/translations/Filipino.properties
+++ b/android/assets/jsons/translations/Filipino.properties
@@ -846,6 +846,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Huling pagbabago: [duration] ang nakararaan
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Kasalukuyang tira: [civName] noong [duration] ang nakararaan
 Seconds = Segundo
 Minutes = Minuto
 Hours = Oras

--- a/android/assets/jsons/translations/Finnish.properties
+++ b/android/assets/jsons/translations/Finnish.properties
@@ -913,6 +913,8 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+ # Requires translation!
+Current Turn: [civName] since [duration] ago = 
 Seconds = Sekuntia
 Minutes = Minuuttia
 Hours = Tuntia

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -764,6 +764,7 @@ The game was out of sync with the server = La partie n'est plus synchronisée av
 Last refresh: [duration] ago = Dernière actualisation : il y a [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Tours en cours : [civName] depuis [duration]
 Seconds = Secondes
 Minutes = Minutes
 Hours = Heures

--- a/android/assets/jsons/translations/Galician.properties
+++ b/android/assets/jsons/translations/Galician.properties
@@ -764,6 +764,7 @@ The game was out of sync with the server = A partida estaba desincronizada co se
 Last refresh: [duration] ago = Derradeira recarga fai: [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Quenda actual: [civName] fai [duration]
 Seconds = Segundos
 Minutes = Minutos
 Hours = Horas

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -801,6 +801,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Letzte Aktualisierung: vor [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Aktueller Zug: [civName] seit [duration] 
 Seconds = Sekunden
 Minutes = Minuten
 Hours = Stunden

--- a/android/assets/jsons/translations/Greek.properties
+++ b/android/assets/jsons/translations/Greek.properties
@@ -1168,6 +1168,8 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+ # Requires translation!
+Current Turn: [civName] since [duration] ago = 
 Seconds = Δευτερόλεπτα
 Minutes = Λεπτά
 Hours = Ώρες

--- a/android/assets/jsons/translations/Hindi.properties
+++ b/android/assets/jsons/translations/Hindi.properties
@@ -1178,6 +1178,8 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+ # Requires translation!
+Current Turn: [civName] since [duration] ago = 
 Seconds = सेकंड
 Minutes = मिनट
 Hours = घंटा/घंटे

--- a/android/assets/jsons/translations/Hungarian.properties
+++ b/android/assets/jsons/translations/Hungarian.properties
@@ -763,6 +763,7 @@ The game was out of sync with the server = A játék nem volt szinkronban a kisz
 Last refresh: [duration] ago = Legutóbbi frissítés: [duration] ezelőtt
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Jelenlegi kör: [civName] [duration] ezelőtt kezdte meg
 Seconds = Másodperc
 Minutes = Perc
 Hours = Óra

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -763,6 +763,7 @@ The game was out of sync with the server = Permainan tidak sinkron dengan pelade
 Last refresh: [duration] ago = Penyegaran terakhir: [duration] yang lalu
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Giliran Saat Ini: [civName] sejak [duration] yang lalu
 Seconds = Detik
 Minutes = Menit
 Hours = Jam

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -770,6 +770,7 @@ The game was out of sync with the server = La partita è andata fuori sincrono c
 Last refresh: [duration] ago = Ultimo aggiornamento: [duration] fa
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Turno attuale: [civName], [duration] fa
 Seconds = secondi
 Minutes = minuti
 Hours = ore

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -786,6 +786,7 @@ The game was out of sync with the server = サーバーとゲームの同期が�
 Last refresh: [duration] ago = 最終更新: [duration]前
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = 現在のターン: [civName]([duration]前-)
 Seconds = 秒
 Minutes = 数分
 Hours = 時間

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -807,6 +807,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = 최근 새로고침: [duration] 전
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = 현재 차례: [civName], [duration] 전부터
 Seconds = 초
 Minutes = 분
 Hours = 시간

--- a/android/assets/jsons/translations/Latin.properties
+++ b/android/assets/jsons/translations/Latin.properties
@@ -900,6 +900,8 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Renovatio postrema: [duration](is) ante
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+ # Requires translation!
+Current Turn: [civName] since [duration] ago = 
 Seconds = Secundæ
 Minutes = Minutæ
 Hours = Horæ

--- a/android/assets/jsons/translations/Lithuanian.properties
+++ b/android/assets/jsons/translations/Lithuanian.properties
@@ -937,6 +937,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Paskutinis atnaujinimas prieš: [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Esamas ėjimas: [civName] nuo [duration]
 Seconds = sek.
 Minutes = min.
 Hours = val.

--- a/android/assets/jsons/translations/Malay.properties
+++ b/android/assets/jsons/translations/Malay.properties
@@ -894,6 +894,8 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+ # Requires translation!
+Current Turn: [civName] since [duration] ago = 
 Seconds = Saat
 Minutes = Minit
 Hours = Jam

--- a/android/assets/jsons/translations/Maltese.properties
+++ b/android/assets/jsons/translations/Maltese.properties
@@ -801,6 +801,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = L-aħħar refresh: [duration] 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Min qed jilgħab: [civName] ilhom jilgħabu għal [duration]
 Seconds = Sekondi
 Minutes = Minuti
 Hours = Siegħat

--- a/android/assets/jsons/translations/Navajo.properties
+++ b/android/assets/jsons/translations/Navajo.properties
@@ -1267,6 +1267,8 @@ Last refresh: [duration] ago =
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
  # Requires translation!
+Current Turn: [civName] since [duration] ago = 
+ # Requires translation!
 Seconds = 
  # Requires translation!
 Minutes = 

--- a/android/assets/jsons/translations/Norwegian.properties
+++ b/android/assets/jsons/translations/Norwegian.properties
@@ -865,6 +865,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Sist oppfriska: [duration] sidan
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Noverande Tur: [civName] for [duration] sidan
 Seconds = Sekund
 Minutes = Minutt
 Hours = Timar

--- a/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
@@ -1192,6 +1192,8 @@ Last refresh: [duration] ago =
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
  # Requires translation!
+Current Turn: [civName] since [duration] ago = 
+ # Requires translation!
 Seconds = 
  # Requires translation!
 Minutes = 

--- a/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
@@ -938,6 +938,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Aakharin refresh: [duration] e pish
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Nobat e fe’li: [civName] az [duration] e pish
 Seconds = Saaniye
 Minutes = Daghighe
 Hours = Saa'at

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -770,6 +770,7 @@ The game was out of sync with the server = Gra utraciła synchronizację z serwe
 Last refresh: [duration] ago = Ostatnie odświeżanie: [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Bieżąca tura: [civName], od [duration]
 Seconds = Sekund
 Minutes = Minut
 Hours = Godzin

--- a/android/assets/jsons/translations/Portuguese.properties
+++ b/android/assets/jsons/translations/Portuguese.properties
@@ -817,6 +817,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Última atualização: [duration] atrás
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Turno Atual: [civName] desde [duration] atrás
 Seconds = Segundos
 Minutes = Minutos
 Hours = Horas

--- a/android/assets/jsons/translations/Romanian.properties
+++ b/android/assets/jsons/translations/Romanian.properties
@@ -877,6 +877,7 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = Ultima reîmprospătare: [duration] în urmă
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Turnul curent: [civName] de la [duration] în urmă
 Seconds = Secunde
 Minutes = Minute
 Hours = Ore

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -763,6 +763,7 @@ The game was out of sync with the server = Игра рассинхронизир
 Last refresh: [duration] ago = Обновлено: [duration] назад
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Текущий ход: [civName], [duration] назад
 Seconds = сек.
 Minutes = мин.
 Hours = ч.

--- a/android/assets/jsons/translations/Rusyn.properties
+++ b/android/assets/jsons/translations/Rusyn.properties
@@ -1181,6 +1181,8 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+ # Requires translation!
+Current Turn: [civName] since [duration] ago = 
 Seconds = секунды
 Minutes = минуты
 Hours = годины

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -767,6 +767,7 @@ The game was out of sync with the server = 该游戏和服务器脱钩
 Last refresh: [duration] ago = 上次刷新是在：[duration]前
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = 当前回合：[civName] 已持续[duration]
 Seconds = 秒
 Minutes = 分钟
 Hours = 小时

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -765,6 +765,7 @@ The game was out of sync with the server = La partida no estaba sincronizada con
 Last refresh: [duration] ago = Última recarga hace: [duration]
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = ⏳Turno actual: [civName] hace [duration]
 Seconds = Segundos
 Minutes = Minutos
 Hours = Horas

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -763,6 +763,7 @@ The game was out of sync with the server = Spelet var inte synkroniserat med ser
 Last refresh: [duration] ago = Sista uppdatering: [duration] sedan
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Nuvarande drag: [civName] sedan [duration]
 Seconds = Sekunder
 Minutes = Minuter
 Hours = Timmar

--- a/android/assets/jsons/translations/Thai.properties
+++ b/android/assets/jsons/translations/Thai.properties
@@ -1145,6 +1145,8 @@ The game was out of sync with the server =
 Last refresh: [duration] ago = 
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+ # Requires translation!
+Current Turn: [civName] since [duration] ago = 
 Seconds = วินาที
 Minutes = นาที
 Hours = ชั่วโมง

--- a/android/assets/jsons/translations/Toki_Pona.properties
+++ b/android/assets/jsons/translations/Toki_Pona.properties
@@ -778,6 +778,7 @@ The game was out of sync with the server = musi li sama ala poka ilo linja
 Last refresh: [duration] ago = sin nanpa pini: tenpo [duration] pini
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = tenpo musi lon: [civName]; tan tenpo [duration] pini
 Seconds = tenpo lili
 Minutes = tenpo lili suli
 Hours = tenpo suli

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -780,6 +780,7 @@ The game was out of sync with the server = 與遊戲伺服器失去同步
 Last refresh: [duration] ago = 上次刷新：[duration]前
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = 當前回合：[civName]已持續[duration]
 Seconds = 秒
 Minutes = 分鐘
 Hours = 小時

--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -784,6 +784,7 @@ The game was out of sync with the server = Oyun sunucuyla eşzamanlı değildi
 Last refresh: [duration] ago = Son yenileme: [duration] önce
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Şu Anki Tur: [duration] süredir [civName]
 Seconds = Saniye
 Minutes = Dakika
 Hours = Saat

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -789,6 +789,7 @@ The game was out of sync with the server = Гра розсинхронізува
 Last refresh: [duration] ago = Останнє оновлення: [duration] тому
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Поточний хід: [civName] вже [duration]
 Seconds = секунд
 Minutes = хвилин
 Hours = годин

--- a/android/assets/jsons/translations/Vietnamese.properties
+++ b/android/assets/jsons/translations/Vietnamese.properties
@@ -765,6 +765,7 @@ The game was out of sync with the server = Trò chơi đã không còn đồng h
 Last refresh: [duration] ago = Lần làm mới cuối cùng: [duration] trước
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = Lượt hiện tại: [civName] kể từ [duration] trước
 Seconds = Giây
 Minutes = Phút
 Hours = Giờ

--- a/android/assets/jsons/translations/Zulu.properties
+++ b/android/assets/jsons/translations/Zulu.properties
@@ -920,6 +920,8 @@ Last refresh: [duration] ago =
  # Requires translation!
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
  # Requires translation!
+Current Turn: [civName] since [duration] ago = 
+ # Requires translation!
 Seconds = 
  # Requires translation!
 Minutes = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -762,8 +762,8 @@ Could not skip turn - current player is [actualCivName], not [expectedCivName] =
 The game was out of sync with the server = 
 
 Last refresh: [duration] ago = 
-Current Turn: [civName] since [duration] ago = 
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
+Current Turn: [civName] since [duration] ago = 
 Seconds = 
 Minutes = 
 Hours = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -762,6 +762,7 @@ Could not skip turn - current player is [actualCivName], not [expectedCivName] =
 The game was out of sync with the server = 
 
 Last refresh: [duration] ago = 
+Current Turn: [civName] since [duration] ago = 
 Current Turn: [civName] since [duration] ago (average: [averageDuration]) = 
 Seconds = 
 Minutes = 

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
@@ -60,9 +60,15 @@ object MultiplayerHelpers {
                 playerText += "{ }({$playerDescriptor})"
 
             val currentTurnTime = Duration.between(currentTurnStartTime, Instant.now())
-            val updatedTotalTurnTime = Duration.ofSeconds(currentPlayer.totalTurnTimeSeconds.toLong()) + currentTurnTime
-            val averageTurnTime = updatedTotalTurnTime.dividedBy(currentPlayer.turnsPlayedAsHuman + 1L) // +1 to include current turn and avoid div by 0
-            descriptionText.appendLine("Current Turn: [$playerText] since [${currentTurnTime.formatShort()}] ago (average: [${averageTurnTime.formatShort()}])".tr())
+            var currentPlayerLine = "Current Turn: [$playerText] since [${currentTurnTime.formatShort()}] ago"
+            // Don't show average until we are sure all players have updated to compatible version
+            // This check can be removed after a few weeks/months
+            if (currentPlayer.turnsPlayedAsHuman > 0) {
+                val updatedTotalTurnTime = Duration.ofSeconds(currentPlayer.totalTurnTimeSeconds.toLong()) + currentTurnTime
+                val averageTurnTime = updatedTotalTurnTime.dividedBy(currentPlayer.turnsPlayedAsHuman + 1L) // +1 to include current turn and avoid div by 0
+                currentPlayerLine += " (average: [${averageTurnTime.formatShort()}])"
+            }
+            descriptionText.appendLine(currentPlayerLine.tr())
             descriptionText.appendLine("Time to play the turn: [${Duration.ofMinutes(currentPlayer.playerMinutesBeforeForceResign.toLong()).formatShort()}]".tr())
 
             val playerCivName = preview.civilizations


### PR DESCRIPTION
As the [average turn time](https://github.com/yairm210/Unciv/pull/15368) is calculated client side with results stored in the savefile, multiplayer games in which some players have not updated their game will cause measurements to be dropped each turn. While the displayed average is still technically correct, it may cause confusion when it does not remember past turns.

This PR offers a workaround by not displaying the average until measurements from a full turn have been collected. In such a situation, we can be confident that all players are on a compatible version (besides the case of players reinstalling an old version or using multiple devices of which some have an old version).
A more reliable alternative is to increment the compatibility version, but that can cause frustration with players using F-Droid (slower releases), and I do not consider this feature important enough to warrant such. 

As the old translation template (without the average turn time) is now displayed prior to a full turn of measurements being collected, I have also recovered the old translations. If this is not the appropriate way to do it, I can revert this commit.