### PR TITLE
#firstXUniqueOrNull, to replace remaining calls of #getXUniques

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -297,7 +297,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     @Readonly
     fun containsBuildingUnique(uniqueType: UniqueType, state: GameContext = this.state) =
-        cityConstructions.builtBuildingUniqueMap.getMatchingUniques(uniqueType, state).any()
+        cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, state) { true } != null
 
     @Readonly fun getGreatPersonPercentageBonus() = GreatPersonPointsBreakdown.getGreatPersonPercentageBonus(this)
     @Readonly fun getGreatPersonPoints() = GreatPersonPointsBreakdown(this).sum()
@@ -633,77 +633,117 @@ class City : IsPartOfGameInfoSerialization, INamed {
         uniqueType: UniqueType,
         gameContext: GameContext = state,
         includeCivUniques: Boolean = true
-    ): Sequence<Unique> {
-        return if (includeCivUniques)
-            civ.getMatchingUniques(uniqueType, gameContext) +
-                getLocalMatchingUniques(uniqueType, gameContext)
-        else (
-            cityConstructions.builtBuildingUniqueMap.getUniques(uniqueType)
-                + religion.getUniques(uniqueType)
-            ).filter {
-                !it.isTimedTriggerable && it.conditionalsApply(gameContext)
-            }.flatMap { it.getMultiplied(gameContext) }
+    ): Sequence<Unique> = getMatchingUniquesSnapshot(uniqueType, gameContext, includeCivUniques).asSequence()
+
+    /** @return a stable snapshot List of uniques matching [uniqueType], safe to keep iterating even if the
+     *  underlying uniques (e.g. built buildings) change mid-iteration - see [forEachTriggeredUnique]'s callers
+     *  in CityTurnManager for why a "get a stable snapshot" method is legitimately still needed sometimes. */
+    @Readonly
+    fun getMatchingUniquesSnapshot(
+        uniqueType: UniqueType,
+        gameContext: GameContext = state,
+        includeCivUniques: Boolean = true
+    ): List<Unique> {
+        val uniques = ArrayList<Unique>()
+        forEachMatchingUnique(uniqueType, gameContext, includeCivUniques) { uniques.add(it) }
+        return uniques
     }
 
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, op: (unique: Unique)->Unit)
-        = forEachMatchingUnique(uniqueType, state, true, op)
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, predicate: (unique: Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, state, true, predicate)
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit)
-        = forEachMatchingUnique(uniqueType, gameContext, true, op)
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, predicate: (unique: Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, true, predicate)
     @Readonly
-    fun forEachMatchingUnique(
+    fun firstMatchingUniqueOrNull(
         uniqueType: UniqueType,
         gameContext: GameContext = state,
         includeCivUniques: Boolean,
-        op: (unique: Unique)->Unit,
-    ) {
+        predicate: (unique: Unique)->Boolean,
+    ): Unique? {
         if (includeCivUniques) {
-            civ.forEachMatchingUnique(uniqueType, gameContext, op)
-            forEachLocalMatchingUnique(uniqueType, gameContext, op)
+            return civ.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+                ?: firstLocalMatchingUniqueOrNull(uniqueType, gameContext, predicate)
         } else {
-            cityConstructions.builtBuildingUniqueMap.forEachMatchingUnique(uniqueType, state, isTimedUniqueFilter, op)
-            religion.forEachMatchingUnique(uniqueType, state, isTimedUniqueFilter, op)
+            return cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, state, isTimedUniqueFilter, predicate)
+                ?: religion.firstMatchingUniqueOrNull(uniqueType, state, isTimedUniqueFilter, predicate)
         }
+    }
+
+    @Readonly
+    fun forEachMatchingUnique(uniqueType: UniqueType, op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, state, true) {op(it); false}
+    }
+    @Readonly
+    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, gameContext, true) {op(it); false}
+    }
+    @Readonly
+    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, includeCivUniques: Boolean, op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, gameContext, includeCivUniques) {op(it); false}
+    }
+
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, initial: T, crossinline accumulate: (T, Unique) -> T): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext) { acc = accumulate(acc, it) }
+        return acc
     }
 
     // Uniques special to this city
     @Readonly
     @Deprecated(message = "forEachLocalMatchingUnique is faster. If not viable, then this can still be used",
         replaceWith = ReplaceWith("forEachLocalMatchingUnique"))
-    fun getLocalMatchingUniques(uniqueType: UniqueType, gameContext: GameContext = state): Sequence<Unique> {
-        val uniques = cityConstructions.builtBuildingUniqueMap.getUniques(uniqueType).filter { it.isLocalEffect } +
-            religion.getUniques(uniqueType)
-        return uniques.filter { !it.isTimedTriggerable && it.conditionalsApply(gameContext) }
-                .flatMap { it.getMultiplied(gameContext) }
+    fun getLocalMatchingUniques(uniqueType: UniqueType, gameContext: GameContext = state): Sequence<Unique> =
+        getLocalMatchingUniquesSnapshot(uniqueType, gameContext).asSequence()
+
+    /** @return a stable snapshot List of uniques special to this city */
+    @Readonly
+    fun getLocalMatchingUniquesSnapshot(uniqueType: UniqueType, gameContext: GameContext = state): List<Unique> {
+        val uniques = ArrayList<Unique>()
+        forEachLocalMatchingUnique(uniqueType, gameContext) { uniques.add(it) }
+        return uniques
     }
 
     // Uniques special to this city
     @Readonly
-    fun forEachLocalMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, op: (unique: Unique)->Unit) {
-        cityConstructions.builtBuildingUniqueMap.forEachMatchingUnique(uniqueType, gameContext, isLocalUniqueFilter, op)
-        religion.forEachMatchingUnique(uniqueType, gameContext, op)
+    inline fun firstLocalMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext = state, crossinline predicate: (unique: Unique)->Boolean): Unique?
+        = cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, isLocalUniqueFilter, predicate)
+        ?: religion.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+
+    @Readonly
+    inline fun forEachLocalMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, crossinline op: (unique: Unique)->Unit) {
+        firstLocalMatchingUniqueOrNull(uniqueType, gameContext, {op(it); false })
     }
 
     // Uniques coming from this city, but that should be provided globally
     @Readonly
     @Deprecated(message = "forEachMatchingUniqueWithNonLocalEffects is faster. If not viable, then this can still be used",
         replaceWith = ReplaceWith("forEachMatchingUniqueWithNonLocalEffects"))
-    fun getMatchingUniquesWithNonLocalEffects(uniqueType: UniqueType, gameContext: GameContext = state): Sequence<Unique> {
-        val uniques = cityConstructions.builtBuildingUniqueMap.getUniques(uniqueType)
-        // Memory performance showed that this function was very memory intensive, thus we only create the filter if needed
-        return if (uniques.any()) uniques.filter { !it.isLocalEffect && !it.isTimedTriggerable
-            && it.conditionalsApply(gameContext) }.flatMap { it.getMultiplied(gameContext) }
-        else uniques
+    fun getMatchingUniquesWithNonLocalEffects(uniqueType: UniqueType, gameContext: GameContext = state): Sequence<Unique> =
+        getMatchingUniquesWithNonLocalEffectsSnapshot(uniqueType, gameContext).asSequence()
+
+    /** @return a stable snapshot List of uniques coming from this city, but that should be provided globally */
+    @Readonly
+    fun getMatchingUniquesWithNonLocalEffectsSnapshot(uniqueType: UniqueType, gameContext: GameContext = state): List<Unique> {
+        val uniques = ArrayList<Unique>()
+        forEachMatchingUniqueWithNonLocalEffects(uniqueType, gameContext) { uniques.add(it) }
+        return uniques
     }
 
     // Uniques coming from this city, but that should be provided globally
     @Readonly
-    fun forEachMatchingUniqueWithNonLocalEffects(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit)
-        = cityConstructions.builtBuildingUniqueMap.forEachMatchingUnique(uniqueType, gameContext, nonLocalUniqueFilter, op)
+    inline fun firstMatchingUniqueWithNonLocalEffectsOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (unique: Unique)->Boolean): Unique?
+        = cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, nonLocalUniqueFilter, predicate)
+    @Readonly
+    inline fun forEachMatchingUniqueWithNonLocalEffects(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (unique: Unique)->Unit)
+        = firstMatchingUniqueWithNonLocalEffectsOrNull(uniqueType, gameContext) { op(it); false }
 
     // All uniques affecting this city: both local uniques and civ uniques.
     // This replaces LocalUniqueCache#forCityGetMatchingUniques
