### PR TITLE
Use live data for charts

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -364,6 +364,16 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     fun isSimulation(): Boolean = turns < DebugUtils.SIMULATE_UNTIL_TURN
             || turns < simulateMaxTurns && simulateUntilWin
 
+    // Records the ranking stats of all major civs
+    private fun recordRankingStats() {
+        for (civ in civilizations) {
+            if (!civ.isMajorCiv() || !civ.isAlive()) continue
+            // Force uses a transient cache that is not invalidated on combat losses during other civs' turns
+            civ.resetMilitaryMightCache()
+            civ.statsHistory.recordRankingStats(civ)
+        }
+    }
+
     /**
      *  Advance a turn, running automation for AI players, stopping for human players
      *  @param progressBar Optional reference to UI widget either provided by [WorldScreen.nextTurn][com.unciv.ui.screens.worldscreen.WorldScreen.nextTurn] or `null` when simulating
@@ -385,6 +395,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         fun setNextPlayer() {
             playerIndex = (playerIndex + 1) % civilizations.size
             if (playerIndex == 0) {
+                recordRankingStats()
                 turns++
                 if (DebugUtils.SIMULATE_UNTIL_TURN != 0)
                     debug("Starting simulation of turn %s", turns)

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -29,12 +29,6 @@ class TurnManager(val civInfo: Civilization) {
         if (civInfo.isSpectator()) return
 
         civInfo.threatManager.clear()
-        if (civInfo.isMajorCiv() && civInfo.isAlive()) {
-            // Force uses a transient cache that is not invalidated on combat losses during
-            // other civs' turns; clear it so the turn-start demographics/charts snapshot is accurate.
-            civInfo.resetMilitaryMightCache()
-            civInfo.statsHistory.recordRankingStats(civInfo)
-        }
 
         if (civInfo.cities.isNotEmpty() && civInfo.gameInfo.ruleset.technologies.isNotEmpty())
             civInfo.tech.updateResearchProgress()

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -119,16 +119,11 @@ class VictoryScreenCharts(
                 turn.value.map { (civ, value) -> DataPoint(turn.key, value, civ) }
             }.toMutableList()
 
-        if (dataPoints.isEmpty()) // e.g. spectator on first turn, before any civ has had a chance to have a turn
-            return emptyList()
-
-        // Historical data does not include data for current turn for civs which haven't got their turn yet,
-        // so we append missing stat for current turn to the data for each such civ
-        val pointsByCiv = dataPoints.sortedBy { it.x }.groupBy { it.civ }
-        val actualTurn = dataPoints.maxOf { it.x }
-        for (civ in pointsByCiv.keys.filterNot { it.isDefeated() })
-            if (pointsByCiv[civ]!!.last().x != actualTurn)
-                dataPoints += DataPoint(actualTurn, civ.getStatForRanking(rankingType), civ)
+        // Historical data is recorded at the end of each turn, so we append the live stat for the current turn
+        val currentTurn = gameInfo.turns
+        if (zoomAtX == null || currentTurn in zoomAtX!!)
+            for (civ in dataPoints.map { it.civ }.distinct().filterNot { it.isDefeated() })
+                dataPoints += DataPoint(currentTurn, civ.getStatForRanking(rankingType), civ)
 
         return dataPoints
     }

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
@@ -55,7 +55,7 @@ class VictoryScreenDemographics(
     }
 
     /**
-     * Ranking value frozen at that civilization's last turn-start recording in [Civilization.statsHistory].
+     * Ranking value frozen at the end of the last completed turn, as recorded in [Civilization.statsHistory].
      * Falls back to a live value only when no history exists yet (e.g. very early game).
      */
     @Readonly


### PR DESCRIPTION
Addressing https://github.com/yairm210/Unciv/issues/15399.

Latest point on chart now updates live, and matches the numbers on the left. Also stat is recorded not on each player's own turn start but rather recorded for every player all at once at the end of last player's turn for consistency with live update.

Screenshots below, check the number for Ethiopia.

Before
<img width="1280" height="764" alt="chart-1" src="https://github.com/user-attachments/assets/235105d7-9ce5-49ec-a94a-1d1cfd250e65" />

After
<img width="1280" height="764" alt="chart-2" src="https://github.com/user-attachments/assets/f094a9fe-8143-4120-a97a-b83efdad8b0d" />

Note: This will create a slight inconsistency in saved games, since the existing stat histories were recorded at turn start, and new ones will be recorded at full-turn end. I don't think this will be a serious issue, but mentioned just in case.