### PR TITLE
chore: Better fix for that `GlobalPoliticsDiagramGroup.Relations.entries` bug

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
@@ -51,7 +51,7 @@ class GlobalPoliticsDiagramGroup(
     }
 
     /** Wrapper around [RelationshipLevel], adding War, DefensivePact, and a Z-Order property */
-    sealed class Relation {
+    private sealed class Relation {
         abstract val ordinal: Int
         abstract val label: String
         abstract val color: Color

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
@@ -81,7 +81,8 @@ class GlobalPoliticsDiagramGroup(
 
             operator fun get(level: RelationshipLevel) = relationshipLevels[level.ordinal]
 
-            val entries = listOf(
+            // Don't materialize this, see issue 15393 (class-initialization cycle when the outer diagram draws a DefensivePact line first)
+            val entries get() = listOf(
                 War,
                 *relationshipLevels,
                 DefensivePact,

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -301,10 +301,6 @@ class GlobalPoliticsOverviewTable(
         if (showDiplomacyGroup) {
             val diplomacySize = (overviewScreen.stage.width - (if (portraitMode) 0f else civTable.minWidth))
                 .coerceAtMost(overviewScreen.centerAreaHeight)
-
-            GlobalPoliticsDiagramGroup.Relation.entries // Doing this solves the bug in #15393
-            // I'm still not sure why, it's definitely a compiler bug
-
             val diplomacyGroup = GlobalPoliticsDiagramGroup(undefeatedCivs, diplomacySize)
             table.add(diplomacyGroup).top()
         }


### PR DESCRIPTION
Closes #15393 - see analysis there