+    // Not inline: civ.forEachMatchingUnique is itself not inline (3+ inner calls)
     @Readonly
     fun forEachAffectingMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, op: (unique: Unique)->Unit) {
         forEachLocalMatchingUnique(uniqueType, gameContext, op)
@@ -739,23 +779,53 @@ class City : IsPartOfGameInfoSerialization, INamed {
     }
 
     @Readonly
+    fun hasMatchingUnique(uniqueType: UniqueType, predicate: (unique: Unique)->Boolean)
+        = firstMatchingUniqueOrNull(uniqueType, state, true, predicate) != null
+    @Readonly
+    fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, includeCivUniques: Boolean = true, predicate: (unique: Unique)->Boolean = {true})
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, includeCivUniques, predicate) != null
+
+    @Readonly
+    fun firstTriggeredUniqueOrNull(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean = { true },
+        includeCivUniques: Boolean = true,
+        predicate: (Unique) -> Boolean): Unique? {
+        if (includeCivUniques) {
+            return civ.firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, predicate)
+                ?: firstLocalTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, predicate)
+        }
+        else {
+            fun filter(unique: Unique): Boolean  =
+                unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
+            return cityConstructions.builtBuildingUniqueMap.firstUniqueOrNull(::filter, predicate)
+                ?: religion.firstUniqueOrNull(::filter, predicate)
+        }
+    }
+
+    // Not inline: firstTriggeredUniqueOrNull delegates to 3+ inner calls and has local functions
+    @Readonly
     fun forEachTriggeredUnique(
         trigger: UniqueType,
         gameContext: GameContext = state,
         triggerFilter: (Unique) -> Boolean = { true },
         includeCivUniques: Boolean = true,
         op: (Unique) -> Unit) {
-        if (includeCivUniques) {
-            civ.forEachTriggeredUnique(trigger, gameContext, triggerFilter, op)
-            forEachLocalTriggeredUnique(trigger, gameContext, triggerFilter, op)
-        }
-        else {
-            fun filter(unique: Unique): Boolean  =
-                unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
-            fun multipliedOp(unique: Unique) = unique.forEachMultiplied(gameContext, op)
-            cityConstructions.builtBuildingUniqueMap.forEachUnique(::filter, ::multipliedOp)
-            religion.forEachUnique(::filter, ::multipliedOp)
-        }
+        firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, includeCivUniques) {op(it); false}
+    }
+
+    /** @return A freshly allocated [List] snapshot of the triggered uniques, for cases that need to trigger uniques
+     *  that may mutate this city's own uniques (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly
+    fun getTriggeredUniquesSnapshot(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean = { true },
+        includeCivUniques: Boolean = true): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachTriggeredUnique(trigger, gameContext, triggerFilter, includeCivUniques) { list.add(it) }
+        return list
     }
 
     @Readonly
@@ -768,6 +838,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         }.flatMap { it.getMultiplied(gameContext) }
     }
 
+    // Not inline: the canonical firstLocalTriggeredUniqueOrNull below uses local functions, which inline functions can't contain
     @Readonly
     fun forEachLocalTriggeredUnique(trigger: UniqueType, gameContext: GameContext = state, op: (Unique)->Unit)
         = forEachLocalTriggeredUnique(trigger, gameContext, {true}, op)
@@ -775,12 +846,21 @@ class City : IsPartOfGameInfoSerialization, INamed {
     // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getLocalTriggeredUniques
     fun forEachLocalTriggeredUnique(trigger: UniqueType, gameContext: GameContext = state,
                                  triggerFilter: (Unique) -> Boolean, op: (Unique)->Unit) {
+        firstLocalTriggeredUniqueOrNull(trigger, gameContext, triggerFilter) {op(it); false}
+    }
+    @Readonly
+    fun firstLocalTriggeredUniqueOrNull(trigger: UniqueType, gameContext: GameContext = state, predicate: (Unique)->Boolean): Unique?
+        = firstLocalTriggeredUniqueOrNull(trigger, gameContext, {true}, predicate)
+    @Readonly
+    // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getLocalTriggeredUniques
+    fun firstLocalTriggeredUniqueOrNull(trigger: UniqueType, gameContext: GameContext = state,
+                                    triggerFilter: (Unique) -> Boolean, predicate: (Unique)->Boolean): Unique? {
         fun uniqueFilter(unique: Unique): Boolean
             = unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
         fun buildingFilter(unique: Unique): Boolean
             = unique.isLocalEffect && uniqueFilter(unique)
-        cityConstructions.builtBuildingUniqueMap.forEachUnique(::buildingFilter, op)
-        religion.forEachUnique(::uniqueFilter, op)
+        return cityConstructions.builtBuildingUniqueMap.firstUniqueOrNull(::buildingFilter, predicate)
+            ?: religion.firstUniqueOrNull(::uniqueFilter, predicate)
     }
 
     //endregion

--- a/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
@@ -69,13 +69,19 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
     }
 
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, op: (unique: Unique)->Unit)
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline op: (unique: Unique)->Unit)
         = forEachMatchingUnique(uniqueType, gameContext, NO_UNIQUE_FILTER, op)
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, filter:(Unique)->Boolean, op: (unique: Unique)->Unit) {
-        val majorityReligion = getMajorityReligion() ?: return
-        majorityReligion.followerBeliefUniqueMap.forEachMatchingUnique(uniqueType, gameContext, filter, op)
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline filter:(Unique)->Boolean, crossinline op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, gameContext, filter) { op(it); false }
     }
+
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline predicate: (unique: Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, NO_UNIQUE_FILTER, predicate)
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline filter:(Unique)->Boolean, crossinline predicate: (unique: Unique)->Boolean): Unique? 
+        = getMajorityReligion()?.followerBeliefUniqueMap?.firstMatchingUniqueOrNull(uniqueType, gameContext, filter, predicate)
 
     @Readonly
     fun getAllUniques(): Sequence<Unique> {
@@ -84,10 +90,13 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
     }
 
     @Readonly
-    fun forEachUnique(filter:(Unique)->Boolean, op: (unique: Unique)->Unit) {
-        val majorityReligion = getMajorityReligion() ?: return
-        majorityReligion.followerBeliefUniqueMap.forEachUnique(filter, op)
+    inline fun forEachUnique(filter:(Unique)->Boolean, crossinline op: (unique: Unique)->Unit) {
+        firstUniqueOrNull(filter) { op(it); false }
     }
+
+    @Readonly
+    inline fun firstUniqueOrNull(filter:(Unique)->Boolean, crossinline predicate: (unique: Unique)->Boolean): Unique? 
+        = getMajorityReligion()?.followerBeliefUniqueMap?.firstUniqueOrNull(filter, predicate)
 
     @Readonly fun getPressures(): Counter<String> = pressures.clone()
 

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -600,8 +600,12 @@ class Civilization : IsPartOfGameInfoSerialization {
     @Readonly fun hasResource(resource: TileResource): Boolean = getResourceAmount(resource) > 0
 
     @Readonly
-    fun hasUnique(uniqueType: UniqueType, gameContext: GameContext = state) =
-        getMatchingUniques(uniqueType, gameContext).any()
+    inline fun hasUnique(uniqueType: UniqueType, gameContext: GameContext = state, noinline predicate: (Unique)->Boolean = { true }) =
+        firstMatchingUniqueOrNull(uniqueType, gameContext, predicate) != null
+
+    @Readonly
+    inline fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, noinline predicate: (unique: Unique)->Boolean) =
+        firstMatchingUniqueOrNull(uniqueType, gameContext, predicate) != null
 
     // Does not return local uniques, only global ones.
     /** Destined to replace getMatchingUniques, gradually, as we fill the enum */
