### PR TITLE
Avoid selling spaceship parts for resource

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -384,7 +384,7 @@ object NextTurnAutomation {
             if (civInfo.getResourceAmount(resource) >= 2) continue
 
             val unitToDisband = civInfo.units.getCivUnits()
-                .filter { it.requiresResource(resource) }
+                .filter { it.requiresResource(resource) && !it.hasUnique(UniqueType.SpaceshipPart) }
                 .minByOrNull { it.getForceEvaluation() }
             unitToDisband?.disband()
             sellBuildingForResource(civInfo, resource)


### PR DESCRIPTION
When building spaceship parts the AI can sell units and buildings to free up aluminium. But it doesn't check what the sold unit is, so it could end up selling spaceship parts to build spaceship parts.

Some sanity check with simulations:
3200 games, 2 players, Prince, Map SIze Small.
52.5% win rate with fix, p=0.0023.
Also made it log spaceship unit disbandment (example: "SS-PART-DISBAND: nation2 disbands finished SS Stasis Chamber on turn 258"), got 2229 hits in 3600 games, so I suppose this is a real problem.

Full log:
[avoid_sell_spaceship_part.log](https://github.com/user-attachments/files/31057270/avoid_sell_spaceship_part.log)
