### PR TITLE
fix: Prevent natural-wonder coast conversion artifacts

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
@@ -164,7 +164,7 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
                     if (convertToTerrain.hasUnique(UniqueType.FreshWater) && tile.isAdjacentToCoast()) continue
                     if (convertToTerrain.type == TerrainType.TerrainFeature && tile.baseTerrain !in convertToTerrain.occursOn) continue
                     if (convertToTerrain.hasUnique(UniqueType.CoastalWater))
-                        removeLakesNextToFutureCoast(tile)
+                        removeLakesNextToFutureCoast(tile, convertToTerrain)
                     if (convertToTerrain.type.isBaseTerrain) {
                         clearTile(tile)
                         tile.setBaseTerrain(convertToTerrain)
@@ -226,19 +226,24 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
         private fun Unique.getIntParam(index: Int) = params[index].toInt()
 
         // location is being converted to a NW, tile is a neighbor to be converted to coast: Ensure that coast won't show invalid rivers or coast touching lakes
-        private fun removeLakesNextToFutureCoast(tile: Tile) {
-            for (neighbor in tile.neighbors) {
-                // This is so we don't have this tile turn into Coast, and then it's touching a Lake tile.
-                // We just turn the lake tiles into this kind of tile.
-                if (neighbor.getBaseTerrain().hasUnique(UniqueType.FreshWater)) {
-                    clearTile(neighbor)
-                    neighbor.baseTerrain = tile.baseTerrain
-                    neighbor.setTerrainTransients()
+        private fun removeLakesNextToFutureCoast(tile: Tile, coastTerrain: Terrain) {
+            val futureCoastTiles = hashSetOf(tile)
+            val tilesToCheck = mutableListOf(tile)
+            var index = 0
+            while (index < tilesToCheck.size) {
+                for (neighbor in tilesToCheck[index++].neighbors) {
+                    if (!neighbor.getBaseTerrain().hasUnique(UniqueType.FreshWater)) continue
+                    if (futureCoastTiles.add(neighbor)) tilesToCheck.add(neighbor)
                 }
             }
-            for (neighbor in tile.neighbors) {
-                tile.setConnectedByRiver(neighbor, false)
+
+            for (lake in futureCoastTiles - tile) {
+                clearTile(lake)
+                lake.setBaseTerrain(coastTerrain)
             }
+            for (futureCoast in futureCoastTiles)
+                for (neighbor in futureCoast.neighbors)
+                    futureCoast.setConnectedByRiver(neighbor, false)
         }
 
         /** Implements [UniqueParameterType.SimpleTerrain][com.unciv.models.ruleset.unique.UniqueParameterType.SimpleTerrain] */

--- a/tests/src/com/unciv/logic/map/mapgenerator/NaturalWonderGeneratorTests.kt
+++ b/tests/src/com/unciv/logic/map/mapgenerator/NaturalWonderGeneratorTests.kt
@@ -1,0 +1,89 @@
+package com.unciv.logic.map.mapgenerator
+
+import com.unciv.Constants
+import com.unciv.logic.map.HexCoord
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.tile.Terrain
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(BaseTestRunner::class)
+class NaturalWonderGeneratorTests {
+    private lateinit var game: TestGame
+    private lateinit var wonder: Terrain
+    private lateinit var location: Tile
+
+    @Before
+    fun setUp() {
+        game = TestGame()
+        game.makeHexagonalMap(3, Constants.grassland)
+        wonder = game.ruleset.terrains["Rock of Gibraltar"]!!
+        location = game.getTile(HexCoord.Zero)
+    }
+
+    @Test
+    fun `Rock of Gibraltar converts connected Lakes outside its neighbor ring to Coast`() {
+        val convertedNeighbor = game.getTile(1, 0)
+        val lakeOutsideNeighborRing = game.getTile(2, 0)
+        val endOfLakeComponent = game.getTile(3, 0)
+        for (tile in listOf(convertedNeighbor, lakeOutsideNeighborRing, endOfLakeComponent))
+            game.setTileTerrain(tile.position, "Lakes")
+
+        NaturalWonderGenerator.placeNaturalWonder(wonder, location)
+
+        for (tile in listOf(convertedNeighbor, lakeOutsideNeighborRing, endOfLakeComponent)) {
+            assertEquals(Constants.coast, tile.baseTerrain)
+            assertFalse(tile.neighbors.any { it.getBaseTerrain().hasUnique(UniqueType.FreshWater) })
+        }
+    }
+
+    @Test
+    fun `Rock of Gibraltar preserves filters and existing conversion clearing behavior`() {
+        val land = game.getTile(1, 0)
+        val existingCoast = game.setTileTerrain(HexCoord(0, 1), Constants.coast)
+        val ocean = game.setTileTerrain(HexCoord(-1, 0), Constants.ocean)
+        val mountain = game.setTileTerrain(HexCoord(0, -1), Constants.mountain)
+        val unrelatedLake = game.setTileTerrain(HexCoord(-3, -3), "Lakes")
+        game.setTileFeatures(land.position, Constants.forest)
+        land.tileResource = game.ruleset.tileResources["Deer"]
+        land.setImprovementBasic("Camp")
+
+        NaturalWonderGenerator.placeNaturalWonder(wonder, location)
+
+        assertEquals(Constants.coast, land.baseTerrain)
+        assertTrue(land.isWater)
+        assertTrue(land.terrainFeatures.isEmpty())
+        assertNull(land.tileResource)
+        assertNull(land.improvement)
+        assertEquals(Constants.coast, existingCoast.baseTerrain)
+        assertEquals(Constants.coast, ocean.baseTerrain)
+        assertEquals(Constants.mountain, mountain.baseTerrain)
+        assertEquals("Lakes", unrelatedLake.baseTerrain)
+    }
+
+    @Test
+    fun `Rock of Gibraltar removes every river edge from all tiles converted to Coast`() {
+        val convertedNeighbor = game.getTile(1, 0)
+        val lakeOutsideNeighborRing = game.getTile(2, 0)
+        game.setTileTerrain(convertedNeighbor.position, "Lakes")
+        game.setTileTerrain(lakeOutsideNeighborRing.position, "Lakes")
+        for (tile in listOf(convertedNeighbor, lakeOutsideNeighborRing))
+            for (neighbor in tile.neighbors)
+                tile.setConnectedByRiver(neighbor, true)
+
+        NaturalWonderGenerator.placeNaturalWonder(wonder, location)
+
+        for (tile in listOf(convertedNeighbor, lakeOutsideNeighborRing)) {
+            assertEquals(Constants.coast, tile.baseTerrain)
+            assertFalse(tile.neighbors.any { tile.isConnectedByRiver(it) })
+        }
+    }
+}


### PR DESCRIPTION
Update `NaturalWonderGenerator.placeNaturalWonder()` and its existing Coast cleanup helper so cleanup is driven by the configured conversion destination rather than the target tile's pre-conversion terrain. Rock of Gibraltar's `NaturalWonderConvertNeighbors` unique can convert a Lake tile to Coast while leaving an adjacent Lake unchanged, producing the Coast/Lakes boundary shown in issue #15391.

Place Rock of Gibraltar so one converted neighbor starts as Lakes and has another Lake neighbor outside the wonder's immediate conversion ring; after placement, the converted Coast has no adjacent freshwater Lake artifact; Place Rock of Gibraltar with conversion targets that begin as land and as existing Coast; eligible neighbors still follow the documented Coast conversion while Mountain-filtered neighbors remain unchanged.

Fixes #15391