@@ -611,36 +615,45 @@ class Civilization : IsPartOfGameInfoSerialization {
     fun getMatchingUniques(
         uniqueType: UniqueType,
         gameContext: GameContext = state
-    ): Sequence<Unique> = sequence {
-        yieldAll(nation.getMatchingUniques(uniqueType, gameContext))
-        yieldAll(cities.asSequence()
-            .flatMap { city -> city.getMatchingUniquesWithNonLocalEffects(uniqueType, gameContext) }
-        )
-        yieldAll(policies.policyUniques.getMatchingUniques(uniqueType, gameContext))
-        yieldAll(tech.techUniques.getMatchingUniques(uniqueType, gameContext))
-        yieldAll(temporaryUniques.getMatchingTagUniques(uniqueType, gameContext))
-        yieldAll(getEra().getMatchingUniques(uniqueType, gameContext))
-        yieldAll(cityStateFunctions.getUniquesProvidedByCityStates(uniqueType, gameContext))
-        if (religionManager.religion != null)
-            yieldAll(religionManager.religion!!.founderBeliefUniqueMap.getMatchingUniques(uniqueType, gameContext))
+    ): Sequence<Unique> = getMatchingUniquesSnapshot(uniqueType, gameContext).asSequence()
 
-        yieldAll(civResourcesUniqueMap.getMatchingUniques(uniqueType, gameContext))
-        yieldAll(gameInfo.getGlobalUniques().getMatchingUniques(uniqueType, gameContext))
+    /** @return a stable snapshot List of uniques matching [uniqueType], safe to keep iterating even if the
+     *  underlying uniques change mid-iteration - unlike [forEachMatchingUnique]. */
+    @Readonly
+    fun getMatchingUniquesSnapshot(uniqueType: UniqueType, gameContext: GameContext = state): List<Unique> {
+        val uniques = ArrayList<Unique>()
+        forEachMatchingUnique(uniqueType, gameContext) { uniques.add(it) }
+        return uniques
     }
 
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, op: (unique: Unique)->Unit) {
-        nation.forEachMatchingUnique(uniqueType, gameContext, op)
-        for (i in 0..<cities.size)
-            cities[i].forEachMatchingUniqueWithNonLocalEffects(uniqueType, gameContext, op)
-        policies.policyUniques.forEachMatchingUnique(uniqueType, gameContext, op)
-        tech.techUniques.forEachMatchingUnique(uniqueType, gameContext, op)
-        temporaryUniques.forEachMatchingUnique(uniqueType, gameContext, op)
-        getEra().forEachMatchingUnique(uniqueType, gameContext, op)
-        cityStateFunctions.forEachUniqueProvidedByCityStates(uniqueType, gameContext, op)
-        religionManager.religion?.founderBeliefUniqueMap?.forEachMatchingUnique(uniqueType, gameContext, op)
-        civResourcesUniqueMap.forEachMatchingUnique(uniqueType, gameContext, op)
-        gameInfo.getGlobalUniques().forEachMatchingUnique(uniqueType, gameContext, op)
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, crossinline op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, gameContext) { op(it); false }
+    }
+
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, initial: T, crossinline accumulate: (T, Unique) -> T): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext) { acc = accumulate(acc, it) }
+        return acc
+    }
+
+    @Readonly
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext = state, predicate: (unique: Unique)->Boolean): Unique? {
+        for (i in 0..<cities.size) {
+            val r = cities[i].firstMatchingUniqueWithNonLocalEffectsOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            if (r != null) return r
+        }
+        return nation.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: policies.policyUniques.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: tech.techUniques.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: temporaryUniques.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: getEra().firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: cityStateFunctions.firstUniqueProvidedByCityStatesOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: religionManager.religion?.founderBeliefUniqueMap?.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: civResourcesUniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: gameInfo.getGlobalUniques().firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
     }
 
     @Readonly
@@ -705,25 +718,54 @@ class Civilization : IsPartOfGameInfoSerialization {
         ignoreCities: Boolean,
         op: (Unique)->Unit,
     ) {
-        // Gathering all uniques into a list first since triggers can add e.g. buildings 
+        // Gathering all uniques into a list first since triggers can add e.g. buildings
         // which contain triggers, causing concurrent modification errors.
         // Cannont use getTriggeredUniques from uniqueMaps since we don't want to check conditionals yet
-        val uniqueFilter = { unique: Unique -> unique.getModifiers(trigger).any(triggerFilter) }
         val uniqueList = ArrayList<Unique>(100)
         val listOp: (Unique)->Unit = { unique: Unique -> uniqueList.add(unique) }
-        nation.uniqueMap.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
+        nation.uniqueMap.forEachTriggeredUnique(trigger, gameContext, triggerFilter, listOp)
         if (!ignoreCities) {
             cities.forEach {city ->
-                city.cityConstructions.builtBuildingUniqueMap.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
+                city.cityConstructions.builtBuildingUniqueMap.forEachTriggeredUnique(trigger, gameContext, triggerFilter, listOp)
             }
         }
-        religionManager.religion?.founderBeliefUniqueMap?.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
-        policies.policyUniques.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
-        tech.techUniques.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
-        getEra().uniqueMap.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
-        gameInfo.getGlobalUniques().uniqueMap.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
+        religionManager.religion?.founderBeliefUniqueMap?.forEachTriggeredUnique(trigger, gameContext, triggerFilter, listOp)
+        policies.policyUniques.forEachTriggeredUnique(trigger, gameContext, triggerFilter, listOp)
+        tech.techUniques.forEachTriggeredUnique(trigger, gameContext, triggerFilter, listOp)
+        getEra().uniqueMap.forEachTriggeredUnique(trigger, gameContext, triggerFilter, listOp)
+        gameInfo.getGlobalUniques().uniqueMap.forEachTriggeredUnique(trigger, gameContext, triggerFilter, listOp)
         // now its safe to do the op, which might mutate the lists
         uniqueList.forEach(op)
+    }
+
+    @Readonly
+    fun firstTriggeredUniqueOrNull(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean,
+        predicate: (Unique)->Boolean,
+    ): Unique? = firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, false, predicate)
+    @Readonly
+    fun firstTriggeredUniqueOrNull(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean = { true },
+        ignoreCities: Boolean,
+        predicate: (Unique)->Boolean,
+    ): Unique? {
+        val uniqueFilter = { unique: Unique -> unique.getModifiers(trigger).any(triggerFilter) }
+        nation.uniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+        if (!ignoreCities) {
+            for (city in cities) {
+                var r = city.cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+                if (r != null) return r
+            }
+        }
+        return religionManager.religion?.founderBeliefUniqueMap?.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: policies.policyUniques.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: tech.techUniques.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: getEra().uniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: gameInfo.getGlobalUniques().uniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)
     }
     /** Implements [UniqueParameterType.CivFilter][com.unciv.models.ruleset.unique.UniqueParameterType.CivFilter] */
     @Readonly

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -822,10 +822,17 @@ class CityStateFunctions(val civInfo: Civilization) {
     }
 
     @Readonly
