### PR TITLE
Gate CityView behind own/spy/spectator and fix spectator city select

### DIFF
--- a/core/src/com/unciv/logic/civilization/NotificationActions.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationActions.kt
@@ -72,8 +72,8 @@ class CityAction(private val city: HexCoord = HexCoord.Zero) : NotificationActio
     override fun execute(worldScreen: WorldScreen) {
         val cityObject = worldScreen.mapHolder.tileMap[city].getCity()
             ?: return
-        if (cityObject.civ == worldScreen.viewingCiv)
-            worldScreen.game.pushScreen(CityScreen(worldScreen.selectedGameView.getCityView(cityObject)))
+        val cityView = worldScreen.selectedGameView.tryGetCityView(cityObject) ?: return
+        worldScreen.game.pushScreen(CityScreen(cityView))
     }
     companion object {
         fun withLocation(city: City) = listOf(LocationAction(city.location), CityAction(city.location))

--- a/core/src/com/unciv/ui/components/tilegroups/citybutton/CityButton.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/citybutton/CityButton.kt
@@ -21,7 +21,6 @@ import com.unciv.ui.screens.cityscreen.CityReligionInfoTable
 import com.unciv.ui.screens.cityscreen.CityScreen
 import com.unciv.view.ForeignCityView
 import com.unciv.ui.screens.diplomacyscreen.DiplomacyScreen
-import yairm210.purity.annotations.Readonly
 
 /**
  *  The city "button" with decorations on the WorldScreen map.
@@ -55,8 +54,6 @@ class CityButton(val foreignCityView: ForeignCityView, private val tileGroup: Ti
     private var isViewable = true
 
     val viewingPlayer = foreignCityView.getViewingCiv()
-
-    @Readonly private fun belongsToViewingCiv() = foreignCityView.belongsTo(viewingPlayer)
 
     fun update(isCityViewable: Boolean) {
         val selectedPlayer = GUI.getSelectedPlayer()
@@ -173,8 +170,7 @@ class CityButton(val foreignCityView: ForeignCityView, private val tileGroup: Ti
         touchable = Touchable.childrenOnly
 
         fun enterCityOrInfoPopup() {
-            // second tap on the button will go to the city screen
-            // if this city belongs to you and you are not iterating though the air units
+            // second tap opens CityScreen when we can see internals (own / spy / spectator)
             val cityView = foreignCityView.tryGetCityView()
             val isIteratingUnits = tileGroup.tileView.getVisibleUnits().none { it.getUnit() == unitTable.selectedUnit }
             if (cityView != null && isIteratingUnits)
@@ -190,7 +186,8 @@ class CityButton(val foreignCityView: ForeignCityView, private val tileGroup: Ti
                 enterCityOrInfoPopup()
             } else {
                 moveButtonDown()
-                if ((unitTable.selectedUnit == null || !unitTable.selectedUnit!!.hasMovement()) && belongsToViewingCiv())
+                if ((unitTable.selectedUnit == null || !unitTable.selectedUnit!!.hasMovement())
+                        && foreignCityView.canSelectOnMap())
                     unitTable.citySelected(foreignCityView.getCity())
             }
         }
@@ -242,7 +239,10 @@ class CityButton(val foreignCityView: ForeignCityView, private val tileGroup: Ti
             if (foreignCityView.isReligionEnabled())
                 add(CityReligionInfoTable(foreignCityView.getReligionManager(), true)).colspan(3).row()
             addOKButton("Diplomacy") { openDiplomacy() }
-            if (espionageVisible) addButton("View") { GUI.pushScreen(CityScreen(GUI.getWorldScreen().selectedGameView.getCityView(foreignCityView.getCity()))) }
+            if (espionageVisible) addButton("View") {
+                val cityView = foreignCityView.tryGetCityView() ?: return@addButton
+                GUI.pushScreen(CityScreen(cityView))
+            }
             add().expandX()
             addCloseButton {
                 GUI.getWorldScreen().run { nextTurnButton.update() }

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreenTileTable.kt
@@ -108,10 +108,13 @@ class CityScreenTileTable(private val cityScreen: CityScreen) : Table() {
 
         if (tileView.isCityCenter()) {
             val otherCity = tileView.owningCity()
-            if (otherCity != null && otherCity != cityView && otherCity.isSameCivAs(cityView) && !cityScreen.isSpying)
-                innerTable.add("Move to city".toTextButton().onClick { cityScreen.game.replaceCurrentScreen(
-                    CityScreen(cityView.gameView.getCityView(otherCity.getCity()))
-                ) })
+            if (otherCity != null && otherCity != cityView && otherCity.isSameCivAs(cityView) && !cityScreen.isSpying) {
+                val otherCityView = otherCity.tryGetCityView()
+                if (otherCityView != null)
+                    innerTable.add("Move to city".toTextButton().onClick {
+                        cityScreen.game.replaceCurrentScreen(CityScreen(otherCityView))
+                    })
+            }
         }
 
         innerTable.pack()

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -47,7 +47,8 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
         override fun getEntryActor(item: City, iconSize: Float, actionContext: EmpireOverviewScreen) =
                 item.name.toTextButton(hideIcons = true)
                 .onClick {
-                    actionContext.game.pushScreen(CityScreen(GUI.getWorldScreen().selectedGameView.getCityView(item)))
+                    val cityView = GUI.getWorldScreen().selectedGameView.tryGetCityView(item) ?: return@onClick
+                    actionContext.game.pushScreen(CityScreen(cityView))
                 }
         override fun getTotalsActor(items: Iterable<City>) = "{Total} ${items.count()}".toLabel()
     },

--- a/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
@@ -114,7 +114,8 @@ class ImprovementPickerScreen(
         } else if (tile.getOwner()!!.isCurrentPlayer()) {
             val button = tile.getCity()!!.name.toTextButton(hideIcons = true)
             button.onClick {
-                val cityView = GUI.getWorldScreen().selectedGameView.getCityView(tile.getCity()!!)
+                val city = tile.getCity() ?: return@onClick
+                val cityView = GUI.getWorldScreen().selectedGameView.tryGetCityView(city) ?: return@onClick
                 this.game.pushScreen(CityScreen(cityView, null, cityView.tileView(tile)))
             }
             val label = "Tile owned by [${tile.getOwner()!!.civName}] (You)".toLabel()

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -292,8 +292,10 @@ class WorldScreen(
         globalShortcuts.add(KeyboardBinding.QuickLoad) { QuickSave.load(this) }
         globalShortcuts.add(KeyboardBinding.ViewCapitalCity) {
             val capital = gameInfo.getCurrentPlayerCivilization().getCapital()
-            if (capital != null && !mapHolder.setCenterPosition(capital.location.toHexCoord()))
-                game.pushScreen(CityScreen(selectedGameView.getCityView(capital)))
+            if (capital != null && !mapHolder.setCenterPosition(capital.location.toHexCoord())) {
+                val cityView = selectedGameView.tryGetCityView(capital) ?: return@add
+                game.pushScreen(CityScreen(cityView))
+            }
         }
         globalShortcuts.add(KeyboardBinding.Options) { // Game Options
             openOptionsPopup { nextTurnButton.update() }

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnAction.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnAction.kt
@@ -56,7 +56,8 @@ enum class NextTurnAction(protected val text: String, val color: Color) {
             getCityWithNoProductionSet(worldScreen) != null
         override fun action(worldScreen: WorldScreen) {
             val city = getCityWithNoProductionSet(worldScreen) ?: return
-            worldScreen.game.pushScreen(CityScreen(worldScreen.selectedGameView.getCityView(city)))
+            val cityView = worldScreen.selectedGameView.tryGetCityView(city) ?: return
+            worldScreen.game.pushScreen(CityScreen(cityView))
         }
     },
     PickTech("Pick a tech", Color.SKY) {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -250,12 +250,11 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
         }
 
 
-        val isCitySelected = selectedTile.isCityCenter()
-            && (selectedTile.getOwner() == worldScreen.viewingCiv || worldScreen.viewingCiv.isSpectator())
-            && !selectedUnitIsConnectingRoad
+        val city = selectedTile.getCity()
         when {
             forceSelectUnit != null -> selectUnit(forceSelectUnit)
-            isCitySelected -> citySelected(selectedTile.getCity()!!)
+            city != null && worldScreen.selectedGameView.getForeignCityView(city).canSelectOnMap()
+                    && !selectedUnitIsConnectingRoad -> citySelected(city)
             nextUnit != null -> selectUnit(nextUnit, Gdx.input.isShiftKeyPressed())
             // toggle selection if same unit is clicked again by player
             selectedTile == previouslySelectedUnit?.currentTile -> {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/presenter/CityPresenter.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/presenter/CityPresenter.kt
@@ -41,9 +41,10 @@ class CityPresenter(private val unitTable: UnitTable, private val unitPresenter:
             unitNameLabel.clearListeners()
             unitNameLabel.onClick {
                 if (!worldScreen.canChangeState) return@onClick
+                val cityView = city.tryGetCityView() ?: return@onClick
                 CityRenamePopup(
                     screen = worldScreen,
-                    cityView = worldScreen.selectedGameView.getCityView(city.getCity()),
+                    cityView = cityView,
                     actionOnClose = {
                         unitNameLabel.setText(city.name.tr())
                         worldScreen.shouldUpdate = true

--- a/core/src/com/unciv/view/CityView.kt
+++ b/core/src/com/unciv/view/CityView.kt
@@ -31,6 +31,10 @@ class CityView(city: City,
                viewer: Civilization,
                spectatorMode: Boolean = false,
                override val gameView: GameView) : ForeignCityView(city, viewer, spectatorMode, gameView) {
+    init {
+        require(canSeeInternals()) { "CityView is only for cities we can see internals of" }
+    }
+
     // Navigation
     /** The viewing player's full CivView (always a self-view). For the city's owning civ, use [owningCiv]. */
     @Readonly fun viewingCiv(): CivView = gameView.civView

--- a/core/src/com/unciv/view/ForeignCityView.kt
+++ b/core/src/com/unciv/view/ForeignCityView.kt
@@ -27,13 +27,19 @@ open class ForeignCityView(internal open val city: City,
     @Readonly fun getViewingCiv(): Civilization = viewer
     /** The owning civ of this city, as visible from [viewer]'s perspective. For the viewing player's full CivView, use [CityView.viewingCiv]. */
     @Readonly open fun owningCiv(): ForeignCivView = ForeignCivView(city.civ, viewer, spectatorMode)
-    /** Get from a foreign view to an inner view */
+    /** Own / spy / spectator (or debug reveal) — required to construct [CityView]. */
+    @Readonly fun canSeeInternals(): Boolean =
+        viewer.isSpectator() // not posing, actual spectator
+            || city.civ == viewer
+            || spyIsSetUpAtCity(viewer)
+            || DebugUtils.VISIBLE_MAP
+
+    /** Own cities, or any city when spectating — WorldScreen unit-table selection (not spy-view). */
+    @Readonly fun canSelectOnMap(): Boolean = city.civ === viewer || viewer.isSpectator()
+
+    /** Get from a foreign view to an inner view, or null if [canSeeInternals] is false. */
     @Readonly fun tryGetCityView(): CityView? {
-        val canSeeCityData = viewer.isSpectator() // not posing, actual spectator
-                || city.civ == viewer
-                || spyIsSetUpAtCity(viewer)
-                || DebugUtils.VISIBLE_MAP
-        if (!canSeeCityData) return null
+        if (!canSeeInternals()) return null
         return gameView.getCityView(city)
     }
 

--- a/core/src/com/unciv/view/GameView.kt
+++ b/core/src/com/unciv/view/GameView.kt
@@ -14,7 +14,9 @@ class GameView(gameInfo: GameInfo, internal val viewer: Civilization, val specta
     // Navigation
     // These can be cached in the future if we see a need, for now - simplicity
     @Readonly fun getCivView(civ: Civilization): CivView = CivView(civ, viewer, spectatorMode, this)
+    /** Unchecked factory — throws if the viewer cannot see this city's internals. Prefer [tryGetCityView]. */
     @Readonly fun getCityView(city: City): CityView = CityView(city, viewer, spectatorMode, this)
+    @Readonly fun tryGetCityView(city: City): CityView? = getForeignCityView(city).tryGetCityView()
     @Readonly fun getForeignCityView(city: City): ForeignCityView = ForeignCityView(city, viewer, spectatorMode, this)
 
     // Data retrieval


### PR DESCRIPTION
## Summary
- Follow-up to the review on closed #15376 and the `tryGetCityView` work in #15280. Replaces #15387 (rebased onto current master after further CityScreen/TileView migration).
- `CityView` can only be constructed when the viewer owns the city, has a set-up spy there, or is a spectator (`require(canSeeInternals())`). UI opens `CityScreen` through `tryGetCityView` / `GameView.tryGetCityView`, so an unauthorized `CityScreen` cannot be created.
- Spectator city **selection** on the map (first click / tile click, like units) uses `ForeignCityView.canSelectOnMap()` instead of an `isSpectator()` special-case in `CityButton`. Spies still cannot select a foreign city as the WorldScreen attacker (bombard), only open it via `tryGetCityView`.

## Test plan
- [ ] As spectator, first-click a city button: city is selected in the unit table (name, strength, bombard stats)
- [ ] Second-click / right-click: `CityScreen` opens
- [ ] Click the city tile (not the button): same selection as own-civ click-to-select
- [ ] As a normal player, own cities still select and open as before
- [ ] Foreign city without a set-up spy: no `CityScreen`, diplomacy/info popup as before
- [ ] Set-up spy: `View` / second click opens `CityScreen`; first click does **not** select that city for bombard
- [ ] Notification / overview / capital hotkey / improvement picker city links still open `CityScreen` for allowed cities only (picker uses `cityView.tileView(tile)`)