### PR TITLE
Add Can melee attack unique for hybrid melee/ranged units

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -6,7 +6,6 @@ import com.unciv.logic.battle.BattleDamage
 import com.unciv.logic.battle.CityCombatant
 import com.unciv.logic.battle.MapUnitCombatant
 import com.unciv.logic.battle.TargetHelper
-import com.unciv.logic.city.City
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
@@ -24,7 +23,7 @@ object BattleHelper {
                 val defender = Battle.getMapCombatantOfTile(it.tileToAttack)
                 unit.hasUnique(UniqueType.SelfDestructs) || (defender != null &&
                 (BattleDamage.calculateDamageToAttacker(
-                    MapUnitCombatant(unit),
+                    MapUnitCombatant(unit, it.isRangedAttack),
                     defender) < unit.health
                     && unit.getDamageFromTerrain(it.tileToAttackFrom) <= 0))
                     // For mounted units it is fine to attack from these tiles, but with current AI movement logic it is not easy to determine if our unit can meaningfully move away after attacking
@@ -34,7 +33,7 @@ object BattleHelper {
         val enemyTileToAttack = chooseAttackTarget(unit, attackableEnemies)
 
         if (enemyTileToAttack != null) {
-            if (enemyTileToAttack.tileToAttack.militaryUnit == null && unit.baseUnit.isRanged()
+            if (enemyTileToAttack.tileToAttack.militaryUnit == null && enemyTileToAttack.isRangedAttack
                 && unit.movement.canMoveTo(enemyTileToAttack.tileToAttack)
                 && distanceToTiles.containsKey(enemyTileToAttack.tileToAttack)) { // Since the 'getAttackableEnemies' could return a tile we attack at range but cannot reach
                 // Ranged units should move to caputre a civilian unit instead of attacking it
@@ -47,14 +46,14 @@ object BattleHelper {
     }
 
     fun tryDisembarkUnitToAttackPosition(unit: MapUnit): Boolean {
-        if (!unit.baseUnit.isMelee() || !unit.baseUnit.isLandUnit || !unit.isEmbarked()) return false
+        if (!unit.canMeleeAttack() || !unit.baseUnit.isLandUnit || !unit.isEmbarked()) return false
         val unitDistanceToTiles = unit.movement.getDistanceToTiles()
 
         val attackableEnemiesNextTurn = TargetHelper.getAttackableEnemies(unit, unitDistanceToTiles)
                 // Only take enemies we can fight without dying
                 .filter {
                     BattleDamage.calculateDamageToAttacker(
-                        MapUnitCombatant(unit),
+                        MapUnitCombatant(unit, it.isRangedAttack),
                         Battle.getMapCombatantOfTile(it.tileToAttack)!!
                     ) < unit.health
                 }
@@ -80,7 +79,7 @@ object BattleHelper {
         // We always have to calculate the attack value even if there is only one attackableEnemy
         for (attackableEnemy in attackableEnemies) {
             val tempAttackValue = if (attackableEnemy.tileToAttack.isCityCenter())
-                getCityAttackValue(unit, attackableEnemy.tileToAttack.getCity()!!)
+                getCityAttackValue(unit, attackableEnemy)
             else getUnitAttackValue(unit, attackableEnemy)
             if (tempAttackValue > highestAttackValue) {
                 highestAttackValue = tempAttackValue
@@ -98,11 +97,12 @@ object BattleHelper {
      * Base value is 100(Mele) 110(Ranged) standard deviation is around 80 to 130
      */
     @Readonly
-    private fun getCityAttackValue(attacker: MapUnit, city: City): Int {
-        val attackerUnit = MapUnitCombatant(attacker)
+    private fun getCityAttackValue(attacker: MapUnit, attackTile: AttackableTile): Int {
+        val city = attackTile.tileToAttack.getCity()!!
+        val attackerUnit = MapUnitCombatant(attacker, attackTile.isRangedAttack)
         val cityUnit = CityCombatant(city)
         
-        val canCaptureCity = attacker.baseUnit.isMelee() && !attacker.hasUnique(UniqueType.CannotCaptureCities)
+        val canCaptureCity = !attackTile.isRangedAttack && attacker.canMeleeAttack() && !attacker.hasUnique(UniqueType.CannotCaptureCities)
         if (city.health == 1)
             return if (canCaptureCity) 10000 // Capture the city immediately!
             else 0 // No reason to attack, we won't make any difference
@@ -111,7 +111,7 @@ object BattleHelper {
             return 10000
             
 
-        if (attacker.baseUnit.isMelee()) {
+        if (!attackTile.isRangedAttack) {
             val battleDamage = BattleDamage.calculateDamageToAttacker(attackerUnit, cityUnit)
             if (attacker.health - battleDamage * 2 <= 0 && !attacker.hasUnique(UniqueType.SelfDestructs)) {
                 // The more fiendly units around the city, the more willing we should be to just attack the city
@@ -129,7 +129,7 @@ object BattleHelper {
         // Siege units should really only attack the city
         if (attacker.baseUnit.isProbablySiegeUnit()) attackValue += 100
         // Ranged units don't take damage from the city
-        else if (attacker.baseUnit.isRanged()) attackValue += 10
+        else if (attackTile.isRangedAttack) attackValue += 10
         // Lower health cities have a higher priority to attack ranges from -20 to 30
         attackValue -= (city.health - 60) / 2
 
@@ -160,16 +160,19 @@ object BattleHelper {
         val civilianUnit = attackTile.tileToAttack.civilianUnit
         if (militaryUnit != null) {
             attackValue = 200 - militaryUnit.health + // continuously prioritise lower-health units
-                BattleDamage.calculateDamageToDefender(MapUnitCombatant(attacker), MapUnitCombatant(militaryUnit))
+                BattleDamage.calculateDamageToDefender(
+                    MapUnitCombatant(attacker, attackTile.isRangedAttack),
+                    MapUnitCombatant(militaryUnit)
+                )
         } else if (civilianUnit != null) {
             attackValue = 50
             // Only melee units should really attack/capture civilian units, ranged units may be able to capture by moving
-            if (attacker.baseUnit.isMelee() || attacker.movement.canReachInCurrentTurn(attackTile.tileToAttack)) {
+            if (!attackTile.isRangedAttack || attacker.movement.canReachInCurrentTurn(attackTile.tileToAttack)) {
                 if (civilianUnit.isGreatPerson()) {
                     attackValue += 150
                 }
                 if (civilianUnit.hasUnique(UniqueType.FoundCity, GameContext.IgnoreConditionals)) attackValue += 60
-            } else if (attacker.baseUnit.isRanged() && !civilianUnit.hasUnique(UniqueType.Uncapturable)) {
+            } else if (!civilianUnit.hasUnique(UniqueType.Uncapturable)) {
                 return 10 // Don't shoot civilians that we can capture!
             }
         }

--- a/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
@@ -46,7 +46,7 @@ object HeadTowardsEnemyCityAutomation {
             .asSequence().filterNot { it.value > 10 } // anything 10 tiles away from the target is irrelevant
             .sortedBy { it.value }.map { it.key } // sort the list by closeness to target - least is best!
 
-        if (unit.baseUnit.isRanged()) // ranged units don't harm capturable cities, waste of a turn
+        if (unit.baseUnit.isRanged() && !unit.canMeleeAttack()) // ranged units don't harm capturable cities, waste of a turn
             enemyCitiesByPriority = enemyCitiesByPriority.filterNot { it.health == 1 }
 
         return enemyCitiesByPriority

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -488,11 +488,14 @@ object UnitAutomation {
                 unit.getMaxMovement() * CLOSE_ENEMY_TURNS_AWAY_LIMIT
         )
         val closeEnemy = TargetHelper.getAttackableEnemies(unit, unitDistanceToTiles, tilesToCheck = unit.getTile().getTilesInDistance(CLOSE_ENEMY_TILES_AWAY_LIMIT).toList())
-            .filterNot { unit.baseUnit.isRanged() && it.tileToAttack.isCityCenter() && it.tileToAttack.getCity()!!.health == 1 } // occurs fairly often probably because AI dumb
+            .filterNot { it.isRangedAttack && it.tileToAttack.isCityCenter() && it.tileToAttack.getCity()!!.health == 1 } // occurs fairly often probably because AI dumb
             .filter { unit.getDamageFromTerrain(it.tileToAttackFrom) <= 0 }  // Don't attack from a mountain or near enemy citadels
             .filter {
             // Ignore units that would 1-shot you if you attacked
-            BattleDamage.calculateDamageToAttacker(MapUnitCombatant(unit), Battle.getMapCombatantOfTile(it.tileToAttack)!!) < unit.health }
+            BattleDamage.calculateDamageToAttacker(
+                MapUnitCombatant(unit, it.isRangedAttack),
+                Battle.getMapCombatantOfTile(it.tileToAttack)!!
+            ) < unit.health }
             .minByOrNull { it.tileToAttack.aerialDistanceTo(unit.getTile()) }
 
         if (closeEnemy != null) {
@@ -615,7 +618,7 @@ object UnitAutomation {
                 } //Most likely just been captured
 
 
-        if (unit.baseUnit.isRanged()) // ranged units don't harm capturable cities, waste of a turn
+        if (unit.baseUnit.isRanged() && !unit.canMeleeAttack()) // ranged units don't harm capturable cities, waste of a turn
             capturedCities = capturedCities.filterNot { it.health == 1 }
 
         val closestReachableCapturedCity = capturedCities

--- a/core/src/com/unciv/logic/battle/AttackableTile.kt
+++ b/core/src/com/unciv/logic/battle/AttackableTile.kt
@@ -6,5 +6,7 @@ data class AttackableTile(
     val tileToAttackFrom: Tile,
     val tileToAttack: Tile,
     val movementLeftAfterMovingToAttackTile: Float,
-    val combatant: ICombatant?
+    val combatant: ICombatant?,
+    /** True when this specific attack uses ranged combat rules. Hybrid melee/ranged units set this per target. */
+    val isRangedAttack: Boolean = false
 )

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -65,7 +65,8 @@ object Battle {
         if (combatant == null || combatant.getCivInfo() == attacker.getCivInfo()) return false
         /** Alternatively, maybe we DID reach that tile, but it turned out to be a hill or something,
          * so we expended all of our movement points! */
-        if (attacker.hasUnique(UniqueType.MustSetUp)
+        if (attackableTile.isRangedAttack
+                && attacker.hasUnique(UniqueType.MustSetUp)
                 && !attacker.unit.isSetUpForSiege()
                 && attacker.unit.hasMovement()
         ) {
@@ -92,11 +93,14 @@ object Battle {
      * This is meant to be called only after all prerequisite checks have been done.
      */
     fun attackOrNuke(attacker: ICombatant, attackableTile: AttackableTile): DamageDealt {
-        return if (attacker is MapUnitCombatant && attacker.unit.isNuclearWeapon()) {
-            Nuke.NUKE(attacker, attackableTile.tileToAttack)
+        val attackingCombatant =
+            if (attacker is MapUnitCombatant) MapUnitCombatant(attacker.unit, attackableTile.isRangedAttack)
+            else attacker
+        return if (attackingCombatant is MapUnitCombatant && attackingCombatant.unit.isNuclearWeapon()) {
+            Nuke.NUKE(attackingCombatant, attackableTile.tileToAttack)
             DamageDealt.None
         } else {
-            attack(attacker, getMapCombatantOfTile(attackableTile.tileToAttack)!!)
+            attack(attackingCombatant, getMapCombatantOfTile(attackableTile.tileToAttack)!!)
         }
     }
 

--- a/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
+++ b/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
@@ -10,7 +10,11 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.UnitType
 import yairm210.purity.annotations.Readonly
 
-class MapUnitCombatant(val unit: MapUnit) : ICombatant {
+class MapUnitCombatant(
+    val unit: MapUnit,
+    /** When set, this combatant is attacking as ranged or melee regardless of [com.unciv.models.ruleset.unit.BaseUnit.isRanged]. */
+    val attackAsRanged: Boolean? = null
+) : ICombatant {
     override fun getHealth(): Int = unit.health
     override fun getMaxHealth() = 100
     override fun getCivInfo(): Civilization = unit.civ
@@ -34,6 +38,9 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
 
 
     override fun takeDamage(damage: Int) = unit.takeDamage(damage)
+
+    @Readonly
+    override fun isRanged(): Boolean = attackAsRanged ?: unit.baseUnit.isRanged()
 
     override fun getAttackingStrength(defender: ICombatant?): Int {
         val state = GameContext(this, defender, this.getTile(), CombatAction.Attack)

--- a/core/src/com/unciv/logic/battle/TargetHelper.kt
+++ b/core/src/com/unciv/logic/battle/TargetHelper.kt
@@ -18,28 +18,79 @@ object TargetHelper {
         tilesToCheck: List<Tile>? = null,
         stayOnTile: Boolean = false
     ): ArrayList<AttackableTile> = timeThis("getAttackableEnemies") {
-        val rangeOfAttack = unit.getRange()
         val attackableTiles = ArrayList<AttackableTile>()
+        if (unit.canMeleeAttack())
+            for (tile in collectAttackableEnemies(unit, unitDistanceToTiles, tilesToCheck, stayOnTile, isRangedAttack = false))
+                attackableTiles += tile
+        if (unit.baseUnit.isRanged())
+            for (tile in collectAttackableEnemies(unit, unitDistanceToTiles, tilesToCheck, stayOnTile, isRangedAttack = true))
+                attackableTiles += tile
+        return attackableTiles
+    }
 
-        val unitMustBeSetUp = unit.hasUnique(UniqueType.MustSetUp)
+    /**
+     * Picks one [AttackableTile] when several exist for the same target
+     * (hybrid melee+ranged units). Prefers capturing a 1-HP city, then attacking
+     * from the current tile, then ranged (no return damage).
+     */
+    @Readonly
+    fun chooseAttackableTileAgainst(
+        unit: MapUnit,
+        tile: Tile,
+        attackableEnemies: List<AttackableTile>
+    ): AttackableTile? {
+        val candidates = attackableEnemies.filter { it.tileToAttack == tile }
+        if (candidates.size <= 1) return candidates.firstOrNull()
+        return candidates.minWithOrNull(preferredAttackComparator(unit))
+    }
+
+    @Readonly
+    fun preferredAttackableEnemies(unit: MapUnit, attackableEnemies: List<AttackableTile>): List<AttackableTile> =
+        attackableEnemies.groupBy { it.tileToAttack }.mapNotNull { (tile, tiles) ->
+            chooseAttackableTileAgainst(unit, tile, tiles)
+        }
+
+    @Readonly
+    private fun preferredAttackComparator(unit: MapUnit) = compareBy<AttackableTile>(
+        { attack ->
+            val city = attack.tileToAttack.getCity()
+            if (city != null && city.health == 1 && !attack.isRangedAttack) 0 else 1
+        },
+        { if (it.tileToAttackFrom == unit.currentTile) 0 else 1 },
+        { if (it.isRangedAttack) 0 else 1 },
+        { -it.movementLeftAfterMovingToAttackTile }
+    )
+
+    @Readonly
+    private fun collectAttackableEnemies(
+        unit: MapUnit,
+        unitDistanceToTiles: PathsToTilesWithinTurn,
+        tilesToCheck: List<Tile>?,
+        stayOnTile: Boolean,
+        isRangedAttack: Boolean
+    ): ArrayList<AttackableTile> {
+        val attackableTiles = ArrayList<AttackableTile>()
+        val rangeOfAttack = unit.getRange()
+        val unitMustBeSetUp = isRangedAttack && unit.hasUnique(UniqueType.MustSetUp)
         val tilesToAttackFrom = if (stayOnTile || unit.baseUnit.movesLikeAirUnits)
             sequenceOf(Pair(unit.currentTile, unit.currentMovement))
         else getTilesToAttackFromWhenUnitMoves(unitDistanceToTiles, unitMustBeSetUp, unit)
 
+        val skipAdjacentRanged = isRangedAttack && unit.canMeleeAttack()
         val tilesWithEnemies: HashSet<Tile> = HashSet()
         val tilesWithoutEnemies: HashSet<Tile> = HashSet()
         for ((reachableTile, movementLeft) in tilesToAttackFrom) {  // tiles we'll still have energy after we reach there
             // If we are a melee unit that is escorting, we only want to be able to attack from this
             // tile if the escorted unit can also move into the tile we are attacking if we kill the enemy unit.
-            if (unit.baseUnit.isMelee() && unit.isEscorting()) {
+            if (!isRangedAttack && unit.isEscorting()) {
                 val escortingUnit = unit.getOtherEscortUnit()!!
                 if (!escortingUnit.movement.canReachInCurrentTurn(reachableTile)
-                    || escortingUnit.currentMovement - escortingUnit.movement.getDistanceToTiles()[reachableTile]!!.totalMovement <= 0f) 
+                    || escortingUnit.currentMovement - escortingUnit.movement.getDistanceToTiles()[reachableTile]!!.totalMovement <= 0f)
                     continue
             }
 
             val tilesInAttackRange =
-                if (unit.baseUnit.isMelee()) reachableTile.neighbors
+                if (!isRangedAttack) reachableTile.neighbors
                 else if (unit.baseUnit.movesLikeAirUnits || unit.hasUnique(UniqueType.IndirectFire, checkCivInfoUniques = true))
                     reachableTile.getTilesInDistance(rangeOfAttack)
                 else reachableTile.tileMap.getViewableTiles(reachableTile.position, rangeOfAttack, true).asSequence()
@@ -49,19 +100,23 @@ object TargetHelper {
                     // Since military units can technically enter tiles with enemy civilians,
                     // some try to move to to the tile and then attack the unit it contains, which is silly
                     tile == reachableTile -> continue
+                    skipAdjacentRanged && (tile.aerialDistanceTo(reachableTile) <= 1
+                        || tile.aerialDistanceTo(unit.currentTile) <= 1) -> continue
 
                     tile in tilesWithEnemies -> attackableTiles += AttackableTile(
                         reachableTile,
                         tile,
                         movementLeft,
-                        Battle.getMapCombatantOfTile(tile)
+                        Battle.getMapCombatantOfTile(tile),
+                        isRangedAttack
                     )
                     tile in tilesWithoutEnemies -> continue // avoid checking the same empty tile multiple times
-                    tileContainsAttackableEnemy(unit, tile, tilesToCheck) || unit.isPreparingAirSweep() -> {
+                    tileContainsAttackableEnemy(unit, tile, tilesToCheck, isRangedAttack) || unit.isPreparingAirSweep() -> {
                         tilesWithEnemies += tile
                         attackableTiles += AttackableTile(
                             reachableTile, tile, movementLeft,
-                            Battle.getMapCombatantOfTile(tile)
+                            Battle.getMapCombatantOfTile(tile),
+                            isRangedAttack
                         )
                     }
                     else -> tilesWithoutEnemies += tile
@@ -92,12 +147,18 @@ object TargetHelper {
             }
 
     @Readonly
-    private fun tileContainsAttackableEnemy(unit: MapUnit, tile: Tile, tilesToCheck: List<Tile>?): Boolean {
-        if (tile !in (tilesToCheck ?: unit.civ.viewableTiles) || !containsAttackableEnemy(tile, MapUnitCombatant(unit)) )
+    private fun tileContainsAttackableEnemy(
+        unit: MapUnit,
+        tile: Tile,
+        tilesToCheck: List<Tile>?,
+        isRangedAttack: Boolean
+    ): Boolean {
+        if (tile !in (tilesToCheck ?: unit.civ.viewableTiles) ||
+            !containsAttackableEnemy(tile, MapUnitCombatant(unit, isRangedAttack)))
             return false
         val mapCombatant = Battle.getMapCombatantOfTile(tile)
 
-        return (!unit.baseUnit.isMelee() || mapCombatant !is MapUnitCombatant || !mapCombatant.unit.isCivilian() || unit.movement.canPassThrough(tile))
+        return (isRangedAttack || mapCombatant !is MapUnitCombatant || !mapCombatant.unit.isCivilian() || unit.movement.canPassThrough(tile))
     }
 
     @Readonly

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -446,6 +446,10 @@ class MapUnit : IsPartOfGameInfoSerialization {
         return attacksThisTurn < maxAttacksPerTurn()
     }
 
+    /** True if this unit can perform a melee attack (pure melee, or ranged with [UniqueType.CanMeleeAttack]). */
+    @Readonly
+    fun canMeleeAttack() = baseUnit.strength > 0 && (baseUnit.isMelee() || hasUnique(UniqueType.CanMeleeAttack))
+
     @Readonly
     fun getRange(): Int {
         if (baseUnit.isMelee()) return 1

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -464,6 +464,8 @@ enum class UniqueType(
     CanOnlyAttackTiles("Can only attack [tileFilter] tiles", UniqueTarget.Unit),
     CannotAttack("Cannot attack", UniqueTarget.Unit),
     MustSetUp("Must set up to ranged attack", UniqueTarget.Unit),
+    CanMeleeAttack("Can melee attack", UniqueTarget.Unit,
+        docDescription = "Allows a ranged unit to also melee attack: attack after moving, deal and take melee damage, and capture cities. Adjacent targets are attacked as melee; more distant targets in range are attacked as ranged. Combine with `Must set up to ranged attack` to require setup only for the ranged attack."),
     SelfDestructs("Self-destructs when attacking", UniqueTarget.Unit),
 
     // Attack unrestrictions

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
@@ -82,14 +82,22 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
             else -> {
                 val defender = tryGetDefender() ?: return hide()
                 if (attacker is CityCombatant && defender is CityCombatant) return hide()
-                val tileToAttackFrom = if (attacker is MapUnitCombatant)
-                    TargetHelper.getAttackableEnemies(
+                val attackableTile = if (attacker is MapUnitCombatant)
+                    TargetHelper.chooseAttackableTileAgainst(
                         attacker.unit,
-                        attacker.unit.movement.getDistanceToTiles()
+                        defender.getTile(),
+                        TargetHelper.getAttackableEnemies(
+                            attacker.unit,
+                            attacker.unit.movement.getDistanceToTiles()
+                        )
                     )
-                        .firstOrNull { it.tileToAttack == defender.getTile() }?.tileToAttackFrom ?: attacker.getTile()
-                else attacker.getTile()
-                simulateBattle(attacker, defender, tileToAttackFrom)
+                else null
+                val tileToAttackFrom = attackableTile?.tileToAttackFrom ?: attacker.getTile()
+                val attackerForSim =
+                    if (attacker is MapUnitCombatant && attackableTile != null)
+                        MapUnitCombatant(attacker.unit, attackableTile.isRangedAttack)
+                    else attacker
+                simulateBattle(attackerForSim, defender, tileToAttackFrom)
             }
         }
 
@@ -314,12 +322,14 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
 
             if (attacker.canAttack()) {
                 if (attacker is MapUnitCombatant) {
-                    attackableTile = TargetHelper
-                        .getAttackableEnemies(
+                    attackableTile = TargetHelper.chooseAttackableTileAgainst(
+                        attacker.unit,
+                        defender.getTile(),
+                        TargetHelper.getAttackableEnemies(
                             attacker.unit,
                             attacker.unit.movement.getDistanceToTiles()
                         )
-                        .firstOrNull { it.tileToAttack == defender.getTile() }
+                    )
                 } else if (attacker is CityCombatant) {
                     val canBombard =
                         TargetHelper.getBombardableTiles(attacker.city).contains(defender.getTile())

--- a/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
@@ -251,12 +251,14 @@ class WorldMapHolder(
             /** If we are in unit-swapping mode and didn't find a swap partner, we don't want to move or attack */
         } else {
             // This seems inefficient as the tileToAttack is already known - but the method also calculates tileToAttackFrom
-            val attackableTile = TargetHelper
-                    .getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
-                    .firstOrNull { it.tileToAttack == tile }
+            val attackableTile = TargetHelper.chooseAttackableTileAgainst(
+                    unit,
+                    tile,
+                    TargetHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
+            )
             if (unit.canAttack() && attackableTile != null) {
                 /** ****** Right-click Attack ****** */
-                val attacker = MapUnitCombatant(unit)
+                val attacker = MapUnitCombatant(unit, attackableTile.isRangedAttack)
                 if (!Battle.movePreparingAttack(attacker, attackableTile)) return
                 if (!SoundPlayer.play(UncivSound(attacker.getName())))
                     SoundPlayer.play(attacker.getAttackSound())

--- a/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapTileUpdater.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapTileUpdater.kt
@@ -216,7 +216,7 @@ object WorldMapTileUpdater {
                         .toList()
                 else TargetHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
                     .filter { it.tileToAttack.isVisible(unit.civ) }
-                    .distinctBy { it.tileToAttack }
+                    .let { TargetHelper.preferredAttackableEnemies(unit, it) }
 
             for (attackableTile in attackableTiles) {
                 val tileGroupToAttack = tileGroups[attackableTile.tileToAttack]!!

--- a/docs/Modders/schemas/refs/Uniques.schema.json
+++ b/docs/Modders/schemas/refs/Uniques.schema.json
@@ -234,6 +234,7 @@
       "Can only attack [tileFilter] tiles",
       "Cannot attack",
       "Must set up to ranged attack",
+      "Can melee attack",
       "Self-destructs when attacking",
       "Eliminates combat penalty for attacking across a coast",
       "May attack when embarked",

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2246,6 +2246,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Must set up to ranged attack"
 	Applicable to: Unit
 
+??? example  "Can melee attack"
+	Allows a ranged unit to also melee attack: attack after moving, deal and take melee damage, and capture cities. Adjacent targets are attacked as melee; more distant targets in range are attacked as ranged. Combine with `Must set up to ranged attack` to require setup only for the ranged attack.
+
+	Applicable to: Unit
+
 ??? example  "Self-destructs when attacking"
 	Applicable to: Unit
 

--- a/tests/src/com/unciv/logic/battle/BattleTest.kt
+++ b/tests/src/com/unciv/logic/battle/BattleTest.kt
@@ -581,4 +581,70 @@ class BattleTest(private val pathfindingAlgorithm: PathfindingAlgorithm) {
         // then
         assertEquals(30, attackerUnit.promotions.XP) // Attacker should get 2 xp from ranged attack but no xp from melee attack
     }
+
+    @Test
+    fun `hybrid unit melee attack deals and takes damage`() {
+        val attackerUnit = addHybridUnit()
+
+        val damageDealt = Battle.attack(
+            MapUnitCombatant(attackerUnit, attackAsRanged = false),
+            MapUnitCombatant(defaultDefenderUnit)
+        )
+
+        assertTrue(damageDealt.attackerDealt > 0)
+        assertTrue(damageDealt.defenderDealt > 0)
+    }
+
+    @Test
+    fun `hybrid unit ranged attack does not take damage`() {
+        val attackerUnit = addHybridUnit()
+
+        val damageDealt = Battle.attack(
+            MapUnitCombatant(attackerUnit, attackAsRanged = true),
+            MapUnitCombatant(defaultDefenderUnit)
+        )
+
+        assertTrue(damageDealt.attackerDealt > 0)
+        assertEquals(0, damageDealt.defenderDealt)
+        assertTrue(attackerUnit.getTile().position.eq(0, 1))
+    }
+
+    @Test
+    fun `hybrid unit melee kill moves onto defender tile`() {
+        val attackerUnit = addHybridUnit()
+        defaultDefenderUnit.health = 1
+
+        Battle.attack(
+            MapUnitCombatant(attackerUnit, attackAsRanged = false),
+            MapUnitCombatant(defaultDefenderUnit)
+        )
+
+        assertTrue(attackerUnit.getTile().position.eq(0, 0))
+        assertTrue(defaultDefenderUnit.isDestroyed)
+    }
+
+    @Test
+    fun `hybrid unit ranged kill stays in place`() {
+        val attackerUnit = addHybridUnit()
+        defaultDefenderUnit.health = 1
+
+        Battle.attack(
+            MapUnitCombatant(attackerUnit, attackAsRanged = true),
+            MapUnitCombatant(defaultDefenderUnit)
+        )
+
+        assertTrue(attackerUnit.getTile().position.eq(0, 1))
+        assertTrue(defaultDefenderUnit.isDestroyed)
+    }
+
+    private fun addHybridUnit(): MapUnit {
+        val baseUnit = testGame.createBaseUnit("Gunpowder", UniqueType.CanMeleeAttack.text)
+        baseUnit.movement = 2
+        baseUnit.strength = 24
+        baseUnit.rangedStrength = 24
+        baseUnit.range = 2
+        val unit = testGame.addUnit(baseUnit.name, attackerCiv, testGame.getTile(0, 1))
+        unit.currentMovement = 2f
+        return unit
+    }
 }

--- a/tests/src/com/unciv/logic/battle/TargetHelperTest.kt
+++ b/tests/src/com/unciv/logic/battle/TargetHelperTest.kt
@@ -4,6 +4,9 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.HexCoord
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.testing.BaseTestRunner
 import com.unciv.testing.TestGame
 import org.junit.Assert.assertEquals
@@ -210,10 +213,10 @@ class TargetHelperTest {
 
         // then
         assertEquals(4, attackableEnemies.toList().size)
-        assertEquals(AttackableTile(tileToAttackFrom, tileToAttack, movementLeftAfterMovingToAttackTile, combatant), attackableEnemies[0])
-        assertTrue(attackableEnemies.contains(AttackableTile(testGame.getTile(0,1), tileToAttack, movementLeftAfterMovingToAttackTile-1, combatant)))
-        assertTrue(attackableEnemies.contains(AttackableTile(testGame.getTile(-1,-1), tileToAttack, movementLeftAfterMovingToAttackTile-1, combatant)))
-        assertTrue(attackableEnemies.contains(AttackableTile(testGame.getTile(HexCoord.Zero), tileToAttack, movementLeftAfterMovingToAttackTile-1, combatant)))
+        assertEquals(AttackableTile(tileToAttackFrom, tileToAttack, movementLeftAfterMovingToAttackTile, combatant, isRangedAttack = true), attackableEnemies[0])
+        assertTrue(attackableEnemies.contains(AttackableTile(testGame.getTile(0,1), tileToAttack, movementLeftAfterMovingToAttackTile-1, combatant, isRangedAttack = true)))
+        assertTrue(attackableEnemies.contains(AttackableTile(testGame.getTile(-1,-1), tileToAttack, movementLeftAfterMovingToAttackTile-1, combatant, isRangedAttack = true)))
+        assertTrue(attackableEnemies.contains(AttackableTile(testGame.getTile(HexCoord.Zero), tileToAttack, movementLeftAfterMovingToAttackTile-1, combatant, isRangedAttack = true)))
     }
 
     @Test
@@ -339,5 +342,43 @@ class TargetHelperTest {
 
         // then
         assertTrue(attackableEnemies.isEmpty())
+    }
+
+    @Test
+    fun `hybrid unit adjacent attack is melee not ranged`() {
+        val attackerUnit = addHybridUnit(testGame.getTile(HexCoord.Zero))
+        testGame.addUnit("Warrior", defenderCiv, testGame.getTile(1, 0))
+
+        val attackableEnemies = TargetHelper.getAttackableEnemies(attackerUnit, attackerUnit.movement.getDistanceToTiles())
+        val againstAdjacent = attackableEnemies.filter { it.tileToAttack == testGame.getTile(1, 0) }
+
+        assertTrue(againstAdjacent.any { !it.isRangedAttack })
+        assertTrue(againstAdjacent.none { it.isRangedAttack })
+    }
+
+    @Test
+    fun `hybrid unit attacks distant target as ranged`() {
+        val attackerUnit = addHybridUnit(testGame.getTile(-1, 0))
+        testGame.addUnit("Warrior", attackerCiv, testGame.getTile(0, 1)) // vision
+        testGame.addUnit("Warrior", defenderCiv, testGame.getTile(1, 0))
+
+        val attackableEnemies = TargetHelper.getAttackableEnemies(attackerUnit, attackerUnit.movement.getDistanceToTiles())
+        val fromCurrentTile = attackableEnemies.filter {
+            it.tileToAttack == testGame.getTile(1, 0) && it.tileToAttackFrom == attackerUnit.getTile()
+        }
+
+        assertTrue(fromCurrentTile.any { it.isRangedAttack })
+        assertTrue(fromCurrentTile.none { !it.isRangedAttack })
+    }
+
+    private fun addHybridUnit(tile: Tile): MapUnit {
+        val baseUnit = testGame.createBaseUnit("Gunpowder", UniqueType.CanMeleeAttack.text)
+        baseUnit.movement = 2
+        baseUnit.strength = 24
+        baseUnit.rangedStrength = 24
+        baseUnit.range = 2
+        val unit = testGame.addUnit(baseUnit.name, attackerCiv, tile)
+        unit.currentMovement = 2f
+        return unit
     }
 }


### PR DESCRIPTION
## Summary
- Adds unique `Can melee attack` so a unit with both `strength` and `rangedStrength` can melee-attack (after moving, capturing cities) as well as fire at range.
- Adjacent targets use melee rules; more distant targets in range use ranged rules. `Must set up to ranged attack` still applies only to the ranged attack.
- Intended for mods such as RekMOD's Hungary UU (Black Arquebusier): 24 melee / 24 ranged, must set up to ranged attack.

## Test plan
- [ ] Unit with `rangedStrength` + `Can melee attack`: click an adjacent enemy — melee combat (both sides take damage), kill moves onto the tile, 1-HP cities are captured.
- [ ] Same unit: click an enemy 2 tiles away — ranged combat (attacker takes no damage), unit stays put.
- [ ] Combine with `Must set up to ranged attack`: can still melee after moving without setup; ranged fire requires setup (or leftover movement to set up in place).
- [ ] Vanilla Archers / Catapults / Warriors unchanged.
- [ ] `.\gradlew tests:test --tests com.unciv.logic.battle.BattleTest --tests com.unciv.logic.battle.TargetHelperTest`