-    fun forEachUniqueProvidedByCityStates(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique) -> Unit) {
-        if (civInfo.isCityState) return
-        for (uniqueMap in civInfo.cache.cityStateBonusUniqueMaps)
-            uniqueMap.forEachMatchingUnique(uniqueType, gameContext, op)
+    inline fun forEachUniqueProvidedByCityStates(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (unique: Unique) -> Unit)
+        = firstUniqueProvidedByCityStatesOrNull(uniqueType, gameContext) { op(it); false }
+
+    @Readonly
+    inline fun firstUniqueProvidedByCityStatesOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (unique: Unique) -> Boolean): Unique? {
+        if (civInfo.isCityState) return null
+        for (uniqueMap in civInfo.cache.cityStateBonusUniqueMaps) {
+            val result = uniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+            if (result != null) return result
+        }
+        return null
     }
 
     companion object {

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -288,42 +288,154 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
                     }
                 }.filterNotNull()
 
+    /** @return All tiles in a hexagon of radius [distance], including the tile at [origin] and all up to [distance] steps away, as a
+     *  freshly allocated [List] snapshot that will not change if the map is mutated afterwards.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun getTilesInDistanceSnapshot(origin: HexCoord, distance: Int): List<Tile> {
+        val list = ArrayList<Tile>()
+        forEachTileInDistance(origin, distance) { list.add(it) }
+        return list
+    }
+
+    /** @return All tiles in a hexagonal ring around [origin] with the distances in [range], as a freshly allocated [List] snapshot
+     *  that will not change if the map is mutated afterwards. Excludes the [origin] tile unless [range] starts at 0.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun getTilesInDistanceRangeSnapshot(origin: HexCoord, range: IntRange): List<Tile> {
+        val list = ArrayList<Tile>()
+        forEachTileInDistanceRange(origin, range) { list.add(it) }
+        return list
+    }
+
+    /** @return All tiles in a hexagonal ring 1 tile wide around [origin] with the [distance], as a freshly allocated [List] snapshot
+     *  that will not change if the map is mutated afterwards. Contains the [origin] if and only if [distance] is <= 0.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun getTilesAtDistanceSnapshot(origin: HexCoord, distance: Int): List<Tile> {
+        val list = ArrayList<Tile>()
+        forEachTileAtDistance(origin, distance) { list.add(it) }
+        return list
+    }
+
     /** @return All tiles in a hexagon of radius [distance], including the tile at [origin] and all up to [distance] steps away.
      *  Respects map edges and world wrap. */
     @Readonly
-    fun forEachTileInDistance(origin: HexCoord, distance: Int, op: (Tile)->Unit)
+    inline fun forEachTileInDistance(origin: HexCoord, distance: Int, crossinline op: (Tile)->Unit)
         = forEachTileInDistance(origin, distance, {true}, op)
     @Readonly
