### PR TITLE
Squash notifications when many units can be promoted

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1145,6 +1145,7 @@ We have captured a barbarian encampment and recovered [goldAmount] gold! =
 An enemy [unitType] has joined us! = 
 [unitName] can be promoted! = 
 [unitName] has fully healed = 
+[amount] units can be promoted! = 
 
 # This might be needed for a rewrite of Germany's unique - see #7376
 A barbarian [unitType] has joined us! = 

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -115,8 +115,6 @@ class TurnManager(val civInfo: Civilization) {
                 "UnitActionIcons/Promote"
             )
         }
-        
-        
 
         updateWinningCiv()
     }

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -97,11 +97,26 @@ class TurnManager(val civInfo: Civilization) {
             }
         }
         
-        for (unit in civInfo.units.getCivUnits().filter { it.promotions.canBePromoted() }){
-            civInfo.addNotification("[${unit.displayName()}] can be promoted!",
-                listOf(MapUnitAction(unit), PromoteUnitAction(unit)),
-                NotificationCategory.Units, unit.name)
+        val promotableUnits = civInfo.units.getCivUnits().filter { it.promotions.canBePromoted() }
+        if (promotableUnits.count() <= 3) {
+            for (unit in civInfo.units.getCivUnits().filter { it.promotions.canBePromoted() }){
+                civInfo.addNotification(
+                    "[${unit.displayName()}] can be promoted!",
+                    listOf(MapUnitAction(unit), PromoteUnitAction(unit)),
+                    NotificationCategory.Units,
+                    unit.name
+                )
+            }
+        } else {
+            civInfo.addNotification(
+                "[${promotableUnits.count()}] units can be promoted!",
+                promotableUnits.map { MapUnitAction(it) },
+                NotificationCategory.Units,
+                promotableUnits.first().name
+            )
         }
+        
+        
 
         updateWinningCiv()
     }

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -112,7 +112,7 @@ class TurnManager(val civInfo: Civilization) {
                 "[${promotableUnits.count()}] units can be promoted!",
                 promotableUnits.map { MapUnitAction(it) },
                 NotificationCategory.Units,
-                promotableUnits.first().name
+                "UnitActionIcons/Promote"
             )
         }
         


### PR DESCRIPTION
[Suggestion](https://discord.com/channels/586194543280390151/1515337853830168699) to reduce clutter when many units can be promoted at the same time.
The new behavior is used when >3 units can be promoted. 

The promotion notification from Battle.kt (upon gaining enough xp for a promotion) is still enabled. Consequently the bug where a notification may show twice for the same unit is still present.

Before:
<img width="1982" height="1079" alt="image" src="https://github.com/user-attachments/assets/a333e962-969a-414a-8b5a-b5ea88ae0097" />

After:
<img width="1982" height="1079" alt="image" src="https://github.com/user-attachments/assets/5cd31701-de19-44db-8096-9a838a26d611" />