### PR TITLE
Fix WLTKD demand rewrite mid-celebration

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -67,14 +67,17 @@ class CityTurnManager(val city: City) {
 
     private fun tryWeLoveTheKing() {
         if (city.demandedResource == "") return
-        if (city.getAvailableResourceAmount(city.demandedResource) > 0) {
-            // manually adjust with game speed because of the +1 at the end
-            val duration = (20 * city.civ.gameInfo.speed.modifier).roundToInt() + 1 // +1 because it will be decremented by 1 in the same startTurn()
-            city.setFlag(CityFlags.WeLoveTheKing, duration) 
-            city.civ.addNotification(
-                "Because they have [${city.demandedResource}], the citizens of [${city.name}] are celebrating We Love The King Day!",
-                CityAction.withLocation(city), NotificationCategory.General, NotificationIcon.City, NotificationIcon.Happiness)
-        }
+        if (city.getAvailableResourceAmount(city.demandedResource) <= 0) return
+
+        // manually adjust with game speed because of the +1 at the end
+        val duration = (20 * city.civ.gameInfo.speed.modifier).roundToInt() + 1 // +1 because it will be decremented by 1 in the same startTurn()
+        city.setFlag(CityFlags.WeLoveTheKing, duration)
+        // Otherwise ResourceDemand can expire mid-celebration, rewrite demandedResource,
+        // and the Resources overview mislabels the active WLTKD (celebration is flag-based).
+        city.removeFlag(CityFlags.ResourceDemand)
+        city.civ.addNotification(
+            "Because they have [${city.demandedResource}], the citizens of [${city.name}] are celebrating We Love The King Day!",
+            CityAction.withLocation(city), NotificationCategory.General, NotificationIcon.City, NotificationIcon.Happiness)
     }
 
     // cf DiplomacyManager nextTurnFlags
@@ -88,7 +91,10 @@ class CityTurnManager(val city: City) {
 
                 when (flag) {
                     CityFlags.ResourceDemand.name -> {
-                        demandNewResource()
+                        // WLTKD end already demands the next resource; demanding while celebrating
+                        // overwrites demandedResource and mislabels the active celebration in the UI
+                        if (!city.hasFlag(CityFlags.WeLoveTheKing))
+                            demandNewResource()
                     }
                     CityFlags.WeLoveTheKing.name -> {
                         city.civ.addNotification(

--- a/tests/src/com/unciv/logic/city/managers/CityTurnManagerWltkTest.kt
+++ b/tests/src/com/unciv/logic/city/managers/CityTurnManagerWltkTest.kt
@@ -1,0 +1,60 @@
+package com.unciv.logic.city.managers
+
+import com.unciv.logic.city.City
+import com.unciv.logic.city.CityFlags
+import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.map.HexCoord
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(BaseTestRunner::class)
+class CityTurnManagerWltkTest {
+    private val testGame = TestGame()
+    private lateinit var civ: Civilization
+    private lateinit var city: City
+
+    @Before
+    fun setUp() {
+        testGame.makeHexagonalMap(3)
+        civ = testGame.addCiv()
+        city = testGame.addCity(civ, testGame.getTile(HexCoord.Zero))
+    }
+
+    @Test
+    fun `ResourceDemand expiry during WLTKD does not rewrite demandedResource`() {
+        city.demandedResource = "Salt"
+        city.setFlag(CityFlags.WeLoveTheKing, 5)
+        city.setFlag(CityFlags.ResourceDemand, 1)
+
+        CityTurnManager(city).startTurn()
+
+        assertEquals("Salt", city.demandedResource)
+        assertTrue(city.hasFlag(CityFlags.WeLoveTheKing))
+        assertFalse(city.hasFlag(CityFlags.ResourceDemand))
+    }
+
+    @Test
+    fun `starting WLTKD clears pending ResourceDemand`() {
+        // City-center Salt needs Mining researched to count as extracted
+        civ.tech.addTechnology("Mining")
+        city.getCenterTile().setTileResource("Salt")
+        city.getCenterTile().resourceAmount = 1
+        civ.cache.updateCivResources()
+
+        city.demandedResource = "Salt"
+        city.setFlag(CityFlags.ResourceDemand, 10)
+        assertFalse(city.hasFlag(CityFlags.WeLoveTheKing))
+
+        CityTurnManager(city).startTurn()
+
+        assertTrue(city.hasFlag(CityFlags.WeLoveTheKing))
+        assertFalse(city.hasFlag(CityFlags.ResourceDemand))
+        assertEquals("Salt", city.demandedResource)
+    }
+}


### PR DESCRIPTION
## Summary
- `ResourceDemand` could expire during an active We Love The King Day and call `demandNewResource()`, overwriting `demandedResource` while the celebration flag was still running.
- The Resources overview then labeled the active WLTKD as the *new* luxury (e.g. Wine) even though the celebration had started from a different one (e.g. Obsidian).
- Clear `ResourceDemand` when WLTKD starts, and skip mid-celebration `demandNewResource()` (WLTKD end already demands the next resource).

## Test plan
- [x] `.\gradlew tests:test --tests com.unciv.logic.city.managers.CityTurnManagerWltkTest`
- [ ] In-game: start WLTKD from luxury A with a short remaining `ResourceDemand`; confirm demand does not switch to luxury B mid-celebration; Resources overview keeps A until WLTKD ends