-    fun forEachTileInDistance(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) {
+    inline fun forEachTileInDistance(origin: HexCoord, distance: Int, noinline filter: (Tile)->Boolean, crossinline op: (Tile)->Unit) {
         for (i in 0..distance)
             forEachTileAtDistance(origin, i, filter, op)
+    }
+
+    /** @return The first tile in a hexagon of radius [distance] (including the tile at [origin]) for which [predicate] returns true, or null if none does.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun firstTileInDistanceOrNull(origin: HexCoord, distance: Int, noinline predicate: (Tile)->Boolean): Tile?
+        = firstTileInDistanceOrNull(origin, distance, {true}, predicate)
+    @Readonly
+    inline fun firstTileInDistanceOrNull(origin: HexCoord, distance: Int, noinline filter: (Tile)->Boolean, noinline predicate: (Tile)->Boolean): Tile? {
+        for (i in 0..distance) {
+            val result = firstTileAtDistanceOrNull(origin, i, filter, predicate)
+            if (result != null) return result
+        }
+        return null
+    }
+
+    /** @return Whether any tile in a hexagon of radius [distance] (including the tile at [origin]) matches [predicate].
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun anyTileInDistance(origin: HexCoord, distance: Int, noinline predicate: (Tile)->Boolean): Boolean
+        = firstTileInDistanceOrNull(origin, distance, predicate) != null
+    @Readonly
+    inline fun anyTileInDistance(origin: HexCoord, distance: Int, noinline filter: (Tile)->Boolean, noinline predicate: (Tile)->Boolean): Boolean
+        = firstTileInDistanceOrNull(origin, distance, filter, predicate) != null
+
+    /** @return The number of tiles in a hexagon of radius [distance] (including the tile at [origin]) that match [predicate].
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun countTilesInDistance(origin: HexCoord, distance: Int, crossinline predicate: (Tile)->Boolean): Int {
+        var count = 0
+        forEachTileInDistance(origin, distance) { if (predicate(it)) count++ }
+        return count
+    }
+
+    /** Folds [accumulate] over every tile in a hexagon of radius [distance] (including the tile at [origin]), starting from [initial].
+     *  Useful for e.g. collecting matching tiles into a list/set/map without a separate forEach+add step. */
+    @Readonly
+    inline fun <T> accumulateForEachTileInDistance(origin: HexCoord, distance: Int, initial: T, crossinline accumulate: (T, Tile) -> T): T {
+        var acc = initial
+        forEachTileInDistance(origin, distance) { acc = accumulate(acc, it) }
+        return acc
     }
 
     /** @return All tiles in a hexagonal ring around [origin] with the distances in [range]. Excludes the [origin] tile unless [range] starts at 0.
      *  Respects map edges and world wrap. */
     @Readonly
-    fun forEachTileInDistanceRange(origin: HexCoord, range: IntRange, op: (Tile)->Unit)
+    inline fun forEachTileInDistanceRange(origin: HexCoord, range: IntRange, crossinline op: (Tile)->Unit)
         = forEachTileInDistanceRange(origin, range, {true}, op)
     @Readonly
-    fun forEachTileInDistanceRange(origin: HexCoord, range: IntRange, filter: (Tile)->Boolean, op: (Tile)->Unit) {
+    inline fun forEachTileInDistanceRange(origin: HexCoord, range: IntRange, noinline filter: (Tile)->Boolean, crossinline op: (Tile)->Unit) {
         for (i in range)
             forEachTileAtDistance(origin, i, filter, op)
+    }
+
+    /** @return The number of tiles in a hexagonal ring around [origin] with the distances in [range] that match [predicate].
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun countTilesInDistanceRange(origin: HexCoord, range: IntRange, crossinline predicate: (Tile)->Boolean): Int {
+        var count = 0
+        forEachTileInDistanceRange(origin, range) { if (predicate(it)) count++ }
+        return count
+    }
+
+    /** Folds [accumulate] over every tile in a hexagonal ring around [origin] with the distances in [range], starting from [initial]. */
+    @Readonly
+    inline fun <T> accumulateForEachTileInDistanceRange(origin: HexCoord, range: IntRange, initial: T, crossinline accumulate: (T, Tile) -> T): T {
+        var acc = initial
+        forEachTileInDistanceRange(origin, range) { acc = accumulate(acc, it) }
+        return acc
+    }
+
+    /** @return The tile in a hexagonal ring around [origin] with the distances in [range] with the highest [selector] value, paired with that value,
+     *  or null if there are no tiles in range. Respects map edges and world wrap. */
+    inline fun <R : Comparable<R>> maxTileInDistanceRange(origin: HexCoord, range: IntRange, crossinline selector: (Tile)->R): Pair<Tile, R>? {
+        var bestTile: Tile? = null
+        var bestValue: R? = null
+        forEachTileInDistanceRange(origin, range) {
+            val value = selector(it)
+            if (bestValue == null || value > bestValue!!) {
+                bestTile = it
+                bestValue = value
+            }
+        }
+        return if (bestTile != null) bestTile to bestValue!! else null
     }
 
     /** @return All tiles in a hexagonal ring 1 tile wide around [origin] with the [distance]. Contains the [origin] if and only if [distance] is <= 0.
      *  Respects map edges and world wrap. */
     @Readonly
-    fun forEachTileAtDistance(origin: HexCoord, distance: Int, op: (Tile)->Unit)
+    inline fun forEachTileAtDistance(origin: HexCoord, distance: Int, crossinline op: (Tile)->Unit)
         = forEachTileAtDistance(origin, distance, {true}, op)
     @Readonly
-    fun forEachTileAtDistance(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) {
+    inline fun forEachTileAtDistance(origin: HexCoord, distance: Int, noinline filter: (Tile)->Boolean, crossinline op: (Tile)->Unit) {
+         firstTileAtDistanceOrNull(origin, distance, filter) { op(it); false }
+    }
+
+    /** @return The first tile in a hexagonal ring 1 tile wide around [origin] with the [distance], for which [predicate] returns true, or null if none does.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun firstTileAtDistanceOrNull(origin: HexCoord, distance: Int, noinline predicate: (Tile)->Boolean): Tile?
+        = firstTileAtDistanceOrNull(origin, distance, {true}, predicate)
+    @Readonly
+    fun firstTileAtDistanceOrNull(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, predicate: (Tile)->Boolean): Tile? {
         if (distance <= 0) {
             val tile = get(origin)
-            if (filter(tile)) op(tile)
+            if (filter(tile) && predicate(tile)) return tile
         } else if (distance == 1) {
             for (tile in get(origin).neighbors) {
-                if (filter(tile))
-                    op(tile)
+                if (filter(tile) && predicate(tile)) return tile
             }
         } else {
             val centerX = origin.x
@@ -336,30 +448,45 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             var tile: Tile?
             repeat (distance) { // From 6 to 8
                 tile = getIfTileExistsOrNull(currentX, currentY)
-                if (tile != null && filter(tile)) op(tile)
-                // We want to get the tile on the other side of the clock,
-                // so if we're at current = origin-delta we want to get to origin+delta.
-                // The simplest way to do this is 2*origin - current = 2*origin- (origin - delta) = origin+delta
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 currentX += 1 // we're going upwards to the left, towards 8 o'clock
             }
             repeat (distance) { // 8 to 10
                 tile = getIfTileExistsOrNull(currentX, currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 currentX += 1
                 currentY += 1 // we're going up the left side of the hexagon so we're going "up" - +1,+1
             }
             repeat (distance) { // 10 to 12
                 tile = getIfTileExistsOrNull(currentX, currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 currentY += 1 // we're going up the top left side of the hexagon so we're heading "up and to the right"
             }
         }
+        return null
+    }
+
+    /** @return The number of tiles in a hexagonal ring 1 tile wide around [origin] with the [distance] that match [predicate].
+     *  Respects map edges and world wrap. */
+    @Readonly
+    inline fun countTilesAtDistance(origin: HexCoord, distance: Int, crossinline predicate: (Tile)->Boolean): Int {
+        var count = 0
+        forEachTileAtDistance(origin, distance) { if (predicate(it)) count++ }
+        return count
+    }
+
+    /** Folds [accumulate] over every tile in a hexagonal ring 1 tile wide around [origin] with the [distance], starting from [initial]. */
+    @Readonly
+    inline fun <T> accumulateForEachTileAtDistance(origin: HexCoord, distance: Int, initial: T, crossinline accumulate: (T, Tile) -> T): T {
+        var acc = initial
+        forEachTileAtDistance(origin, distance) { acc = accumulate(acc, it) }
+        return acc
     }
 
     /** @return all tiles within [rectangle], respecting world edges and wrap.

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -136,7 +136,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     fun hasTile() = ::currentTile.isInitialized
 
     @Transient
-    private var tempUniquesMap = UniqueMap()
+    @PublishedApi internal var tempUniquesMap = UniqueMap()
 
     @Transient
     /** Temp map excluding unit uniques*/
@@ -325,37 +325,127 @@ class MapUnit : IsPartOfGameInfoSerialization {
             yieldAll(civ.getMatchingUniques(uniqueType, gameContext))
     }
 
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueType], for cases that need to mutate
+     *  this unit's uniques (or otherwise cannot use a live view) while iterating the result. */
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, op: (Unique)->Unit)
-        = forEachMatchingUnique(uniqueType, gameContext, checkCivInfoUniques = false, op)
-    @Readonly
-    fun forEachMatchingUnique(
-        uniqueType: UniqueType,
-        gameContext: GameContext = cache.state,
-        checkCivInfoUniques: Boolean,
-        op: (Unique)->Unit,
-    ) {
-        tempUniquesMap.forEachMatchingUnique(uniqueType, gameContext, op)
-        if (checkCivInfoUniques)
-            civ.forEachMatchingUnique(uniqueType, gameContext, op)
-    }
-
-    @Readonly
-    fun hasUnique(
+    fun getMatchingUniquesSnapshot(
         uniqueType: UniqueType,
         gameContext: GameContext = cache.state,
         checkCivInfoUniques: Boolean = false
-    ): Boolean {
-        return getMatchingUniques(uniqueType, gameContext, checkCivInfoUniques).any()
+    ): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachMatchingUnique(uniqueType, gameContext) { list.add(it) }
+        if (checkCivInfoUniques)
+            civ.forEachMatchingUnique(uniqueType, gameContext) { list.add(it) }
+        return list
     }
 
     @Readonly
-    fun getTriggeredUniques(
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, crossinline op: (Unique)->Unit)
+        = forEachMatchingUnique(uniqueType, gameContext, checkCivInfoUniques = false, op)
+    @Readonly
+    inline fun forEachMatchingUnique(
+        uniqueType: UniqueType,
+        gameContext: GameContext = cache.state,
+        checkCivInfoUniques: Boolean,
+        crossinline op: (Unique)->Unit,
+    )
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, checkCivInfoUniques) { op(it); false }
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, initial: T, crossinline accumulate: (T, Unique) -> T): T
+        = accumulateForEachMatchingUnique(uniqueType, gameContext, checkCivInfoUniques = false, initial, accumulate)
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(
+        uniqueType: UniqueType,
+        gameContext: GameContext = cache.state,
+        checkCivInfoUniques: Boolean,
+        initial: T,
+        crossinline accumulate: (T, Unique) -> T
+    ): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext, checkCivInfoUniques) { acc = accumulate(acc, it) }
+        return acc
+    }
+
+    /** @return the unique matching [uniqueType] for which [selector] returns the highest value, or null if [selector] returns null for
+     *  every matching unique (useful to combine filtering and comparison in one step) or there are no matching uniques at all. */
+    @Readonly
+    inline fun maxByMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, crossinline selector: (Unique) -> Float?): Unique? {
+        var best: Unique? = null
+        var bestValue = Float.NEGATIVE_INFINITY
+        forEachMatchingUnique(uniqueType, gameContext) { unique ->
+            val value = selector(unique) ?: return@forEachMatchingUnique
+            if (value > bestValue) {
+                best = unique
+                bestValue = value
+            }
+        }
+        return best
+    }
+
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext = cache.state, noinline predicate: (Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, checkCivInfoUniques = false, predicate)
+    @Readonly
+    fun firstMatchingUniqueOrNull(
+        uniqueType: UniqueType,
+        gameContext: GameContext = cache.state,
+        checkCivInfoUniques: Boolean,
+        predicate: (Unique)->Boolean,
+    ): Unique? {
+        val r = tempUniquesMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+        if (r != null) return r
+        if (checkCivInfoUniques)
+            return civ.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+        return null
+    }
+
+    @Readonly
+    inline fun hasUnique(
+        uniqueType: UniqueType,
+        gameContext: GameContext = cache.state,
+        checkCivInfoUniques: Boolean = false,
+        noinline predicate: (Unique)->Boolean = {true}
+    ): Boolean {
+        return firstMatchingUniqueOrNull(uniqueType, gameContext, checkCivInfoUniques, predicate) != null
+    }
+
+    @Readonly
+    inline fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, noinline predicate: (Unique)->Boolean) =
+        hasUnique(uniqueType, gameContext, checkCivInfoUniques = false, predicate)
+
+    @Readonly
+    inline fun getTriggeredUniques(
         trigger: UniqueType,
         gameContext: GameContext = cache.state,
-        triggerFilter: (Unique) -> Boolean = { true }
+        noinline triggerFilter: (Unique) -> Boolean = { true }
     ): Sequence<Unique> {
         return tempUniquesMap.getTriggeredUniques(trigger, gameContext, triggerFilter)
+    }
+
+    @Readonly
+    inline fun forEachTriggeredUnique(
+        trigger: UniqueType,
+        gameContext: GameContext = cache.state,
+        crossinline triggerFilter: (Unique) -> Boolean = { true },
+        crossinline op: (Unique) -> Unit
+    ) {
+        tempUniquesMap.forEachTriggeredUnique(trigger, gameContext, triggerFilter, op)
+    }
+
+    /** @return a stable snapshot List of triggered uniques - unlike [forEachTriggeredUnique], safe to keep iterating
+     *  while triggering mutations to this unit's own uniques (which would otherwise risk a ConcurrentModificationException,
+     *  since [tempUniquesMap] is iterated live by [forEachTriggeredUnique]). */
+    @Readonly
+    inline fun getTriggeredUniquesSnapshot(
+        trigger: UniqueType,
+        gameContext: GameContext = cache.state,
+        crossinline triggerFilter: (Unique) -> Boolean = { true }
+    ): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachTriggeredUnique(trigger, gameContext, triggerFilter) { list.add(it) }
+        return list
     }
 
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -633,12 +633,33 @@ class Tile : IsPartOfGameInfoSerialization {
         replaceWith = ReplaceWith("forEachTileAtDistance"))
     @Readonly fun getTilesAtDistance(distance: Int): Sequence<Tile> = tileMap.getTilesAtDistance(position, distance)
 
