### PR TITLE
chore: Treat Gradle warnings

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -13,13 +13,12 @@ android {
     sourceSets {
         getByName("main").apply {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs("src")
-            kotlin.srcDirs("src")
-            aidl.srcDirs("src")
-            renderscript.srcDirs("src")
-            res.srcDirs("res")
-            assets.srcDirs("assets")
-            jniLibs.srcDirs("libs")
+            java.directories += "src"
+            kotlin.directories += "src"
+            aidl.directories += "src"
+            res.directories += "res"
+            assets.directories += "assets"
+            jniLibs.directories += "libs"
         }
     }
     packaging {
@@ -74,7 +73,6 @@ android {
         ignoreAssetsPattern = "!SaveFiles:!fonts:!maps:!music:!mods"
     }
     buildFeatures {
-        renderScript = true
         aidl = true
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -38,13 +38,6 @@ android {
         base.archivesName.set("Unciv")
     }
 
-    // necessary for Android Work lib
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_1_8
-        }
-    }
-
     // Had to add this crap for Travis to build, it wanted to sign the app
     // but couldn't create the debug keystore for some reason
 
@@ -83,6 +76,13 @@ android {
     buildFeatures {
         renderScript = true
         aidl = true
+    }
+}
+
+// necessary for Android WorkManager lib, used in MultiplayerTurnCheckWorker
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,6 @@
 # android
 android.useAndroidX=true
-android.enableJetifier=true
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 
 # gradle
 org.gradle.parallel=true


### PR DESCRIPTION
* Moves the `kotlin {}` block outside `android {}` per [Google's built-in-Kotlin migration guide](https://developer.android.com/build/migrate-to-built-in-kotlin), which removes a "suspicious receiver type" warning.

    Current output was already correct because, per the same doc, jvmTarget defaults to android.compileOptions.targetCompatibility when unset - confirmed via javap (major version 52 = Java 8) both before and after this change:
    `javap -verbose AndroidDisplay.class`
    ```
    Classfile /home/bob/Work/Unciv/android/build/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes/com/unciv/app/AndroidDisplay.class
      Last modified 16 Aug 2026; size 7571 bytes
      SHA-256 checksum 8d7c846009722791fd3cf6416ad5a21ab9316c63769195d98f719cce4e31c689
      Compiled from "AndroidDisplay.kt"
    public final class com.unciv.app.AndroidDisplay implements com.unciv.utils.PlatformDisplay
      minor version: 0
      major version: 52
    ```

* Removing a few "'fun srcDirs(vararg srcDirs: Any): Any' is deprecated. Use `directories` mutable set instead." warnings - about due.

* The warning "'var renderScript: Boolean?' is deprecated. This property and renderScript support will be removed in AGP 10.0." - is about due too, and I'm sure it's an unused leftover from templates. RenderScript itself has been deprecated since Android 12 and AGP 7.2, it's a compute API for offloading image processing and similar tasks to hardware, and certainly not used by us or within Gdx OpenGL backend code. Plus, we have no `.rs` or `.rsh` files. Therefore - dropped.

* Warnings "Task is missing a description", "A newer version of `compileSdk` than 36 is available: 37", and "Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details." are cosmetic and untouched.

* Clarified the WorkManager comment - though that's slight pitfall too: That usecase might today be better served by leveraging GCM (pardon, FCM, microG still hasn't adopted the new name), but that would require dropping passive Dropbox-based multiplayer support, and a server-side push component. No idea whether there's already any development in that direction.

* Removed deprecated jetifier line, verified by `./gradlew :android:checkJetifier`.

* Removed the deprecated `nonFinalResIds` setting - analysis:
    - Introduced without stating a reason in https://github.com/yairm210/Unciv/commit/52a9eebe28275e6bd7ce16eb9268e4a88ac4642f
    - Would affect use of `when` with a resource ID as subject - so that should turn up as compilation error when removed - no such error with Build-Clean Project / Build-Generate APKs.
    - Would affect reflection on `R` with decisions based on `Modifier.isFinal()` - too far-fetched.