-    @Readonly fun forEachTileInDistance(distance: Int, op: (Tile)->Unit) = tileMap.forEachTileInDistance(position, distance, op)
-    @Readonly fun forEachTileInDistance(distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) = tileMap.forEachTileInDistance(position, distance, filter, op)
-    @Readonly fun forEachTileInDistanceRange(range: IntRange, op: (Tile)->Unit) = tileMap.forEachTileInDistanceRange(position, range, op)
-    @Readonly fun forEachTileInDistanceRange(range: IntRange, filter: (Tile)->Boolean, op: (Tile)->Unit) = tileMap.forEachTileInDistanceRange(position, range, filter, op)
-    @Readonly fun forEachTileAtDistance(distance: Int, op: (Tile)->Unit) = tileMap.forEachTileAtDistance(position, distance, op)
-    @Readonly fun forEachTileAtDistance(distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) = tileMap.forEachTileAtDistance(position, distance, filter, op)
+    /** @return All tiles in a hexagon of radius [distance] as a freshly allocated [List] snapshot, for cases that need to
+     *  mutate the map (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly fun getTilesInDistanceSnapshot(distance: Int): List<Tile> = tileMap.getTilesInDistanceSnapshot(position, distance)
+    /** @return All tiles in a hexagonal ring in [range] as a freshly allocated [List] snapshot, for cases that need to
+     *  mutate the map (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly fun getTilesInDistanceRangeSnapshot(range: IntRange): List<Tile> = tileMap.getTilesInDistanceRangeSnapshot(position, range)
+    /** @return All tiles at [distance] as a freshly allocated [List] snapshot, for cases that need to
+     *  mutate the map (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly fun getTilesAtDistanceSnapshot(distance: Int): List<Tile> = tileMap.getTilesAtDistanceSnapshot(position, distance)
+
+    @Readonly inline fun forEachTileInDistance(distance: Int, crossinline op: (Tile)->Unit) = tileMap.forEachTileInDistance(position, distance, op)
+    @Readonly inline fun forEachTileInDistance(distance: Int, noinline filter: (Tile)->Boolean, crossinline op: (Tile)->Unit) = tileMap.forEachTileInDistance(position, distance, filter, op)
+    @Readonly inline fun firstTileInDistanceOrNull(distance: Int, noinline predicate: (Tile)->Boolean) = tileMap.firstTileInDistanceOrNull(position, distance, predicate)
+    @Readonly inline fun firstTileInDistanceOrNull(distance: Int, noinline filter: (Tile)->Boolean, noinline predicate: (Tile)->Boolean) = tileMap.firstTileInDistanceOrNull(position, distance, filter, predicate)
+    @Readonly inline fun anyTileInDistance(distance: Int, noinline predicate: (Tile)->Boolean) = tileMap.anyTileInDistance(position, distance, predicate)
+    @Readonly inline fun anyTileInDistance(distance: Int, noinline filter: (Tile)->Boolean, noinline predicate: (Tile)->Boolean) = tileMap.anyTileInDistance(position, distance, filter, predicate)
+    @Readonly inline fun countTilesInDistance(distance: Int, crossinline predicate: (Tile)->Boolean) = tileMap.countTilesInDistance(position, distance, predicate)
+    @Readonly inline fun <T> accumulateForEachTileInDistance(distance: Int, initial: T, crossinline accumulate: (T, Tile) -> T) = tileMap.accumulateForEachTileInDistance(position, distance, initial, accumulate)
+    @Readonly inline fun forEachTileInDistanceRange(range: IntRange, crossinline op: (Tile)->Unit) = tileMap.forEachTileInDistanceRange(position, range, op)
+    @Readonly inline fun forEachTileInDistanceRange(range: IntRange, noinline filter: (Tile)->Boolean, crossinline op: (Tile)->Unit) = tileMap.forEachTileInDistanceRange(position, range, filter, op)
+    @Readonly inline fun countTilesInDistanceRange(range: IntRange, crossinline predicate: (Tile)->Boolean) = tileMap.countTilesInDistanceRange(position, range, predicate)
+    @Readonly inline fun <T> accumulateForEachTileInDistanceRange(range: IntRange, initial: T, crossinline accumulate: (T, Tile) -> T) = tileMap.accumulateForEachTileInDistanceRange(position, range, initial, accumulate)
+    inline fun <R : Comparable<R>> maxTileInDistanceRange(range: IntRange, crossinline selector: (Tile)->R) = tileMap.maxTileInDistanceRange(position, range, selector)
+    @Readonly inline fun forEachTileAtDistance(distance: Int, crossinline op: (Tile)->Unit) = tileMap.forEachTileAtDistance(position, distance, op)
+    @Readonly inline fun forEachTileAtDistance(distance: Int, noinline filter: (Tile)->Boolean, crossinline op: (Tile)->Unit) = tileMap.forEachTileAtDistance(position, distance, filter, op)
+    @Readonly inline fun countTilesAtDistance(distance: Int, crossinline predicate: (Tile)->Boolean) = tileMap.countTilesAtDistance(position, distance, predicate)
+    @Readonly inline fun <T> accumulateForEachTileAtDistance(distance: Int, initial: T, crossinline accumulate: (T, Tile) -> T) = tileMap.accumulateForEachTileAtDistance(position, distance, initial, accumulate)
 
     @Readonly
     fun getDefensiveBonus(includeImprovementBonus: Boolean = true, unit: MapUnit? = null): Float {

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -56,10 +56,51 @@ interface IHasUniques : INamed {
     @Readonly
     fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit)
         = uniqueMap.forEachMatchingUnique(uniqueType, gameContext, op)
+    
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses.
+     *  Not `inline` - interface members are virtual/open and Kotlin disallows `inline` on virtual members - so the accumulator
+     *  is held in a dedicated object's field rather than a captured `var`, to avoid the compiler boxing that `var` into a Ref. */
+    @Readonly
+    fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, initial: T, accumulate: (T, Unique) -> T): T {
+        // interface methods can't be `inline`, so we make an accumulator object to reduce allocations
+        val accumulator = object : (Unique) -> Unit {
+            var acc = initial
+            @Suppress("OVERRIDE_BY_INLINE")
+            override inline fun invoke(unique: Unique) { acc = accumulate(acc, unique) }
+        }
+        forEachMatchingUnique(uniqueType, gameContext, accumulator)
+        return accumulator.acc
+    }
+
+    @Readonly
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, filter:(Unique)->Boolean, predicate: (unique: Unique)->Boolean): Unique?
+        = uniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, filter, predicate)
+    @Readonly
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, predicate: (unique: Unique)->Boolean): Unique?
+        = uniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+
+    @Readonly
+    fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, filter: (unique: Unique)->Boolean, predicate: (unique: Unique)->Boolean): Boolean
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, filter, predicate) != null
+    @Readonly
+    fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = GameContext.EmptyState, predicate: (unique: Unique)->Boolean = { true }): Boolean
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, predicate) != null
 
     @Readonly
     fun getMatchingTagUniques(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
         uniqueMap.getMatchingTagUniques(uniqueTag, state)
+
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueType], for cases that need to mutate
+     *  [uniques] (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly
+    fun getMatchingUniquesSnapshot(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
+        uniqueMap.getMatchingUniquesSnapshot(uniqueType, state)
+
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueTag], for cases that need to mutate
+     *  [uniques] (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly
+    fun getMatchingTagUniquesSnapshot(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
+        uniqueMap.getMatchingTagUniquesSnapshot(uniqueTag, state)
 
     @Readonly
     fun hasUnique(uniqueType: UniqueType, state: GameContext? = null) =

--- a/core/src/com/unciv/models/ruleset/unique/TemporaryUnique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/TemporaryUnique.kt
@@ -42,10 +42,17 @@ fun ArrayList<TemporaryUnique>.getMatchingTagUniques(uniqueType: UniqueType, gam
 }
 
 @Readonly
-fun ArrayList<TemporaryUnique>.forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit) {
+inline fun ArrayList<TemporaryUnique>.forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (unique: Unique)->Unit)
+    = firstMatchingUniqueOrNull(uniqueType, gameContext) { op(it); false }
+
+
+@Readonly
+inline fun ArrayList<TemporaryUnique>.firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (unique: Unique)->Boolean): Unique? {
     for (i in 0..<size) {
         val unique = get(i).uniqueObject
-        if (unique.type == uniqueType && unique.conditionalsApply(gameContext))
-            unique.forEachMultiplied(gameContext, op)
+        if (unique.type == uniqueType && unique.conditionalsApply(gameContext) && predicate(unique)) {
+            return unique
+        }
     }
+    return null
 }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -145,6 +145,16 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             op(this)
     }
 
+    /** Multiplies the unique according to the multiplication conditionals, returning this unique
+     *  as soon as [predicate] returns true for it, or null if it never does (or the multiplier is 0) */
+    @Readonly
+    inline fun firstMultipliedOrNull(gameContext: GameContext, predicate: (Unique)->Boolean): Unique? {
+        val multiplier = getUniqueMultiplier(gameContext)
+        for (j in 0..<multiplier)
+            if (predicate(this)) return this
+        return null
+    }
+
     private class EndlessSequenceOf<T>(private val value: T) : Sequence<T> {
         override fun iterator(): Iterator<T> = object : Iterator<T> {
             override fun next() = value

--- a/core/src/com/unciv/models/ruleset/unique/UniqueMap.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueMap.kt
@@ -4,12 +4,12 @@ import yairm210.purity.annotations.Readonly
 import java.util.*
 
 open class UniqueMap() {
-    private val tagUniqueMap = HashMap<String, ArrayList<Unique>>()
+    @PublishedApi internal val tagUniqueMap = HashMap<String, ArrayList<Unique>>()
 
     // *shares* the list of uniques with the other map, to save on memory and allocations
     // This is a memory/speed tradeoff, since there are *600 unique types*,
     // 750 including deprecated, and EnumMap creates a N-sized array where N is the number of objects in the enum
-    private val typedUniqueMap = EnumMap<UniqueType, ArrayList<Unique>>(UniqueType::class.java)
+    @PublishedApi internal val typedUniqueMap = EnumMap<UniqueType, ArrayList<Unique>>(UniqueType::class.java)
 
     constructor(uniques: Sequence<Unique>) : this() {
         addUniques(uniques.asIterable())
@@ -45,12 +45,12 @@ open class UniqueMap() {
     fun isEmpty(): Boolean = tagUniqueMap.isEmpty()
     
     @Readonly
-    fun hasUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
-        getUniques(uniqueType).any { it.conditionalsApply(state) && !it.isTimedTriggerable }
+    inline fun hasUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
+        firstUniqueOrNull(uniqueType) { it.conditionalsApply(state) && !it.isTimedTriggerable } != null
 
     @Readonly
-    fun hasUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
-        getTagUniques(uniqueTag).any { it.conditionalsApply(state) && !it.isTimedTriggerable }
+    inline fun hasUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
+        firstTagUniqueOrNull(uniqueTag) { it.conditionalsApply(state) && !it.isTimedTriggerable } != null
 
     @Readonly
     fun hasTagUnique(tagUnique: String) =
@@ -64,10 +64,15 @@ open class UniqueMap() {
         ?: emptySequence()
 
     @Readonly
-    fun forEachUnique(uniqueType: UniqueType, op: (Unique)->Unit) {
-        val uniques = typedUniqueMap[uniqueType] ?: return
+    inline fun forEachUnique(uniqueType: UniqueType, crossinline op: (Unique)->Unit)
+        = firstUniqueOrNull(uniqueType) { op(it); false }
+
+    @Readonly
+    inline fun firstUniqueOrNull(uniqueType: UniqueType, predicate: (Unique)->Boolean): Unique? {
+        val uniques = typedUniqueMap[uniqueType] ?: return null
         for (i in 0..< uniques.size)
-            op(uniques[i])
+            if (predicate(uniques[i])) return uniques[i]
+        return null
     }
 
     @Readonly
@@ -75,6 +80,18 @@ open class UniqueMap() {
     fun getTagUniques(uniqueTag: String) = tagUniqueMap[uniqueTag]
         ?.asSequence()
         ?: emptySequence()
+
+    @Readonly
+    inline fun forEachTagUnique(uniqueTag: String, crossinline op: (Unique)->Unit)
+        = firstTagUniqueOrNull(uniqueTag) { op(it); false }
+
+    @Readonly
+    inline fun firstTagUniqueOrNull(uniqueTag: String, predicate: (Unique)->Boolean): Unique? {
+        val uniques = tagUniqueMap[uniqueTag] ?: return null
+        for (i in 0..< uniques.size)
+            if (predicate(uniques[i])) return uniques[i]
+        return null
+    }
 
     @Readonly
     /** forEachMatchingUnique faster, for cases that require high perf */ 
@@ -89,13 +106,30 @@ open class UniqueMap() {
                 }
             }
 
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueType], for cases that need to mutate
+     *  this map (or otherwise cannot use a live view) while iterating the result. */
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (Unique)->Unit)
+    fun getMatchingUniquesSnapshot(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachMatchingUnique(uniqueType, state) { list.add(it) }
+        return list
+    }
+
+    @Readonly
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (Unique)->Unit)
         = forEachMatchingUnique(uniqueType, gameContext, NO_UNIQUE_FILTER, op)
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, filter:(Unique)->Boolean, op: (Unique)->Unit) {
-        val list = typedUniqueMap[uniqueType] ?: return
-        forEachMatchingUnique(list, gameContext, filter, op)
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline op: (Unique)->Unit)
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, filter) { op(it); false }
+    
+
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, NO_UNIQUE_FILTER, predicate)
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
+        val list = typedUniqueMap[uniqueType] ?: return null
+        return firstMatchingUniqueOrNull(list, gameContext, filter, predicate)
     }
 
     @Readonly
@@ -111,40 +145,87 @@ open class UniqueMap() {
                 }
             }
 
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueTag], for cases that need to mutate
+     *  this map (or otherwise cannot use a live view) while iterating the result. */
     @Readonly
-    fun forEachMatchingTagUnique(uniqueTag: String, gameContext: GameContext, filter:(Unique)->Boolean, op: (Unique)->Unit) {
-        val list = tagUniqueMap[uniqueTag] ?: return
-        forEachMatchingUnique(list, gameContext, filter, op)
+    fun getMatchingTagUniquesSnapshot(uniqueTag: String, state: GameContext = GameContext.EmptyState): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachMatchingTagUnique(uniqueTag, state, NO_UNIQUE_FILTER) { list.add(it) }
+        return list
     }
 
     @Readonly
-    fun forEachMatchingUnique(list: List<Unique>, gameContext: GameContext, filter:(Unique)->Boolean, op: (Unique)->Unit) {
+    inline fun forEachMatchingTagUnique(uniqueTag: String, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline op: (Unique)->Unit)
+        = firstMatchingTagUniqueOrNull(uniqueTag, gameContext, filter) { op(it); false }
+
+    @Readonly
+    inline fun firstMatchingTagUniqueOrNull(uniqueTag: String, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
+        val list = tagUniqueMap[uniqueTag] ?: return null
+        return firstMatchingUniqueOrNull(list, gameContext, filter, predicate)
+    }
+
+    @Readonly
+    inline fun forEachMatchingUnique(list: List<Unique>, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline op: (Unique)->Unit) {
+        firstMatchingUniqueOrNull(list, gameContext, filter) { op(it); false }
+    }
+
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(list: List<Unique>, gameContext: GameContext, filter:(Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
         for (i in 0..<list.size) {
             val unique = list[i]
             if (unique.isTimedTriggerable) continue
             if (!filter(unique)) continue
             if (!unique.conditionalsApply(gameContext)) continue
-            unique.forEachMultiplied(gameContext, op)
-        }
+            // This seems like it shouldn't be needed, but actually is since it loops over *active* Uniques,
+            // so we need to call the predicate for each multiplied unique, not each base unique.
+            val result = unique.firstMultipliedOrNull(gameContext, predicate)
+            if (result != null) return result        }
+        return null
     }
     
     @Readonly
-    fun hasMatchingUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) = 
-        getUniques(uniqueType).any { it.conditionalsApply(state) }
+    inline fun hasMatchingUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
+        firstUniqueOrNull(uniqueType) { it.conditionalsApply(state) } != null
 
     @Readonly
-    fun hasMatchingTagUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
-        getTagUniques(uniqueTag)
-            .any { it.conditionalsApply(state) }
+    inline fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (Unique)->Boolean) =
+        firstMatchingUniqueOrNull(uniqueType, gameContext, predicate) != null
+    @Readonly
+    inline fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline filter: (Unique)->Boolean, crossinline predicate: (Unique)->Boolean) =
+        firstMatchingUniqueOrNull(uniqueType, gameContext, filter, predicate) != null
+
+    @Readonly
+    inline fun hasMatchingTagUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
+        firstTagUniqueOrNull(uniqueTag) { it.conditionalsApply(state) } != null
+
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, initial: T, crossinline accumulate: (T, Unique) -> T): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext) { acc = accumulate(acc, it) }
+        return acc
+    }
 
     @Readonly
     fun getAllUniques() = tagUniqueMap.values.asSequence().flatten()
     
     @Readonly
     // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getLocalTriggeredUniques
-    fun forEachUnique(op: (Unique)->Unit) = getAllUniques().forEach(op)
+    inline fun forEachUnique(crossinline op: (Unique)->Unit) = getAllUniques().forEach(op)
     @Readonly
-    fun forEachUnique(filter: (Unique)->Boolean, op: (Unique)->Unit) = getAllUniques().filter(filter).forEach(op)
+    inline fun forEachUnique(filter: (Unique)->Boolean, crossinline op: (Unique)->Unit) {
+        firstUniqueOrNull(filter) { op(it); false }
+    }
+
+    @Readonly
+    // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getAllUniques
+    fun firstUniqueOrNull(predicate: (Unique)->Boolean): Unique? = getAllUniques().firstOrNull(predicate)
+    @Readonly
+    inline fun firstUniqueOrNull(filter: (Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
+        for (unique in getAllUniques())
+            if (filter(unique) && predicate(unique)) return unique
+        return null
+    }
 
     @Readonly
     fun getTriggeredUniques(trigger: UniqueType, gameContext: GameContext,
@@ -152,6 +233,26 @@ open class UniqueMap() {
         return typedUniqueMap.values.asSequence().flatten().filter { unique ->
             unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
         }.flatMap { it.getMultiplied(gameContext) }
+    }
+
+    @Readonly
+    inline fun forEachTriggeredUnique(trigger: UniqueType, gameContext: GameContext,
+                               crossinline triggerFilter: (Unique) -> Boolean = { true }, crossinline op: (Unique)->Unit) {
+        firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter) { op(it); false }
+    }
+
+    @Readonly
+    inline fun firstTriggeredUniqueOrNull(trigger: UniqueType, gameContext: GameContext,
+                                    triggerFilter: (Unique) -> Boolean = { true }, crossinline predicate: (Unique)->Boolean): Unique? {
+        for (unique in typedUniqueMap.values.asSequence().flatten()) {
+            if (!unique.getModifiers(trigger).any(triggerFilter) || !unique.conditionalsApply(gameContext))
+                continue
+            // This seems like it shouldn't be needed, but actually is since it loops over *active* Uniques,
+            // so we need to call the predicate for each multiplied unique, not each base unique.
+            val result = unique.firstMultipliedOrNull(gameContext, predicate)
+            if (result != null) return result
+        }
+        return null
     }
     
     companion object{


### PR DESCRIPTION
most #getXUniques calls could be replaced with #forEachUnique, but some callers were using .any(...) or .first(...) on the result list.  #firstXUnique(...), and #hasXUnique(...) better supports those pattern. To avoid duplication, #forEachXUnique and #hasXUnique are now implemented in terms of #firstXUnique.  (Also for #getXTiles)

This is followed up by PRs to clean up the methods for Automation, Battle, City, Civilization, MapGen, MapUnit, Models, and Ui. Total GameInfo.nextTurn performance improvement is 14.95% faster (https://docs.google.com/spreadsheets/d/1tjm7_uvMxiQmyOnWzM2lvqY2B5m29FfrVzjx3RflU1E/edit?gid=703144985#gid=703144985)