### PR TITLE
Replacing deprecated getTiles and getUnique calls in automation

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -171,7 +171,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
 
         val civilianUnit = city.getCenterTile().civilianUnit
         if (civilianUnit != null && civilianUnit.hasUnique(UniqueType.FoundCity)
-                && city.getCenterTile().getTilesInDistance(city.getExpandRange()).none { it.militaryUnit?.civ == civInfo })
+                && !city.getCenterTile().anyTileInDistance(city.getExpandRange()) { it.militaryUnit?.civ == civInfo })
             modifier = 5f // there's a settler just sitting here, doing nothing - BAD
 
         if (!civInfo.isAIOrAutoPlaying()) modifier /= 2 // Players prefer to make their own unit choices usually
@@ -194,8 +194,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
         val twoTurnsMovement = buildableWorkboatUnits.maxOf { it.movement } * 2
         @Readonly fun MapUnit.isOurWorkBoat() = cache.hasUniqueToCreateWaterImprovements
                 && this.civ == this@ConstructionAutomation.civInfo
-        val alreadyHasWorkBoat = city.getCenterTile().getTilesInDistance(twoTurnsMovement)
-            .any { it.civilianUnit?.isOurWorkBoat() == true }
+        val alreadyHasWorkBoat = city.getCenterTile().anyTileInDistance(twoTurnsMovement) { it.civilianUnit?.isOurWorkBoat() == true }
         if (alreadyHasWorkBoat) return
 
         // Define what makes a tile worth sending a Workboat to

--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -101,12 +101,11 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
         if (campsToAdd <= 0) return
 
         // Camps can't spawn within 7 tiles of each other or within 4 tiles of major civ capitals
+        // We need a snapshot Set to test membership against below, not a one-off iteration.
         val tooCloseToCapitals = gameInfo.civilizations.filterNot { it.isBarbarian || it.isSpectator() || it.cities.isEmpty() || it.isCityState || it.getCapital() == null }
-            .flatMap { it.getCapital()!!.getCenterTile().getTilesInDistance(4) }.toSet()
+            .flatMap { it.getCapital()!!.getCenterTile().getTilesInDistanceSnapshot(4) }.toSet()
         val tooCloseToCamps = encampments
-            .flatMap { tileMap[it.position].getTilesInDistance(
-                    if (it.destroyed) 4 else 7
-            ) }.toSet()
+            .flatMap { tileMap[it.position].getTilesInDistanceSnapshot(if (it.destroyed) 4 else 7) }.toSet()
 
         val viableTiles = fogTiles.filter {
             !it.isImpassible()
@@ -141,7 +140,7 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
             // Still more camps to add?
             if (addedCamps < campsToAdd) {
                 // Remove some newly non-viable tiles
-                viableTiles.removeAll(tile.getTilesInDistance(7).toSet())
+                tile.forEachTileInDistance(7) { viableTiles.remove(it) }
                 // Reroll bias
                 biasCoast = rng.nextInt(6) == 0
             }
@@ -192,9 +191,7 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
             if (gameInfo.turns < 10)
                 return null
 
-            val nearbyBarbarians = tile.getTilesInDistance(4)
-                .mapNotNull { it.militaryUnit }
-                .count { it.civ.isBarbarian }
+            val nearbyBarbarians = tile.countTilesInDistance(4) { it.militaryUnit?.civ?.isBarbarian == true }
             // Too many barbarians around already?
             if (nearbyBarbarians > 2)
                 return null

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomacyManager
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
+import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.trade.TradeEvaluation
 import com.unciv.logic.trade.TradeLogic
 import com.unciv.logic.trade.TradeOffer
@@ -490,24 +491,23 @@ object DiplomacyAutomation {
     internal fun checkMilitaryPresenceNearBorder(
         civInfo: Civilization
     ) {
-        val nearbyTiles = civInfo.cities.asSequence()
-            .flatMap { it.getTiles() }
-            .flatMap { it.getTilesInDistance(2) }
-            .filter { it.getOwner() != civInfo } // skip open borders
-            .filter { it.isVisible(civInfo) }
-            .toSet()
-
         // only counts what is visible to us
         val nearbyUnitCountByCiv = Counter<Civilization>()
         val nearbyForceByCiv = Counter<Civilization>()
 
-        for (tile in nearbyTiles) {
-            val unit = tile.militaryUnit ?: continue
-            if (! unit.civ.isMajorCiv() || unit.civ == civInfo || unit.isInvisible(civInfo))
-                continue
-            nearbyUnitCountByCiv.add(unit.civ, 1)
-            nearbyForceByCiv.add(unit.civ, unit.getForceEvaluation())
-        }
+        val visitedTiles = HashSet<Tile>()
+        for (city in civInfo.cities) for (tile in city.getTiles())
+            tile.forEachTileInDistance(2) {
+                if (it.getOwner() == civInfo // skip open borders
+                    || !it.isVisible(civInfo)
+                    || !visitedTiles.add(it)) // already counted from a nearer tile
+                    return@forEachTileInDistance
+                val unit = it.militaryUnit ?: return@forEachTileInDistance
+                if (!unit.civ.isMajorCiv() || unit.civ == civInfo || unit.isInvisible(civInfo))
+                    return@forEachTileInDistance
+                nearbyUnitCountByCiv.add(unit.civ, 1)
+                nearbyForceByCiv.add(unit.civ, unit.getForceEvaluation())
+            }
 
         fun decideWhetherToDenounce(otherCiv: Civilization) {
             // this ultimatum can currently only be made by AI to human players, to avoid abuse

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -415,7 +415,7 @@ object NextTurnAutomation {
 
         val citiesRequiringManualPlacement = civInfo.getKnownCivs().filter { it.isAtWarWith(civInfo) }
             .flatMap { it.cities }
-            .filter { it.getCenterTile().getTilesInDistance(4).count { it.militaryUnit?.civ == civInfo } > 4 }
+            .filter { city -> city.getCenterTile().countTilesInDistance(4) { it.militaryUnit?.civ == civInfo } > 4 }
             .toList()
 
         for (unit in sortedUnits) applyPromotions(unit)
@@ -463,8 +463,15 @@ object NextTurnAutomation {
 
     /** All units will continue after this to the regular automation, so units not moved in this function will still move */
     private fun automateCityConquer(civInfo: Civilization, city: City){
-        @Readonly fun ourUnitsInRange(range: Int) = city.getCenterTile().getTilesInDistance(range)
-            .mapNotNull { it.militaryUnit }.filter { it.civ == civInfo && (!it.baseUnit.isMelee() || it.health > 30) }.toList()
+        @Readonly fun ourUnitsInRange(range: Int): List<MapUnit> {
+            val units = ArrayList<MapUnit>()
+            city.getCenterTile().forEachTileInDistance(range) {
+                val unit = it.militaryUnit
+                if (unit != null && unit.civ == civInfo && (!unit.baseUnit.isMelee() || unit.health > 30))
+                    units.add(unit)
+            }
+            return units
+        }
         
         
         fun attackIfPossible(unit: MapUnit, tile: Tile){
@@ -494,13 +501,14 @@ object NextTurnAutomation {
             // We're so close, full speed ahead!
             if (city.health < city.getMaxHealth() / 5) attackIfPossible(unit, city.getCenterTile())
             
-            val tilesToTarget = city.getCenterTile().getTilesInDistance(4).toList()
-            
+            // We need a snapshot List for getAttackableEnemies below.
+            val tilesToTarget = city.getCenterTile().getTilesInDistanceSnapshot(4)
+
             val attackableEnemies = TargetHelper.getAttackableEnemies(unit,
                 unit.movement.getDistanceToTiles(), tilesToTarget)
             if (attackableEnemies.isEmpty()) continue
             val mostSurroundedEnemy = attackableEnemies.maxBy {
-                it.tileToAttack.getTilesAtDistance(1).count { it.militaryUnit?.civ == unit.civ }
+                it.tileToAttack.countTilesAtDistance(1) { tile -> tile.militaryUnit?.civ == unit.civ }
             } // aims to maximize flanking bonus and number of hits in order to get kills
 
             Battle.moveAndAttack(MapUnitCombatant(unit), mostSurroundedEnemy)
@@ -510,16 +518,22 @@ object NextTurnAutomation {
     @VisibleForTesting
     fun automateSettlerEscorting(civInfo: Civilization){
         val capitalTile = civInfo.getCapital()!!.getCenterTile()
-        @Readonly fun bestUnitInRange(tile: Tile, range: Int) = tile.getTilesInDistance(range)
-            .mapNotNull { it.militaryUnit }.filter {
-                it.civ == civInfo
-                    && it.health >= 100
+        @Readonly fun bestUnitInRange(tile: Tile, range: Int): MapUnit? {
+            val unitsInRange = ArrayList<MapUnit>()
+            tile.forEachTileInDistance(range) {
+                val unit = it.militaryUnit
+                if (unit != null
+                    && unit.civ == civInfo
+                    && unit.health >= 100
                     // only draft a unit from the core of the empire, or it'll interfere with other anti-barb activities
-                    && (it.currentTile.aerialDistanceTo(capitalTile) < tile.aerialDistanceTo(capitalTile))
-                    && it.movement.canReach(tile) 
+                    && (unit.currentTile.aerialDistanceTo(capitalTile) < tile.aerialDistanceTo(capitalTile))
+                    && unit.movement.canReach(tile))
+                    unitsInRange.add(unit)
             }
-            .sortedBy { it.currentTile.aerialDistanceTo(tile) }
-            .maxByOrNull { it.baseUnit.strength } // could be more sophisticated based on promotions, movement speed etc.
+            return unitsInRange
+                .sortedBy { it.currentTile.aerialDistanceTo(tile) }
+                .maxByOrNull { it.baseUnit.strength } // could be more sophisticated based on promotions, movement speed etc.
+        }
         
         val settlersToAccompany = civInfo.units.getCivUnits()
             .filter { it.isCivilian() && it.hasUnique(UniqueType.FoundCity) }
@@ -599,10 +613,11 @@ object NextTurnAutomation {
         if (CivilianUnitAutomation.isLateGame(civInfo)){
             // all suitable land may be occupied already
             // 10 tiles away and 6 "options" are heuristics based on nothing, feel free to change 
-            val unoccupiedNearishTiles = civInfo.cities.asSequence()
-                .flatMap { it.getCenterTile().getTilesInDistance(10) }
-                .filter { it.owningCity == null && it.neighbors.all { it.owningCity == null } }
-                .count()
+            var unoccupiedNearishTiles = 0
+            for (city in civInfo.cities)
+                unoccupiedNearishTiles += city.getCenterTile().countTilesInDistance(10) {
+                    it.owningCity == null && it.neighbors.all { neighbor -> neighbor.owningCity == null }
+                }
             if (unoccupiedNearishTiles < 6) return
         } 
 

--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -117,9 +117,9 @@ object ReligionAutomation {
         if (validCitiesToBuy.isEmpty()) return
 
         val citiesWithBonusCharges = validCitiesToBuy.filter { city ->
-            city.getMatchingUniques(UniqueType.UnitStartingPromotions).any {
+            city.hasMatchingUnique(UniqueType.UnitStartingPromotions) {
                 val promotionName = it.params[2]
-                val promotion = city.getRuleset().unitPromotions[promotionName] ?: return@any false
+                val promotion = city.getRuleset().unitPromotions[promotionName] ?: return@hasMatchingUnique false
                 promotion.hasUnique(UniqueType.CanSpreadReligion)
             }
         }
@@ -211,7 +211,7 @@ object ReligionAutomation {
         var score = 0f // Roughly equivalent to the sum of stats gained across all cities
 
         for (city in civInfo.cities) {
-            for (tile in city.getCenterTile().getTilesInDistance(city.getWorkRange())) {
+            city.getCenterTile().forEachTileInDistance(city.getWorkRange()) { tile ->
                 val tileRng = tile.stateThisTile.stateBasedRandom("ReligionAutomation.rateBelief")
                 val tileScore = beliefBonusForTile(belief, tile, city)
                 

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -131,13 +131,12 @@ object UseGoldAutomation {
         )
 
         for (city in civInfo.cities.filter { !it.isPuppet && !it.isBeingRazed }) {
-            val highlyDesirableTilesInCity = city.getCenterTile().getTilesAtDistance(2).filter {
-                // Only consider second ring tiles: further tiles may be as good or better, but have much higher gold cost 
-                isHighlyDesirableTile(it, civInfo, city)
-            }
-            for (highlyDesirableTileInCity in highlyDesirableTilesInCity) {
-                @LocalState val desirableTiles = highlyDesirableTiles.getOrPut(highlyDesirableTileInCity) { mutableSetOf() }
-                desirableTiles.add(city)
+            // Only consider second ring tiles: further tiles may be as good or better, but have much higher gold cost
+            city.getCenterTile().forEachTileAtDistance(2) { highlyDesirableTileInCity ->
+                if (isHighlyDesirableTile(highlyDesirableTileInCity, civInfo, city)) {
+                    @LocalState val desirableTiles = highlyDesirableTiles.getOrPut(highlyDesirableTileInCity) { mutableSetOf() }
+                    desirableTiles.add(city)
+                }
             }
         }
         return highlyDesirableTiles

--- a/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
@@ -18,23 +18,19 @@ object AirUnitAutomation {
         if (unit.health < 75) return // Wait and heal
 
         val tilesWithEnemyUnitsInRange = unit.civ.threatManager.getTilesWithEnemyUnitsInDistance(unit.getTile(), unit.getRange())
-        // TODO: Optimize [friendlyAirUnitsInRange] by creating an alternate [ThreatManager.getTilesWithEnemyUnitsInDistance] that handles only friendly units
-        val friendlyAirUnitsInRange = unit.getTile().getTilesInDistance(unit.getRange()).flatMap { it.airUnits }.filter { it.civ == unit.civ }
         // Find all visible enemy air units
         val enemyAirUnitsInRange = tilesWithEnemyUnitsInRange
             .flatMap { it.airUnits.asSequence() }.filter { it.civ.isAtWarWith(unit.civ) }
         val enemyFighters = enemyAirUnitsInRange.size / 2 // Assume half the planes are fighters
-        val friendlyUnusedFighterCount = friendlyAirUnitsInRange.count { it.canAttack() }
-        val friendlyUsedFighterCount = friendlyAirUnitsInRange.count { !it.canAttack() }
+        val friendlyUnusedFighterCount = unit.getTile().countTilesInDistance(unit.getRange()) { tile -> tile.airUnits.any { it.civ == unit.civ && it.canAttack() } }
+        val friendlyUsedFighterCount = unit.getTile().countTilesInDistance(unit.getRange()) { tile -> tile.airUnits.any { it.civ == unit.civ && !it.canAttack() } }
 
         // We need to be on standby in case they attack
         if (friendlyUnusedFighterCount < enemyFighters) return
 
         if (friendlyUsedFighterCount <= enemyFighters) {
-            @Readonly fun airSweepDamagePercentBonus(): Int {
-                return unit.getMatchingUniques(UniqueType.StrengthWhenAirsweep)
-                    .sumOf { it.params[0].toInt() }
-            }
+            @Readonly fun airSweepDamagePercentBonus(): Int =
+                unit.accumulateForEachMatchingUnique(UniqueType.StrengthWhenAirsweep, initial = 0) { acc, unique -> acc + unique.params[0].toInt() }
 
             // If we are outnumbered, don't heal after attacking and don't have an Air Sweep bonus
             // Then we shouldn't speed the air battle by killing our fighters, instead, focus on defending
@@ -62,11 +58,10 @@ object AirUnitAutomation {
 
         val citiesByNearbyAirUnits = pathsToCities.keys
             .groupBy { key ->
-                key.getTilesInDistance(unit.getMaxMovementForAirUnits())
-                    .count {
-                        val firstAirUnit = it.airUnits.firstOrNull()
-                        firstAirUnit != null && firstAirUnit.civ.isAtWarWith(unit.civ)
-                    }
+                key.countTilesInDistance(unit.getMaxMovementForAirUnits()) {
+                    val firstAirUnit = it.airUnits.firstOrNull()
+                    firstAirUnit != null && firstAirUnit.civ.isAtWarWith(unit.civ)
+                }
             }
 
         if (citiesByNearbyAirUnits.keys.any { it != 0 }) {
@@ -113,8 +108,9 @@ object AirUnitAutomation {
         val citiesThatCanAttackFrom = pathsToCities.keys
             .filter { destinationCity ->
                 destinationCity != airUnit.currentTile
-                    && destinationCity.getTilesInDistance(airUnit.getRange())
-                    .any { TargetHelper.containsAttackableEnemy(it, MapUnitCombatant(airUnit)) }
+                    && destinationCity.anyTileInDistance(airUnit.getRange()) {
+                        TargetHelper.containsAttackableEnemy(it, MapUnitCombatant(airUnit))
+                    }
             }
         if (citiesThatCanAttackFrom.isEmpty()) return
 
@@ -130,11 +126,9 @@ object AirUnitAutomation {
         if (!unit.civ.isAtWar()) return
         // We should *Almost* never want to nuke our own city, so don't consider it
         if (unit.type.isAirUnit()) {
-            val tilesInRange = unit.currentTile.getTilesInDistanceRange(2..unit.getRange())
-            val highestTileNukeValue = tilesInRange.map { it to getNukeLocationValue(unit, it) }
-                .maxByOrNull { it.second }
-            if (highestTileNukeValue != null && highestTileNukeValue.second > 0)
-                Nuke.NUKE(MapUnitCombatant(unit), highestTileNukeValue.first)
+            val bestNuke = unit.currentTile.maxTileInDistanceRange(2..unit.getRange()) { getNukeLocationValue(unit, it) }
+            if (bestNuke != null && bestNuke.second > 0)
+                Nuke.NUKE(MapUnitCombatant(unit), bestNuke.first)
 
             tryRelocateMissileToNearbyAttackableCities(unit)
         } else {
@@ -156,26 +150,31 @@ object AirUnitAutomation {
         val civ = nuke.civ
         if (!Nuke.mayUseNuke(MapUnitCombatant(nuke), tile)) return Int.MIN_VALUE
         val blastRadius = nuke.getNukeBlastRadius()
-        val tilesInBlastRadius = tile.getTilesInDistance(blastRadius)
-        val civsInBlastRadius = tilesInBlastRadius.mapNotNull { it.getOwner() } +
-            tilesInBlastRadius.mapNotNull { it.getFirstUnit()?.civ }
-
-        // Don't nuke if it means we will be declaring war on someone!
-        if (civsInBlastRadius.any { it != civ && !it.isAtWarWith(civ) }) return -100000
-        // If there are no enemies to hit, don't nuke
-        if (!civsInBlastRadius.any { it.isAtWarWith(civ) }) return -100000
-
         // Launching a Nuke uses resources, therefore don't launch it by default
         var explosionValue = -500
+        var anyEnemiesHit = false
+        tile.firstTileInDistanceOrNull(blastRadius) { targetTile->
+            // Don't nuke if it means we will be declaring war on someone!
+            val owner = targetTile.getOwner()
+            val unitCiv = targetTile.getFirstUnit()?.civ
+            val willDeclareWarOnOwner = owner != null && owner != civ && !owner.isAtWarWith(civ)
+            val willDeclareWarOnUnit = unitCiv != null && unitCiv != civ && !unitCiv.isAtWarWith(civ)
 
-        // Returns either ourValue or thierValue depending on if the input Civ matches the Nuke's Civ
-        @Pure
-        fun evaluateCivValue(targetCiv: Civilization, ourValue: Int, theirValue: Int): Int {
-            if (targetCiv == civ) // We are nuking something that we own!
-                return ourValue
-            return theirValue // We are nuking an enemy!
-        }
-        for (targetTile in tilesInBlastRadius) {
+            if (willDeclareWarOnOwner || willDeclareWarOnUnit) {
+                explosionValue = -100000
+                return@firstTileInDistanceOrNull true
+            }
+            if (owner?.isAtWarWith(civ) ?: false || unitCiv?.isAtWarWith(civ) ?: false) {
+                anyEnemiesHit = true
+            }
+    
+            // Returns either ourValue or thierValue depending on if the input Civ matches the Nuke's Civ
+            @Pure
+            fun evaluateCivValue(targetCiv: Civilization, ourValue: Int, theirValue: Int): Int {
+                if (targetCiv == civ) // We are nuking something that we own!
+                    return ourValue
+                return theirValue // We are nuking an enemy!
+            }
             // We can only account for visible units
             if (targetTile.isVisible(civ)) {
                 for (targetUnit in targetTile.getUnits()) {
@@ -206,8 +205,13 @@ object AirUnitAutomation {
                     explosionValue += evaluateCivValue(owningCiv, -40, 20)
             }
             // If the value is too low end the search early
-            if (explosionValue < -1000) return explosionValue
+            if (explosionValue < -1000) return@firstTileInDistanceOrNull true
+            // otherwise, keep analyzing affected tiles
+            return@firstTileInDistanceOrNull false
         }
+        // If there are no enemies to hit, don't nuke
+        if (!anyEnemiesHit)
+            return -100000
         return explosionValue
     }
 
@@ -218,14 +222,13 @@ object AirUnitAutomation {
     }
 
     private fun tryRelocateMissileToNearbyAttackableCities(unit: MapUnit) {
-        val tilesInRange = unit.currentTile.getTilesInDistance(unit.getRange())
-        val immediatelyReachableCities = tilesInRange
-            .filter { unit.movement.canMoveTo(it) }
-
-        for (city in immediatelyReachableCities) if (city.getTilesInDistance(unit.getRange())
-                .any { it.isCityCenter() && it.getOwner()!!.isAtWarWith(unit.civ) }
-        ) {
-            unit.movement.moveToTile(city)
+        val cityToMoveTo = unit.currentTile.firstTileInDistanceOrNull(unit.getRange()) { city ->
+            unit.movement.canMoveTo(city) && city.anyTileInDistance(unit.getRange()) {
+                it.isCityCenter() && it.getOwner()!!.isAtWarWith(unit.civ)
+            }
+        }
+        if (cityToMoveTo != null) {
+            unit.movement.moveToTile(cityToMoveTo)
             return
         }
 
@@ -235,19 +238,13 @@ object AirUnitAutomation {
     }
 
     private fun tryRelocateToCitiesWithEnemyNearBy(unit: MapUnit): Boolean {
-        val immediatelyReachableCitiesAndCarriers = unit.currentTile
-            .getTilesInDistance(unit.getMaxMovementForAirUnits()).filter { unit.movement.canMoveTo(it) }
-
-        for (city in immediatelyReachableCitiesAndCarriers) {
-            if (city.getTilesInDistance(unit.getRange())
-                    .any {
-                        it.isVisible(unit.civ) &&
-                            TargetHelper.containsAttackableEnemy(it,MapUnitCombatant(unit))
-                    }) {
-                unit.movement.moveToTile(city)
-                return true
+        val cityToMoveTo = unit.currentTile.firstTileInDistanceOrNull(unit.getMaxMovementForAirUnits()) { city ->
+            unit.movement.canMoveTo(city) && city.anyTileInDistance(unit.getRange()) {
+                it.isVisible(unit.civ) &&
+                    TargetHelper.containsAttackableEnemy(it,MapUnitCombatant(unit))
             }
-        }
-        return false
+        } ?: return false
+        unit.movement.moveToTile(cityToMoveTo)
+        return true
     }
 }

--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -115,7 +115,7 @@ object BattleHelper {
             val battleDamage = BattleDamage.calculateDamageToAttacker(attackerUnit, cityUnit)
             if (attacker.health - battleDamage * 2 <= 0 && !attacker.hasUnique(UniqueType.SelfDestructs)) {
                 // The more fiendly units around the city, the more willing we should be to just attack the city
-                val friendlyUnitsAroundCity = city.getCenterTile().getTilesInDistance(3).count { it.militaryUnit?.civ == attacker.civ }
+                val friendlyUnitsAroundCity = city.getCenterTile().countTilesInDistance(3) { it.militaryUnit?.civ == attacker.civ }
                 // If we have more than 4 other units around the city, go for it
                 if (friendlyUnitsAroundCity < 5) {
                     val attackerHealthModifier = 1.0 + 1.0 / friendlyUnitsAroundCity
@@ -135,7 +135,7 @@ object BattleHelper {
 
         // Add value based on number of units around the city
         val defendingCityCiv = city.civ
-        city.getCenterTile().getTilesInDistance(2).forEach {
+        city.getCenterTile().forEachTileInDistance(2) {
             if (it.militaryUnit != null) {
                 if (it.militaryUnit!!.civ.isAtWarWith(attacker.civ))
                     attackValue -= 5

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -35,11 +35,13 @@ object CityLocationTileRanker {
         val nearbyCities = unit.civ.gameInfo.getCities()
             .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 7 + range }
 
-        val uniques = unit.getMatchingUniques(UniqueType.FoundCity) + unit.getMatchingUniques(UniqueType.FoundPuppetCity)
-        val possibleCityLocations = unit.getTile().getTilesInDistance(range)
+        // We need a snapshot List, used below in a .map/.filter chain.
+        val possibleCityLocations = unit.getTile().getTilesInDistanceSnapshot(range).filter { tile ->
             // Filter out tiles that we can't actually found on
-            .filter { tile -> uniques.any { it.conditionalsApply(GameContext(unit = unit, tile = tile)) } }
-            .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.getTile() == it || unit.movement.canMoveTo(it)) }
+            val unique = unit.firstMatchingUniqueOrNull(UniqueType.FoundCity) { it.conditionalsApply(GameContext(unit = unit, tile = tile)) }
+                ?: unit.firstMatchingUniqueOrNull(UniqueType.FoundPuppetCity) { it.conditionalsApply(GameContext(unit = unit, tile = tile)) }
+            unique != null && canSettleTile(tile, unit.civ, nearbyCities) && (unit.getTile() == tile || unit.movement.canMoveTo(tile))
+        }
         val bestTilesToFoundCity = BestTilesToFoundCity()
         val baseTileMap = HashMap<Tile, Float>()
 
@@ -126,7 +128,7 @@ object CityLocationTileRanker {
         var tiles = 0
         for (i in 0..2) {
             //Ideally, we shouldn't really count the center tile, as it's converted into 1 production 2 food anyways with special cases treated above, but doing so can lead to AI moving settler back and forth until forever
-            for (nearbyTile in newCityTile.getTilesAtDistance(i)) {
+            newCityTile.forEachTileAtDistance(i) { nearbyTile ->
                 tiles++
                 tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap) * (3f / (i + 1))
                 //Tiles close to the city can be worked more quickly, and thus should gain higher weight.

--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -28,9 +28,9 @@ object CivilianUnitAutomation {
         // Slightly modified getUsableUnitActionUniques() to allow for settlers with *conditional* settling uniques
         @Readonly
         fun hasSettlerAction(uniqueType: UniqueType) =
-            unit.getMatchingUniques(uniqueType, GameContext.IgnoreConditionals)
-                .filter { unique -> !unique.hasModifier(UniqueType.UnitActionExtraLimitedTimes) }
-                .any { canUse(unit, it) }
+            unit.hasUnique(uniqueType, GameContext.IgnoreConditionals) { unique ->
+                !unique.hasModifier(UniqueType.UnitActionExtraLimitedTimes) && canUse(unit, unique)
+            }
         
         val hasSettlerUnique = hasSettlerAction(UniqueType.FoundCity) || hasSettlerAction(UniqueType.FoundPuppetCity)
         
@@ -133,7 +133,7 @@ object CivilianUnitAutomation {
         }
 
         if (unit.hasUnique(UniqueType.GainFreeBuildings)) {
-            val unique = unit.getMatchingUniques(UniqueType.GainFreeBuildings).first()
+            val unique = unit.firstMatchingUniqueOrNull(UniqueType.GainFreeBuildings) { true }!!
             val buildingName = unique.params[0]
             // Choose the city that is closest in distance and does not have the building constructed.
             val cityToGainBuilding = unit.civ.cities.filter {

--- a/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
@@ -81,13 +81,16 @@ object HeadTowardsEnemyCityAutomation {
             return true
         }
 
-        val ourUnitsAroundEnemyCity = closestReachableEnemyCity.getTilesInDistance(6)
-            .flatMap { it.getUnits() }
-            .filter { it.isMilitary() && it.civ == unit.civ }
-
         val city = closestReachableEnemyCity.getCity()!!
+        val cityCombatant = CityCombatant(city)
+        var expectedDamagePerTurn = 0
+        closestReachableEnemyCity.forEachTileInDistance(6) { tile ->
+            for (tileUnit in tile.getUnits())
+                if (tileUnit.isMilitary() && tileUnit.civ == unit.civ)
+                    expectedDamagePerTurn += BattleDamage.calculateDamageToDefender(MapUnitCombatant(tileUnit), cityCombatant)
+        }
 
-        if (cannotTakeCitySoon(ourUnitsAroundEnemyCity, city)) {
+        if (cannotTakeCitySoon(expectedDamagePerTurn, city)) {
             return headToLandingGrounds(closestReachableEnemyCity, unit)
         }
 
@@ -99,13 +102,9 @@ object HeadTowardsEnemyCityAutomation {
     /** Cannot take within 5 turns */
     @Readonly
     private fun cannotTakeCitySoon(
-        ourUnitsAroundEnemyCity: Sequence<MapUnit>,
+        expectedDamagePerTurn: Int,
         city: City
     ): Boolean {
-        val cityCombatant = CityCombatant(city)
-        val expectedDamagePerTurn = ourUnitsAroundEnemyCity
-            .sumOf { BattleDamage.calculateDamageToDefender(MapUnitCombatant(it), cityCombatant) }
-
         val cityHealingPerTurn = 20
         return expectedDamagePerTurn < city.health && // Cannot take immediately
             (expectedDamagePerTurn <= cityHealingPerTurn // No lasting damage
@@ -115,8 +114,11 @@ object HeadTowardsEnemyCityAutomation {
     private fun headToLandingGrounds(closestReachableEnemyCity: Tile, unit: MapUnit): Boolean {
         // don't head straight to the city, try to head to landing grounds -
         // this is against tha AI's brilliant plan of having everyone embarked and attacking via sea when unnecessary.
-        val tileToHeadTo = closestReachableEnemyCity.getTilesInDistanceRange(minDistanceFromCityToConsiderForLandingArea..maxDistanceFromCityToConsiderForLandingArea)
-            .filter { it.isLand && unit.getDamageFromTerrain(it) <= 0 } // Don't head for hurty terrain
+        // We need a snapshot List for sortedBy below.
+        val candidateLandingTiles = closestReachableEnemyCity.getTilesInDistanceRangeSnapshot(minDistanceFromCityToConsiderForLandingArea..maxDistanceFromCityToConsiderForLandingArea)
+            // Don't head for hurty terrain
+            .filter { it.isLand && unit.getDamageFromTerrain(it) <= 0 }
+        val tileToHeadTo = candidateLandingTiles
             .sortedBy { it.aerialDistanceTo(unit.currentTile) }
             .firstOrNull { (unit.movement.canMoveTo(it) || it == unit.currentTile) && unit.movement.canReach(it) }
 
@@ -134,10 +136,11 @@ object HeadTowardsEnemyCityAutomation {
     ): Boolean {
         // If we're already in fire range but have no sight, hold position
         // If there IS sight, automateUnitMoves would order attacking instead of heading to city
-        if (closestReachableEnemyCity.getTilesInDistance(unitRange).contains(unit.getTile()))
+        if (closestReachableEnemyCity.anyTileInDistance(unitRange) { it == unit.getTile() })
             return true
 
-        val tilesInBombardRange = closestReachableEnemyCity.getTilesInDistance(2).toSet()
+        // We need a snapshot Set for membership testing below.
+        val tilesInBombardRange = closestReachableEnemyCity.getTilesInDistanceSnapshot(2).toSet()
         val candidateTiles = unitDistanceToTiles.asSequence().filter {
             it.key.aerialDistanceTo(closestReachableEnemyCity) >= unitRange
                 && it.key !in tilesInBombardRange

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -158,8 +158,7 @@ object SpecificUnitAutomation {
             /** @return the number of tiles 4 (un-modded) out from this city that could hold a city, ie how lonely this city is */
             @Readonly
             fun getFrontierScore(city: City) = city.getCenterTile()
-                .getTilesAtDistance(city.civ.gameInfo.ruleset.modOptions.constants.minimalCityDistance + 1)
-                .count { it.canBeSettled(unit.civ) }
+                .countTilesAtDistance(city.civ.gameInfo.ruleset.modOptions.constants.minimalCityDistance + 1) { it.canBeSettled(unit.civ) }
 
             val frontierCity = unit.civ.cities.maxByOrNull { getFrontierScore(it) }
             if (frontierCity != null && getFrontierScore(frontierCity) > 0  && unit.movement.canReach(frontierCity.getCenterTile()))
@@ -188,7 +187,7 @@ object SpecificUnitAutomation {
     /** @return whether there was any progress in placing the improvement. A return value of `false`
      * can be interpreted as: the unit doesn't know where to place the improvement or is stuck. */
     fun automateImprovementPlacer(unit: MapUnit) : Boolean {
-        val improvementBuildingUnique = unit.getMatchingUniques(UniqueType.ConstructImprovementInstantly).firstOrNull()
+        val improvementBuildingUnique = unit.firstMatchingUniqueOrNull(UniqueType.ConstructImprovementInstantly) { true }
             ?: return false
 
         val improvementName = improvementBuildingUnique.params[0]
@@ -224,7 +223,7 @@ object SpecificUnitAutomation {
                 // Radius 5 is quite arbitrary. Few units have such a high movement radius although
                 // streets might modify it. Also there might be invisible units, so this is just an
                 // approximation for relative safety and simplicity.
-                val enemyUnitsNearby = unit.getTile().getTilesInDistance(5).any { tileNearby ->
+                val enemyUnitsNearby = unit.getTile().anyTileInDistance(5) { tileNearby ->
                     tileNearby.getUnits().any { unitOnTileNearby ->
                         unitOnTileNearby.isMilitary() && unitOnTileNearby.civ.isAtWarWith(unit.civ)
                     }

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -126,7 +126,7 @@ object UnitAutomation {
     private fun isGoodTileToExplore(unit: MapUnit, tile: Tile, unitVisibilityRange: Int): Boolean {
         // These should be ordered by increasing computational cost
         return (tile.getOwner() == null || !tile.getOwner()!!.isCityState)
-                && tile.getTilesInDistance(unitVisibilityRange).any { !unit.civ.hasExplored(it) }
+                && tile.anyTileInDistance(unitVisibilityRange) { !unit.civ.hasExplored(it) }
                 && (!unit.civ.isCityState || tile.neighbors.any { it.getOwner() == unit.civ }) // Don't want city-states exploring far outside their borders
                 && unit.getDamageFromTerrain(tile) <= 0    // Don't take unnecessary damage
                 && unit.civ.threatManager.getDistanceToClosestEnemyUnit(tile, 3) > 3 // don't walk in range of enemy units
@@ -142,7 +142,7 @@ object UnitAutomation {
                 unit.movement.getDistanceToTiles().keys.filter { isGoodTileToExplore(unit, it, unitVisibilityRange) }
         if (explorableTilesThisTurn.any()) {
             val bestTile = explorableTilesThisTurn
-                .maxBy { it.tileHeight + it.getTilesAtDistance(unit.getVisibilityRange()).count { tile -> !tile.isExplored(unit.civ) }}
+                .maxBy { it.tileHeight + it.countTilesAtDistance(unit.getVisibilityRange()) { tile -> !tile.isExplored(unit.civ) } }
             // Assign each tile a score for "explore value"
             // This could be more elaborate: for example add a malus for distant tiles such as to move not too far away from capital (barb control)
             // or bonus according to tile yields (likely candidates for city locations), but this comes at a cost of performance
@@ -151,11 +151,11 @@ object UnitAutomation {
         }
 
         // Nothing immediate, lets look further. Number increases exponentially with distance - at 10 this took a looong time
-        for (tile in unit.currentTile.getTilesInDistance(5))
-            if (isGoodTileToExplore(unit, tile, unitVisibilityRange)) {
-                unit.movement.headTowards(tile)
-                return true
-            }
+        val goodTile = unit.currentTile.firstTileInDistanceOrNull(5) { isGoodTileToExplore(unit, it, unitVisibilityRange) }
+        if (goodTile != null) {
+            unit.movement.headTowards(goodTile)
+            return true
+        }
         return false
     }
 
@@ -177,7 +177,7 @@ object UnitAutomation {
 
         // If everything around this unit is visible, we can stop.
         // Calculations below are quite expensive especially in the late game.
-        if (unit.currentTile.getTilesInDistance(5).all { it.isVisible(unit.civ) }) {
+        if (!unit.currentTile.anyTileInDistance(5) { !it.isVisible(unit.civ) }) {
             return false
         }
 
@@ -190,11 +190,11 @@ object UnitAutomation {
         }
 
         // Nothing immediate, lets look further. Number increases exponentially with distance - at 10 this took a looong time
-        for (tile in unit.currentTile.getTilesInDistance(5))
-            if (isGoodTileForFogBusting(unit, tile)) {
-                unit.movement.headTowards(tile)
-                return true
-            }
+        val goodTile = unit.currentTile.firstTileInDistanceOrNull(5) { isGoodTileForFogBusting(unit, it) }
+        if (goodTile != null) {
+            unit.movement.headTowards(goodTile)
+            return true
+        }
         return false
     }
 
@@ -204,26 +204,25 @@ object UnitAutomation {
                 && tile.getOwner() == null
                 && tile.neighbors.all { it.getOwner() == null }
                 && unit.civ.hasExplored(tile)
-                && tile.getTilesInDistance(2).any { it.getOwner() == unit.civ }
+                && tile.anyTileInDistance(2) { it.getOwner() == unit.civ }
                 && unit.getDamageFromTerrain(tile) <= 0
                 && unit.movement.canReach(tile) // expensive, evaluate last
     }
 
     fun wander(unit: MapUnit, stayInTerritory: Boolean = false, tilesToAvoid: Set<Tile> = setOf()) {
         if (!unit.hasMovement()) return // return in case we can't move anyways
-        val unitDistanceToTiles = unit.currentTile.getTilesAtDistance(1)
         // We could walk further, but wander() is meant to let units not stay on the same tile permanently,
         // to avoid obstructing human scouts and workers, moving just one tile should be enough
-        val reachableTiles = unitDistanceToTiles
-                .filter {
-                    it !in tilesToAvoid
-                        && unit.movement.canMoveTo(it)
-                        && unit.movement.canReachInCurrentTurn(it) // Yes this is required despite the above line - see #14461
-                        && unit.getDamageFromTerrain(it) <= 0 // Don't end turn on damaging terrain for no good reason
-                        && (!stayInTerritory || it.getOwner() == unit.civ || unit.currentTile.getOwner() != unit.civ)
-                }
+        // We need a snapshot List for .random(rng) below.
+        val reachableTiles = unit.currentTile.getTilesAtDistanceSnapshot(1).filter {
+            it !in tilesToAvoid
+                && unit.movement.canMoveTo(it)
+                && unit.movement.canReachInCurrentTurn(it) // Yes this is required despite the above line - see #14461
+                && unit.getDamageFromTerrain(it) <= 0 // Don't end turn on damaging terrain for no good reason
+                && (!stayInTerritory || it.getOwner() == unit.civ || unit.currentTile.getOwner() != unit.civ)
+        }
         val rng = unit.cache.state.stateBasedRandom("UnitAutomation.wander")
-        if (reachableTiles.any()) unit.movement.moveToTile(reachableTiles.toList().random(rng))
+        if (reachableTiles.isNotEmpty()) unit.movement.moveToTile(reachableTiles.random(rng))
     }
 
     internal fun tryUpgradeUnit(unit: MapUnit): Boolean {
@@ -284,16 +283,22 @@ object UnitAutomation {
 
     private fun tryHeadTowardsEncampment(unit: MapUnit): Boolean {
         if (unit.hasUnique(UniqueType.SelfDestructs)) return false // don't use single-use units against barbarians...
-        val cities = unit.civ.cities
-        val knownEncampments = cities.asSequence()
-            .flatMap { it.getCenterTile().getTilesInDistance(6) }
-                .filter { it.isBarbarianEncampment() && unit.civ.hasExplored(it) }
-            .distinct()
-        val encampmentsCloseToCities = knownEncampments.asSequence()
-            .sortedBy { it.aerialDistanceTo(unit.currentTile) }
-        val encampmentToHeadTowards = encampmentsCloseToCities.firstOrNull { unit.movement.canReach(it) }
-            ?: return false
-        unit.movement.headTowards(encampmentToHeadTowards)
+        var closestReachableEncampment: Tile? = null
+        var closestDistance = Int.MAX_VALUE
+        for (city in unit.civ.cities) {
+            val nearestEncampment = city.getCenterTile().maxTileInDistanceRange(0..6) { tile ->
+                if (tile.isBarbarianEncampment() && unit.civ.hasExplored(tile) && unit.movement.canReach(tile))
+                    -tile.aerialDistanceTo(unit.currentTile)
+                else Int.MIN_VALUE
+            } ?: continue
+            val distance = -nearestEncampment.second
+            if (nearestEncampment.second != Int.MIN_VALUE && distance < closestDistance) {
+                closestReachableEncampment = nearestEncampment.first
+                closestDistance = distance
+            }
+        }
+        if (closestReachableEncampment == null) return false
+        unit.movement.headTowards(closestReachableEncampment)
         return true
     }
 
@@ -436,20 +441,20 @@ object UnitAutomation {
 
     @Readonly
     private fun getDangerousTiles(unit: MapUnit): HashSet<Tile> {
-        val nearbyEnemyUnits = unit.currentTile.getTilesInDistance(3)
-            .flatMap { tile -> tile.getUnits().filter { unit.civ.isAtWarWith(it.civ) } }
+        val dangerousTiles = HashSet<Tile>()
 
-        val tilesInRangeOfAttack = nearbyEnemyUnits
-            .flatMap { it.getTile().getTilesInDistance((it.getMaxMovement() - 1) + it.getRange()) }
+        unit.currentTile.forEachTileInDistance(3) { tile ->
+            for (nearbyEnemyUnit in tile.getUnits())
+                if (unit.civ.isAtWarWith(nearbyEnemyUnit.civ))
+                    nearbyEnemyUnit.getTile().forEachTileInDistance((nearbyEnemyUnit.getMaxMovement() - 1) + nearbyEnemyUnit.getRange()) { dangerousTiles.add(it) }
 
-        val tilesWithinBombardmentRange = unit.currentTile.getTilesInDistance(3)
-            .filter { it.isCityCenter() && it.getCity()!!.civ.isAtWarWith(unit.civ) }
-            .flatMap { it.getTilesInDistance(it.getCity()!!.getBombardRange()) }
+            if (tile.isCityCenter() && tile.getCity()!!.civ.isAtWarWith(unit.civ))
+                tile.forEachTileInDistance(tile.getCity()!!.getBombardRange()) { dangerousTiles.add(it) }
 
-        val tilesWithTerrainDamage = unit.currentTile.getTilesInDistance(3)
-            .filter { unit.getDamageFromTerrain(it) > 0 }
+            if (unit.getDamageFromTerrain(tile) > 0) dangerousTiles.add(tile)
+        }
 
-        return (tilesInRangeOfAttack + tilesWithinBombardmentRange + tilesWithTerrainDamage).toHashSet()
+        return dangerousTiles
     }
 
     /**
@@ -487,7 +492,9 @@ object UnitAutomation {
                 unit.getTile().position,
                 unit.getMaxMovement() * CLOSE_ENEMY_TURNS_AWAY_LIMIT
         )
-        val closeEnemy = TargetHelper.getAttackableEnemies(unit, unitDistanceToTiles, tilesToCheck = unit.getTile().getTilesInDistance(CLOSE_ENEMY_TILES_AWAY_LIMIT).toList())
+        // We need a snapshot List for getAttackableEnemies below.
+        val tilesToCheck = unit.getTile().getTilesInDistanceSnapshot(CLOSE_ENEMY_TILES_AWAY_LIMIT)
+        val closeEnemy = TargetHelper.getAttackableEnemies(unit, unitDistanceToTiles, tilesToCheck = tilesToCheck)
             .filterNot { unit.baseUnit.isRanged() && it.tileToAttack.isCityCenter() && it.tileToAttack.getCity()!!.health == 1 } // occurs fairly often probably because AI dumb
             .filter { unit.getDamageFromTerrain(it.tileToAttackFrom) <= 0 }  // Don't attack from a mountain or near enemy citadels
             .filter {
@@ -530,8 +537,7 @@ object UnitAutomation {
         // Move to the closest city with a tile we can enter nearby
         for (city in citiesToDefend) {
             if (unit.getTile().aerialDistanceTo(city.getCenterTile()) <= 2) return true
-            val tileToMoveTo = city.getCenterTile().getTilesInDistance(2)
-                .firstOrNull { unit.movement.canMoveTo(it) && unit.movement.canReach(it) } ?: continue
+            val tileToMoveTo = city.getCenterTile().firstTileInDistanceOrNull(2) { unit.movement.canMoveTo(it) && unit.movement.canReach(it) } ?: continue
             unit.movement.headTowards(tileToMoveTo)
             return true
         }
@@ -563,11 +569,21 @@ object UnitAutomation {
         if (siegedCities.any { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 2 })
             return false
 
-        val reachableTileNearSiegedCity = siegedCities
-                .flatMap { it.getCenterTile().getTilesAtDistance(2) }
-                .sortedBy { it.aerialDistanceTo(unit.currentTile) }
-                .firstOrNull { unit.movement.canMoveTo(it) && unit.movement.canReach(it)
-                        && unit.getDamageFromTerrain(it) <= 0 } // Avoid ending up on damaging terrain
+        var reachableTileNearSiegedCity: Tile? = null
+        var closestDistance = Int.MAX_VALUE
+        for (siegedCity in siegedCities) {
+            val nearestTile = siegedCity.getCenterTile().maxTileInDistanceRange(2..2) { tile ->
+                if (unit.movement.canMoveTo(tile) && unit.movement.canReach(tile)
+                        && unit.getDamageFromTerrain(tile) <= 0) // Avoid ending up on damaging terrain
+                    -tile.aerialDistanceTo(unit.currentTile)
+                else Int.MIN_VALUE
+            } ?: continue
+            val distance = -nearestTile.second
+            if (nearestTile.second != Int.MIN_VALUE && distance < closestDistance) {
+                reachableTileNearSiegedCity = nearestTile.first
+                closestDistance = distance
+            }
+        }
 
         if (reachableTileNearSiegedCity != null) {
             unit.movement.headTowards(reachableTileNearSiegedCity)

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -227,12 +227,12 @@ class WorkerAutomation(
             && (currentTile.isPillaged() || currentTile.hasFalloutEquivalent() || tileHasWorkToDo(currentTile, unit)))
             return currentTile
         
-        val workableTilesCenterFirst = currentTile.getTilesInDistance(3)
-            .filter {
-                (it.getOwner() == null || it.getOwner() == unit.civ || it.getOwner()!!.isCityState)
-                    && isAutomationWorkableTile(it, tilesToAvoid, currentTile, unit) 
-                    && getBasePriority(it, unit) >= 0
-            }
+        // We need a snapshot List for groupBy below.
+        val workableTilesCenterFirst = currentTile.getTilesInDistanceSnapshot(3).filter {
+            (it.getOwner() == null || it.getOwner() == unit.civ || it.getOwner()!!.isCityState)
+                && isAutomationWorkableTile(it, tilesToAvoid, currentTile, unit)
+                && getBasePriority(it, unit) >= 0
+        }
 
         val workableTilesPrioritized = workableTilesCenterFirst.groupBy { getBasePriority(it, unit) }
             .asSequence().sortedByDescending { it.key }
@@ -275,8 +275,8 @@ class WorkerAutomation(
         if (tile.isCityCenter()) return false
         if (tile in roadBetweenCitiesAutomation.tilesOfRoadsMap) return true
         // Don't try to improve tiles we can't benefit from at all
-        if (!civInfo.canSeeResource(tile.tileResource) && tile.getTilesInDistance(civInfo.gameInfo.ruleset.modOptions.constants.cityWorkRange)
-                .none { it.isCityCenter() && it.getCity()?.civ == civInfo }
+        if (!civInfo.canSeeResource(tile.tileResource) && !tile.anyTileInDistance(civInfo.gameInfo.ruleset.modOptions.constants.cityWorkRange) {
+                it.isCityCenter() && it.getCity()?.civ == civInfo }
         ) return false
         if (tile.tileImprovement?.hasUnique(UniqueType.AutomatedUnitsWillNotReplace) == true && !tile.isPillaged()) return false
         return true
@@ -560,7 +560,7 @@ class WorkerAutomation(
                 if (currentImprovement != null && tile.tileResource!!.isImprovedBy(currentImprovement)) {
                     value -= 0.3f // enough to offset the 0.2f food vs production value difference
                 }
-                if (isResourceImprovedByNewImprovement && tile.getTilesInDistance(4).none { it.tileImprovement == improvement }) {
+                if (isResourceImprovedByNewImprovement && !tile.anyTileInDistance(4) { it.tileImprovement == improvement }) {
                     value += 0.3f
                 }
             }

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -297,7 +297,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     @Readonly
     fun containsBuildingUnique(uniqueType: UniqueType, state: GameContext = this.state) =
-        cityConstructions.builtBuildingUniqueMap.getMatchingUniques(uniqueType, state).any()
+        cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, state) { true } != null
 
     @Readonly fun getGreatPersonPercentageBonus() = GreatPersonPointsBreakdown.getGreatPersonPercentageBonus(this)
     @Readonly fun getGreatPersonPoints() = GreatPersonPointsBreakdown(this).sum()
@@ -646,25 +646,46 @@ class City : IsPartOfGameInfoSerialization, INamed {
     }
 
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, op: (unique: Unique)->Unit)
-        = forEachMatchingUnique(uniqueType, state, true, op)
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, predicate: (unique: Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, state, true, predicate)
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit)
-        = forEachMatchingUnique(uniqueType, gameContext, true, op)
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, predicate: (unique: Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, true, predicate)
     @Readonly
-    fun forEachMatchingUnique(
+    fun firstMatchingUniqueOrNull(
         uniqueType: UniqueType,
         gameContext: GameContext = state,
         includeCivUniques: Boolean,
-        op: (unique: Unique)->Unit,
-    ) {
+        predicate: (unique: Unique)->Boolean,
+    ): Unique? {
         if (includeCivUniques) {
-            civ.forEachMatchingUnique(uniqueType, gameContext, op)
-            forEachLocalMatchingUnique(uniqueType, gameContext, op)
+            return civ.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+                ?: firstLocalMatchingUniqueOrNull(uniqueType, gameContext, predicate)
         } else {
-            cityConstructions.builtBuildingUniqueMap.forEachMatchingUnique(uniqueType, state, isTimedUniqueFilter, op)
-            religion.forEachMatchingUnique(uniqueType, state, isTimedUniqueFilter, op)
+            return cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, state, isTimedUniqueFilter, predicate)
+                ?: religion.firstMatchingUniqueOrNull(uniqueType, state, isTimedUniqueFilter, predicate)
         }
+    }
+
+    @Readonly
+    fun forEachMatchingUnique(uniqueType: UniqueType, op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, state, true) {op(it); false}
+    }
+    @Readonly
+    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, gameContext, true) {op(it); false}
+    }
+    @Readonly
+    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, includeCivUniques: Boolean, op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, gameContext, includeCivUniques) {op(it); false}
+    }
+
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, initial: T, crossinline accumulate: (T, Unique) -> T): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext) { acc = accumulate(acc, it) }
+        return acc
     }
 
     // Uniques special to this city
@@ -680,9 +701,13 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     // Uniques special to this city
     @Readonly
-    fun forEachLocalMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, op: (unique: Unique)->Unit) {
-        cityConstructions.builtBuildingUniqueMap.forEachMatchingUnique(uniqueType, gameContext, isLocalUniqueFilter, op)
-        religion.forEachMatchingUnique(uniqueType, gameContext, op)
+    inline fun firstLocalMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext = state, crossinline predicate: (unique: Unique)->Boolean): Unique?
+        = cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, isLocalUniqueFilter, predicate)
+        ?: religion.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+
+    @Readonly
+    inline fun forEachLocalMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, crossinline op: (unique: Unique)->Unit) {
+        firstLocalMatchingUniqueOrNull(uniqueType, gameContext, {op(it); false })
     }
 
     // Uniques coming from this city, but that should be provided globally
@@ -699,11 +724,15 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     // Uniques coming from this city, but that should be provided globally
     @Readonly
-    fun forEachMatchingUniqueWithNonLocalEffects(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit)
-        = cityConstructions.builtBuildingUniqueMap.forEachMatchingUnique(uniqueType, gameContext, nonLocalUniqueFilter, op)
+    inline fun firstMatchingUniqueWithNonLocalEffectsOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (unique: Unique)->Boolean): Unique?
+        = cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, nonLocalUniqueFilter, predicate)
+    @Readonly
+    inline fun forEachMatchingUniqueWithNonLocalEffects(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (unique: Unique)->Unit)
+        = firstMatchingUniqueWithNonLocalEffectsOrNull(uniqueType, gameContext) { op(it); false }
 
     // All uniques affecting this city: both local uniques and civ uniques.
     // This replaces LocalUniqueCache#forCityGetMatchingUniques
+    // Not inline: civ.forEachMatchingUnique is itself not inline (3+ inner calls)
     @Readonly
     fun forEachAffectingMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, op: (unique: Unique)->Unit) {
         forEachLocalMatchingUnique(uniqueType, gameContext, op)
@@ -739,23 +768,53 @@ class City : IsPartOfGameInfoSerialization, INamed {
     }
 
     @Readonly
+    fun hasMatchingUnique(uniqueType: UniqueType, predicate: (unique: Unique)->Boolean)
+        = firstMatchingUniqueOrNull(uniqueType, state, true, predicate) != null
+    @Readonly
+    fun hasMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, includeCivUniques: Boolean = true, predicate: (unique: Unique)->Boolean = {true})
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, includeCivUniques, predicate) != null
+
+    @Readonly
+    fun firstTriggeredUniqueOrNull(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean = { true },
+        includeCivUniques: Boolean = true,
+        predicate: (Unique) -> Boolean): Unique? {
+        if (includeCivUniques) {
+            return civ.firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, predicate)
+                ?: firstLocalTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, predicate)
+        }
+        else {
+            fun filter(unique: Unique): Boolean  =
+                unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
+            return cityConstructions.builtBuildingUniqueMap.firstUniqueOrNull(::filter, predicate)
+                ?: religion.firstUniqueOrNull(::filter, predicate)
+        }
+    }
+
+    // Not inline: firstTriggeredUniqueOrNull delegates to 3+ inner calls and has local functions
+    @Readonly
     fun forEachTriggeredUnique(
         trigger: UniqueType,
         gameContext: GameContext = state,
         triggerFilter: (Unique) -> Boolean = { true },
         includeCivUniques: Boolean = true,
         op: (Unique) -> Unit) {
-        if (includeCivUniques) {
-            civ.forEachTriggeredUnique(trigger, gameContext, triggerFilter, op)
-            forEachLocalTriggeredUnique(trigger, gameContext, triggerFilter, op)
-        }
-        else {
-            fun filter(unique: Unique): Boolean  =
-                unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
-            fun multipliedOp(unique: Unique) = unique.forEachMultiplied(gameContext, op)
-            cityConstructions.builtBuildingUniqueMap.forEachUnique(::filter, ::multipliedOp)
-            religion.forEachUnique(::filter, ::multipliedOp)
-        }
+        firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, includeCivUniques) {op(it); false}
+    }
+
+    /** @return A freshly allocated [List] snapshot of the triggered uniques, for cases that need to trigger uniques
+     *  that may mutate this city's own uniques (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly
+    fun getTriggeredUniquesSnapshot(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean = { true },
+        includeCivUniques: Boolean = true): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachTriggeredUnique(trigger, gameContext, triggerFilter, includeCivUniques) { list.add(it) }
+        return list
     }
 
     @Readonly
@@ -768,6 +827,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         }.flatMap { it.getMultiplied(gameContext) }
     }
 
+    // Not inline: the canonical firstLocalTriggeredUniqueOrNull below uses local functions, which inline functions can't contain
     @Readonly
     fun forEachLocalTriggeredUnique(trigger: UniqueType, gameContext: GameContext = state, op: (Unique)->Unit)
         = forEachLocalTriggeredUnique(trigger, gameContext, {true}, op)
@@ -775,12 +835,21 @@ class City : IsPartOfGameInfoSerialization, INamed {
     // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getLocalTriggeredUniques
     fun forEachLocalTriggeredUnique(trigger: UniqueType, gameContext: GameContext = state,
                                  triggerFilter: (Unique) -> Boolean, op: (Unique)->Unit) {
+        firstLocalTriggeredUniqueOrNull(trigger, gameContext, triggerFilter) {op(it); false}
+    }
+    @Readonly
+    fun firstLocalTriggeredUniqueOrNull(trigger: UniqueType, gameContext: GameContext = state, predicate: (Unique)->Boolean): Unique?
+        = firstLocalTriggeredUniqueOrNull(trigger, gameContext, {true}, predicate)
+    @Readonly
+    // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getLocalTriggeredUniques
+    fun firstLocalTriggeredUniqueOrNull(trigger: UniqueType, gameContext: GameContext = state,
+                                    triggerFilter: (Unique) -> Boolean, predicate: (Unique)->Boolean): Unique? {
         fun uniqueFilter(unique: Unique): Boolean
             = unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
         fun buildingFilter(unique: Unique): Boolean
             = unique.isLocalEffect && uniqueFilter(unique)
-        cityConstructions.builtBuildingUniqueMap.forEachUnique(::buildingFilter, op)
-        religion.forEachUnique(::uniqueFilter, op)
+        return cityConstructions.builtBuildingUniqueMap.firstUniqueOrNull(::buildingFilter, predicate)
+            ?: religion.firstUniqueOrNull(::uniqueFilter, predicate)
     }
 
     //endregion

--- a/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
@@ -69,13 +69,19 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
     }
 
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, op: (unique: Unique)->Unit)
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline op: (unique: Unique)->Unit)
         = forEachMatchingUnique(uniqueType, gameContext, NO_UNIQUE_FILTER, op)
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, filter:(Unique)->Boolean, op: (unique: Unique)->Unit) {
-        val majorityReligion = getMajorityReligion() ?: return
-        majorityReligion.followerBeliefUniqueMap.forEachMatchingUnique(uniqueType, gameContext, filter, op)
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline filter:(Unique)->Boolean, crossinline op: (unique: Unique)->Unit) {
+        firstMatchingUniqueOrNull(uniqueType, gameContext, filter) { op(it); false }
     }
+
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline predicate: (unique: Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, NO_UNIQUE_FILTER, predicate)
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext=city.state, crossinline filter:(Unique)->Boolean, crossinline predicate: (unique: Unique)->Boolean): Unique? 
+        = getMajorityReligion()?.followerBeliefUniqueMap?.firstMatchingUniqueOrNull(uniqueType, gameContext, filter, predicate)
 
     @Readonly
     fun getAllUniques(): Sequence<Unique> {
@@ -84,10 +90,13 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
     }
 
     @Readonly
-    fun forEachUnique(filter:(Unique)->Boolean, op: (unique: Unique)->Unit) {
-        val majorityReligion = getMajorityReligion() ?: return
-        majorityReligion.followerBeliefUniqueMap.forEachUnique(filter, op)
+    inline fun forEachUnique(filter:(Unique)->Boolean, crossinline op: (unique: Unique)->Unit) {
+        firstUniqueOrNull(filter) { op(it); false }
     }
+
+    @Readonly
+    inline fun firstUniqueOrNull(filter:(Unique)->Boolean, crossinline predicate: (unique: Unique)->Boolean): Unique? 
+        = getMajorityReligion()?.followerBeliefUniqueMap?.firstUniqueOrNull(filter, predicate)
 
     @Readonly fun getPressures(): Counter<String> = pressures.clone()
 

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -25,7 +25,7 @@ class CityTurnManager(val city: City) {
             if (resource.resource.isStockpiled && resource.resource.isCityWide)
                 city.gainStockpiledResource(resource.resource, resource.amount)
         }
-        for (unique in city.getTriggeredUniques(UniqueType.TriggerUponTurnStart, includeCivUniques = false).toList()) {
+        for (unique in city.getTriggeredUniquesSnapshot(UniqueType.TriggerUponTurnStart, includeCivUniques = false)) {
             UniqueTriggerActivation.triggerUnique(unique, city)
         }
 
@@ -143,7 +143,7 @@ class CityTurnManager(val city: City) {
 
 
     fun endTurn():Unit = timeThis("CityTurnManager.endTurn") {
-        for (unique in city.getTriggeredUniques(UniqueType.TriggerUponTurnEnd, includeCivUniques = false).toList()) {
+        for (unique in city.getTriggeredUniquesSnapshot(UniqueType.TriggerUponTurnEnd, includeCivUniques = false)) {
             UniqueTriggerActivation.triggerUnique(unique, city)
         }
         val stats = city.cityStats.currentCityStats

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -601,7 +601,7 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun hasUnique(uniqueType: UniqueType, gameContext: GameContext = state) =
-        getMatchingUniques(uniqueType, gameContext).any()
+        firstMatchingUniqueOrNull(uniqueType, gameContext) { true } != null
 
     // Does not return local uniques, only global ones.
     /** Destined to replace getMatchingUniques, gradually, as we fill the enum */
@@ -630,17 +630,32 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, op: (unique: Unique)->Unit) {
-        nation.forEachMatchingUnique(uniqueType, gameContext, op)
-        for (i in 0..<cities.size)
-            cities[i].forEachMatchingUniqueWithNonLocalEffects(uniqueType, gameContext, op)
-        policies.policyUniques.forEachMatchingUnique(uniqueType, gameContext, op)
-        tech.techUniques.forEachMatchingUnique(uniqueType, gameContext, op)
-        temporaryUniques.forEachMatchingUnique(uniqueType, gameContext, op)
-        getEra().forEachMatchingUnique(uniqueType, gameContext, op)
-        cityStateFunctions.forEachUniqueProvidedByCityStates(uniqueType, gameContext, op)
-        religionManager.religion?.founderBeliefUniqueMap?.forEachMatchingUnique(uniqueType, gameContext, op)
-        civResourcesUniqueMap.forEachMatchingUnique(uniqueType, gameContext, op)
-        gameInfo.getGlobalUniques().forEachMatchingUnique(uniqueType, gameContext, op)
+        firstMatchingUniqueOrNull(uniqueType, gameContext) { op(it); false }
+    }
+
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = state, initial: T, crossinline accumulate: (T, Unique) -> T): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext) { acc = accumulate(acc, it) }
+        return acc
+    }
+
+    @Readonly
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext = state, predicate: (unique: Unique)->Boolean): Unique? {
+        for (i in 0..<cities.size) {
+            val r = cities[i].firstMatchingUniqueWithNonLocalEffectsOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            if (r != null) return r
+        }
+        return nation.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: policies.policyUniques.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: tech.techUniques.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: temporaryUniques.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: getEra().firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: cityStateFunctions.firstUniqueProvidedByCityStatesOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: religionManager.religion?.founderBeliefUniqueMap?.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: civResourcesUniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+            ?: gameInfo.getGlobalUniques().firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
     }
 
     @Readonly
@@ -724,6 +739,36 @@ class Civilization : IsPartOfGameInfoSerialization {
         gameInfo.getGlobalUniques().uniqueMap.forEachMatchingUnique(trigger, gameContext, uniqueFilter, listOp)
         // now its safe to do the op, which might mutate the lists
         uniqueList.forEach(op)
+    }
+
+    @Readonly
+    fun firstTriggeredUniqueOrNull(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean,
+        predicate: (Unique)->Boolean,
+    ): Unique? = firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter, false, predicate)
+    @Readonly
+    fun firstTriggeredUniqueOrNull(
+        trigger: UniqueType,
+        gameContext: GameContext = state,
+        triggerFilter: (Unique) -> Boolean = { true },
+        ignoreCities: Boolean,
+        predicate: (Unique)->Boolean,
+    ): Unique? {
+        val uniqueFilter = { unique: Unique -> unique.getModifiers(trigger).any(triggerFilter) }
+        nation.uniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+        if (!ignoreCities) {
+            for (city in cities) {
+                var r = city.cityConstructions.builtBuildingUniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+                if (r != null) return r
+            }
+        }
+        return religionManager.religion?.founderBeliefUniqueMap?.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: policies.policyUniques.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: tech.techUniques.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: getEra().uniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)?.let { return it }
+            ?: gameInfo.getGlobalUniques().uniqueMap.firstMatchingUniqueOrNull(trigger, gameContext, uniqueFilter, predicate)
     }
     /** Implements [UniqueParameterType.CivFilter][com.unciv.models.ruleset.unique.UniqueParameterType.CivFilter] */
     @Readonly

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -822,10 +822,17 @@ class CityStateFunctions(val civInfo: Civilization) {
     }
 
     @Readonly
-    fun forEachUniqueProvidedByCityStates(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique) -> Unit) {
-        if (civInfo.isCityState) return
-        for (uniqueMap in civInfo.cache.cityStateBonusUniqueMaps)
-            uniqueMap.forEachMatchingUnique(uniqueType, gameContext, op)
+    inline fun forEachUniqueProvidedByCityStates(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (unique: Unique) -> Unit)
+        = firstUniqueProvidedByCityStatesOrNull(uniqueType, gameContext) { op(it); false }
+
+    @Readonly
+    inline fun firstUniqueProvidedByCityStatesOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (unique: Unique) -> Boolean): Unique? {
+        if (civInfo.isCityState) return null
+        for (uniqueMap in civInfo.cache.cityStateBonusUniqueMaps) {
+            val result = uniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+            if (result != null) return result
+        }
+        return null
     }
 
     companion object {

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -288,6 +288,36 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
                     }
                 }.filterNotNull()
 
+    /** @return All tiles in a hexagon of radius [distance], including the tile at [origin] and all up to [distance] steps away, as a
+     *  freshly allocated [List] snapshot that will not change if the map is mutated afterwards.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun getTilesInDistanceSnapshot(origin: HexCoord, distance: Int): List<Tile> {
+        val list = ArrayList<Tile>()
+        forEachTileInDistance(origin, distance) { list.add(it) }
+        return list
+    }
+
+    /** @return All tiles in a hexagonal ring around [origin] with the distances in [range], as a freshly allocated [List] snapshot
+     *  that will not change if the map is mutated afterwards. Excludes the [origin] tile unless [range] starts at 0.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun getTilesInDistanceRangeSnapshot(origin: HexCoord, range: IntRange): List<Tile> {
+        val list = ArrayList<Tile>()
+        forEachTileInDistanceRange(origin, range) { list.add(it) }
+        return list
+    }
+
+    /** @return All tiles in a hexagonal ring 1 tile wide around [origin] with the [distance], as a freshly allocated [List] snapshot
+     *  that will not change if the map is mutated afterwards. Contains the [origin] if and only if [distance] is <= 0.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun getTilesAtDistanceSnapshot(origin: HexCoord, distance: Int): List<Tile> {
+        val list = ArrayList<Tile>()
+        forEachTileAtDistance(origin, distance) { list.add(it) }
+        return list
+    }
+
     /** @return All tiles in a hexagon of radius [distance], including the tile at [origin] and all up to [distance] steps away.
      *  Respects map edges and world wrap. */
     @Readonly
@@ -297,6 +327,47 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     fun forEachTileInDistance(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) {
         for (i in 0..distance)
             forEachTileAtDistance(origin, i, filter, op)
+    }
+
+    /** @return The first tile in a hexagon of radius [distance] (including the tile at [origin]) for which [predicate] returns true, or null if none does.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun firstTileInDistanceOrNull(origin: HexCoord, distance: Int, predicate: (Tile)->Boolean): Tile?
+        = firstTileInDistanceOrNull(origin, distance, {true}, predicate)
+    @Readonly
+    fun firstTileInDistanceOrNull(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, predicate: (Tile)->Boolean): Tile? {
+        for (i in 0..distance) {
+            val result = firstTileAtDistanceOrNull(origin, i, filter, predicate)
+            if (result != null) return result
+        }
+        return null
+    }
+
+    /** @return Whether any tile in a hexagon of radius [distance] (including the tile at [origin]) matches [predicate].
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun anyTileInDistance(origin: HexCoord, distance: Int, predicate: (Tile)->Boolean): Boolean
+        = firstTileInDistanceOrNull(origin, distance, predicate) != null
+    @Readonly
+    fun anyTileInDistance(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, predicate: (Tile)->Boolean): Boolean
+        = firstTileInDistanceOrNull(origin, distance, filter, predicate) != null
+
+    /** @return The number of tiles in a hexagon of radius [distance] (including the tile at [origin]) that match [predicate].
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun countTilesInDistance(origin: HexCoord, distance: Int, predicate: (Tile)->Boolean): Int {
+        var count = 0
+        forEachTileInDistance(origin, distance) { if (predicate(it)) count++ }
+        return count
+    }
+
+    /** Folds [accumulate] over every tile in a hexagon of radius [distance] (including the tile at [origin]), starting from [initial].
+     *  Useful for e.g. collecting matching tiles into a list/set/map without a separate forEach+add step. */
+    @Readonly
+    fun <T> accumulateForEachTileInDistance(origin: HexCoord, distance: Int, initial: T, accumulate: (T, Tile) -> T): T {
+        var acc = initial
+        forEachTileInDistance(origin, distance) { acc = accumulate(acc, it) }
+        return acc
     }
 
     /** @return All tiles in a hexagonal ring around [origin] with the distances in [range]. Excludes the [origin] tile unless [range] starts at 0.
@@ -310,6 +381,21 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             forEachTileAtDistance(origin, i, filter, op)
     }
 
+    /** @return The tile in a hexagonal ring around [origin] with the distances in [range] with the highest [selector] value, paired with that value,
+     *  or null if there are no tiles in range. Respects map edges and world wrap. */
+    fun <R : Comparable<R>> maxTileInDistanceRange(origin: HexCoord, range: IntRange, selector: (Tile)->R): Pair<Tile, R>? {
+        var bestTile: Tile? = null
+        var bestValue: R? = null
+        forEachTileInDistanceRange(origin, range) {
+            val value = selector(it)
+            if (bestValue == null || value > bestValue!!) {
+                bestTile = it
+                bestValue = value
+            }
+        }
+        return if (bestTile != null) bestTile to bestValue!! else null
+    }
+
     /** @return All tiles in a hexagonal ring 1 tile wide around [origin] with the [distance]. Contains the [origin] if and only if [distance] is <= 0.
      *  Respects map edges and world wrap. */
     @Readonly
@@ -317,13 +403,22 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         = forEachTileAtDistance(origin, distance, {true}, op)
     @Readonly
     fun forEachTileAtDistance(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) {
+         firstTileAtDistanceOrNull(origin, distance, filter) { op(it); false }
+    }
+
+    /** @return The first tile in a hexagonal ring 1 tile wide around [origin] with the [distance], for which [predicate] returns true, or null if none does.
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun firstTileAtDistanceOrNull(origin: HexCoord, distance: Int, predicate: (Tile)->Boolean): Tile?
+        = firstTileAtDistanceOrNull(origin, distance, {true}, predicate)
+    @Readonly
+    fun firstTileAtDistanceOrNull(origin: HexCoord, distance: Int, filter: (Tile)->Boolean, predicate: (Tile)->Boolean): Tile? {
         if (distance <= 0) {
             val tile = get(origin)
-            if (filter(tile)) op(tile)
+            if (filter(tile) && predicate(tile)) return tile
         } else if (distance == 1) {
             for (tile in get(origin).neighbors) {
-                if (filter(tile))
-                    op(tile)
+                if (filter(tile) && predicate(tile)) return tile
             }
         } else {
             val centerX = origin.x
@@ -336,30 +431,37 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             var tile: Tile?
             repeat (distance) { // From 6 to 8
                 tile = getIfTileExistsOrNull(currentX, currentY)
-                if (tile != null && filter(tile)) op(tile)
-                // We want to get the tile on the other side of the clock,
-                // so if we're at current = origin-delta we want to get to origin+delta.
-                // The simplest way to do this is 2*origin - current = 2*origin- (origin - delta) = origin+delta
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 currentX += 1 // we're going upwards to the left, towards 8 o'clock
             }
             repeat (distance) { // 8 to 10
                 tile = getIfTileExistsOrNull(currentX, currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 currentX += 1
                 currentY += 1 // we're going up the left side of the hexagon so we're going "up" - +1,+1
             }
             repeat (distance) { // 10 to 12
                 tile = getIfTileExistsOrNull(currentX, currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 tile = getIfTileExistsOrNull(2 * centerX - currentX, 2 * centerY - currentY)
-                if (tile != null && filter(tile)) op(tile)
+                if (tile != null && filter(tile) && predicate(tile)) return tile
                 currentY += 1 // we're going up the top left side of the hexagon so we're heading "up and to the right"
             }
         }
+        return null
+    }
+
+    /** @return The number of tiles in a hexagonal ring 1 tile wide around [origin] with the [distance] that match [predicate].
+     *  Respects map edges and world wrap. */
+    @Readonly
+    fun countTilesAtDistance(origin: HexCoord, distance: Int, predicate: (Tile)->Boolean): Int {
+        var count = 0
+        forEachTileAtDistance(origin, distance) { if (predicate(it)) count++ }
+        return count
     }
 
     /** @return all tiles within [rectangle], respecting world edges and wrap.

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -325,6 +325,21 @@ class MapUnit : IsPartOfGameInfoSerialization {
             yieldAll(civ.getMatchingUniques(uniqueType, gameContext))
     }
 
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueType], for cases that need to mutate
+     *  this unit's uniques (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly
+    fun getMatchingUniquesSnapshot(
+        uniqueType: UniqueType,
+        gameContext: GameContext = cache.state,
+        checkCivInfoUniques: Boolean = false
+    ): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachMatchingUnique(uniqueType, gameContext) { list.add(it) }
+        if (checkCivInfoUniques)
+            civ.forEachMatchingUnique(uniqueType, gameContext) { list.add(it) }
+        return list
+    }
+
     @Readonly
     fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, op: (Unique)->Unit)
         = forEachMatchingUnique(uniqueType, gameContext, checkCivInfoUniques = false, op)
@@ -334,19 +349,66 @@ class MapUnit : IsPartOfGameInfoSerialization {
         gameContext: GameContext = cache.state,
         checkCivInfoUniques: Boolean,
         op: (Unique)->Unit,
-    ) {
-        tempUniquesMap.forEachMatchingUnique(uniqueType, gameContext, op)
+    )
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, checkCivInfoUniques) { op(it); false }
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, initial: T, crossinline accumulate: (T, Unique) -> T): T
+        = accumulateForEachMatchingUnique(uniqueType, gameContext, checkCivInfoUniques = false, initial, accumulate)
+    @Readonly
+    inline fun <T> accumulateForEachMatchingUnique(
+        uniqueType: UniqueType,
+        gameContext: GameContext = cache.state,
+        checkCivInfoUniques: Boolean,
+        initial: T,
+        crossinline accumulate: (T, Unique) -> T
+    ): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext, checkCivInfoUniques) { acc = accumulate(acc, it) }
+        return acc
+    }
+
+    /** @return the unique matching [uniqueType] for which [selector] returns the highest value, or null if [selector] returns null for
+     *  every matching unique (useful to combine filtering and comparison in one step) or there are no matching uniques at all. */
+    @Readonly
+    inline fun maxByMatchingUnique(uniqueType: UniqueType, gameContext: GameContext = cache.state, crossinline selector: (Unique) -> Float?): Unique? {
+        var best: Unique? = null
+        var bestValue = Float.NEGATIVE_INFINITY
+        forEachMatchingUnique(uniqueType, gameContext) { unique ->
+            val value = selector(unique) ?: return@forEachMatchingUnique
+            if (value > bestValue) {
+                best = unique
+                bestValue = value
+            }
+        }
+        return best
+    }
+
+    @Readonly
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext = cache.state, predicate: (Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, checkCivInfoUniques = false, predicate)
+    @Readonly
+    fun firstMatchingUniqueOrNull(
+        uniqueType: UniqueType,
+        gameContext: GameContext = cache.state,
+        checkCivInfoUniques: Boolean,
+        predicate: (Unique)->Boolean,
+    ): Unique? {
+        val r = tempUniquesMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)?.let { return it }
+        if (r != null) return r
         if (checkCivInfoUniques)
-            civ.forEachMatchingUnique(uniqueType, gameContext, op)
+            return civ.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
+        return null
     }
 
     @Readonly
     fun hasUnique(
         uniqueType: UniqueType,
         gameContext: GameContext = cache.state,
-        checkCivInfoUniques: Boolean = false
+        checkCivInfoUniques: Boolean = false,
+        predicate: (Unique)->Boolean = {true}
     ): Boolean {
-        return getMatchingUniques(uniqueType, gameContext, checkCivInfoUniques).any()
+        return firstMatchingUniqueOrNull(uniqueType, gameContext, checkCivInfoUniques, predicate) != null
     }
 
     @Readonly
@@ -356,6 +418,16 @@ class MapUnit : IsPartOfGameInfoSerialization {
         triggerFilter: (Unique) -> Boolean = { true }
     ): Sequence<Unique> {
         return tempUniquesMap.getTriggeredUniques(trigger, gameContext, triggerFilter)
+    }
+
+    @Readonly
+    fun forEachTriggeredUnique(
+        trigger: UniqueType,
+        gameContext: GameContext = cache.state,
+        triggerFilter: (Unique) -> Boolean = { true },
+        op: (Unique) -> Unit
+    ) {
+        tempUniquesMap.forEachTriggeredUnique(trigger, gameContext, triggerFilter, op)
     }
 
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -633,12 +633,30 @@ class Tile : IsPartOfGameInfoSerialization {
         replaceWith = ReplaceWith("forEachTileAtDistance"))
     @Readonly fun getTilesAtDistance(distance: Int): Sequence<Tile> = tileMap.getTilesAtDistance(position, distance)
 
+    /** @return All tiles in a hexagon of radius [distance] as a freshly allocated [List] snapshot, for cases that need to
+     *  mutate the map (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly fun getTilesInDistanceSnapshot(distance: Int): List<Tile> = tileMap.getTilesInDistanceSnapshot(position, distance)
+    /** @return All tiles in a hexagonal ring in [range] as a freshly allocated [List] snapshot, for cases that need to
+     *  mutate the map (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly fun getTilesInDistanceRangeSnapshot(range: IntRange): List<Tile> = tileMap.getTilesInDistanceRangeSnapshot(position, range)
+    /** @return All tiles at [distance] as a freshly allocated [List] snapshot, for cases that need to
+     *  mutate the map (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly fun getTilesAtDistanceSnapshot(distance: Int): List<Tile> = tileMap.getTilesAtDistanceSnapshot(position, distance)
+
     @Readonly fun forEachTileInDistance(distance: Int, op: (Tile)->Unit) = tileMap.forEachTileInDistance(position, distance, op)
     @Readonly fun forEachTileInDistance(distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) = tileMap.forEachTileInDistance(position, distance, filter, op)
+    @Readonly fun firstTileInDistanceOrNull(distance: Int, predicate: (Tile)->Boolean) = tileMap.firstTileInDistanceOrNull(position, distance, predicate)
+    @Readonly fun firstTileInDistanceOrNull(distance: Int, filter: (Tile)->Boolean, predicate: (Tile)->Boolean) = tileMap.firstTileInDistanceOrNull(position, distance, filter, predicate)
+    @Readonly fun anyTileInDistance(distance: Int, predicate: (Tile)->Boolean) = tileMap.anyTileInDistance(position, distance, predicate)
+    @Readonly fun anyTileInDistance(distance: Int, filter: (Tile)->Boolean, predicate: (Tile)->Boolean) = tileMap.anyTileInDistance(position, distance, filter, predicate)
+    @Readonly fun countTilesInDistance(distance: Int, predicate: (Tile)->Boolean) = tileMap.countTilesInDistance(position, distance, predicate)
+    @Readonly fun <T> accumulateForEachTileInDistance(distance: Int, initial: T, accumulate: (T, Tile) -> T) = tileMap.accumulateForEachTileInDistance(position, distance, initial, accumulate)
     @Readonly fun forEachTileInDistanceRange(range: IntRange, op: (Tile)->Unit) = tileMap.forEachTileInDistanceRange(position, range, op)
     @Readonly fun forEachTileInDistanceRange(range: IntRange, filter: (Tile)->Boolean, op: (Tile)->Unit) = tileMap.forEachTileInDistanceRange(position, range, filter, op)
+    fun <R : Comparable<R>> maxTileInDistanceRange(range: IntRange, selector: (Tile)->R) = tileMap.maxTileInDistanceRange(position, range, selector)
     @Readonly fun forEachTileAtDistance(distance: Int, op: (Tile)->Unit) = tileMap.forEachTileAtDistance(position, distance, op)
     @Readonly fun forEachTileAtDistance(distance: Int, filter: (Tile)->Boolean, op: (Tile)->Unit) = tileMap.forEachTileAtDistance(position, distance, filter, op)
+    @Readonly fun countTilesAtDistance(distance: Int, predicate: (Tile)->Boolean) = tileMap.countTilesAtDistance(position, distance, predicate)
 
     @Readonly
     fun getDefensiveBonus(includeImprovementBonus: Boolean = true, unit: MapUnit? = null): Float {

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -56,10 +56,37 @@ interface IHasUniques : INamed {
     @Readonly
     fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit)
         = uniqueMap.forEachMatchingUnique(uniqueType, gameContext, op)
+    
+    /** Folds [accumulate] over every unique matching [uniqueType], starting from [initial]. Useful for e.g. summing up bonuses. */
+    @Readonly
+    fun <T> accumulateForEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, initial: T, accumulate: (T, Unique) -> T): T {
+        var acc = initial
+        forEachMatchingUnique(uniqueType, gameContext) { acc = accumulate(acc, it) }
+        return acc
+    }
+
+    @Readonly
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, filter:(Unique)->Boolean, predicate: (unique: Unique)->Boolean): Unique?
+        = uniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, filter, predicate)
+    @Readonly
+    fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, predicate: (unique: Unique)->Boolean): Unique?
+        = uniqueMap.firstMatchingUniqueOrNull(uniqueType, gameContext, predicate)
 
     @Readonly
     fun getMatchingTagUniques(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
         uniqueMap.getMatchingTagUniques(uniqueTag, state)
+
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueType], for cases that need to mutate
+     *  [uniques] (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly
+    fun getMatchingUniquesSnapshot(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
+        uniqueMap.getMatchingUniquesSnapshot(uniqueType, state)
+
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueTag], for cases that need to mutate
+     *  [uniques] (or otherwise cannot use a live view) while iterating the result. */
+    @Readonly
+    fun getMatchingTagUniquesSnapshot(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
+        uniqueMap.getMatchingTagUniquesSnapshot(uniqueTag, state)
 
     @Readonly
     fun hasUnique(uniqueType: UniqueType, state: GameContext? = null) =

--- a/core/src/com/unciv/models/ruleset/unique/TemporaryUnique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/TemporaryUnique.kt
@@ -42,10 +42,17 @@ fun ArrayList<TemporaryUnique>.getMatchingTagUniques(uniqueType: UniqueType, gam
 }
 
 @Readonly
-fun ArrayList<TemporaryUnique>.forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (unique: Unique)->Unit) {
+inline fun ArrayList<TemporaryUnique>.forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (unique: Unique)->Unit)
+    = firstMatchingUniqueOrNull(uniqueType, gameContext) { op(it); false }
+
+
+@Readonly
+inline fun ArrayList<TemporaryUnique>.firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (unique: Unique)->Boolean): Unique? {
     for (i in 0..<size) {
         val unique = get(i).uniqueObject
-        if (unique.type == uniqueType && unique.conditionalsApply(gameContext))
-            unique.forEachMultiplied(gameContext, op)
+        if (unique.type == uniqueType && unique.conditionalsApply(gameContext) && predicate(unique)) {
+            return unique
+        }
     }
+    return null
 }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -145,6 +145,16 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             op(this)
     }
 
+    /** Multiplies the unique according to the multiplication conditionals, returning this unique
+     *  as soon as [predicate] returns true for it, or null if it never does (or the multiplier is 0) */
+    @Readonly
+    inline fun firstMultipliedOrNull(gameContext: GameContext, predicate: (Unique)->Boolean): Unique? {
+        val multiplier = getUniqueMultiplier(gameContext)
+        for (j in 0..<multiplier)
+            if (predicate(this)) return this
+        return null
+    }
+
     private class EndlessSequenceOf<T>(private val value: T) : Sequence<T> {
         override fun iterator(): Iterator<T> = object : Iterator<T> {
             override fun next() = value

--- a/core/src/com/unciv/models/ruleset/unique/UniqueMap.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueMap.kt
@@ -4,12 +4,12 @@ import yairm210.purity.annotations.Readonly
 import java.util.*
 
 open class UniqueMap() {
-    private val tagUniqueMap = HashMap<String, ArrayList<Unique>>()
+    @PublishedApi internal val tagUniqueMap = HashMap<String, ArrayList<Unique>>()
 
     // *shares* the list of uniques with the other map, to save on memory and allocations
     // This is a memory/speed tradeoff, since there are *600 unique types*,
     // 750 including deprecated, and EnumMap creates a N-sized array where N is the number of objects in the enum
-    private val typedUniqueMap = EnumMap<UniqueType, ArrayList<Unique>>(UniqueType::class.java)
+    @PublishedApi internal val typedUniqueMap = EnumMap<UniqueType, ArrayList<Unique>>(UniqueType::class.java)
 
     constructor(uniques: Sequence<Unique>) : this() {
         addUniques(uniques.asIterable())
@@ -45,12 +45,12 @@ open class UniqueMap() {
     fun isEmpty(): Boolean = tagUniqueMap.isEmpty()
     
     @Readonly
-    fun hasUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
-        getUniques(uniqueType).any { it.conditionalsApply(state) && !it.isTimedTriggerable }
+    inline fun hasUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
+        firstUniqueOrNull(uniqueType) { it.conditionalsApply(state) && !it.isTimedTriggerable } != null
 
     @Readonly
-    fun hasUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
-        getTagUniques(uniqueTag).any { it.conditionalsApply(state) && !it.isTimedTriggerable }
+    inline fun hasUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
+        firstTagUniqueOrNull(uniqueTag) { it.conditionalsApply(state) && !it.isTimedTriggerable } != null
 
     @Readonly
     fun hasTagUnique(tagUnique: String) =
@@ -64,10 +64,15 @@ open class UniqueMap() {
         ?: emptySequence()
 
     @Readonly
-    fun forEachUnique(uniqueType: UniqueType, op: (Unique)->Unit) {
-        val uniques = typedUniqueMap[uniqueType] ?: return
+    inline fun forEachUnique(uniqueType: UniqueType, crossinline op: (Unique)->Unit)
+        = firstUniqueOrNull(uniqueType) { op(it); false }
+
+    @Readonly
+    inline fun firstUniqueOrNull(uniqueType: UniqueType, predicate: (Unique)->Boolean): Unique? {
+        val uniques = typedUniqueMap[uniqueType] ?: return null
         for (i in 0..< uniques.size)
-            op(uniques[i])
+            if (predicate(uniques[i])) return uniques[i]
+        return null
     }
 
     @Readonly
@@ -75,6 +80,18 @@ open class UniqueMap() {
     fun getTagUniques(uniqueTag: String) = tagUniqueMap[uniqueTag]
         ?.asSequence()
         ?: emptySequence()
+
+    @Readonly
+    inline fun forEachTagUnique(uniqueTag: String, crossinline op: (Unique)->Unit)
+        = firstTagUniqueOrNull(uniqueTag) { op(it); false }
+
+    @Readonly
+    inline fun firstTagUniqueOrNull(uniqueTag: String, predicate: (Unique)->Boolean): Unique? {
+        val uniques = tagUniqueMap[uniqueTag] ?: return null
+        for (i in 0..< uniques.size)
+            if (predicate(uniques[i])) return uniques[i]
+        return null
+    }
 
     @Readonly
     /** forEachMatchingUnique faster, for cases that require high perf */ 
@@ -89,13 +106,30 @@ open class UniqueMap() {
                 }
             }
 
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueType], for cases that need to mutate
+     *  this map (or otherwise cannot use a live view) while iterating the result. */
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, op: (Unique)->Unit)
+    fun getMatchingUniquesSnapshot(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachMatchingUnique(uniqueType, state) { list.add(it) }
+        return list
+    }
+
+    @Readonly
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline op: (Unique)->Unit)
         = forEachMatchingUnique(uniqueType, gameContext, NO_UNIQUE_FILTER, op)
     @Readonly
-    fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, filter:(Unique)->Boolean, op: (Unique)->Unit) {
-        val list = typedUniqueMap[uniqueType] ?: return
-        forEachMatchingUnique(list, gameContext, filter, op)
+    inline fun forEachMatchingUnique(uniqueType: UniqueType, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline op: (Unique)->Unit)
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, filter) { op(it); false }
+    
+
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline predicate: (Unique)->Boolean): Unique?
+        = firstMatchingUniqueOrNull(uniqueType, gameContext, NO_UNIQUE_FILTER, predicate)
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(uniqueType: UniqueType, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
+        val list = typedUniqueMap[uniqueType] ?: return null
+        return firstMatchingUniqueOrNull(list, gameContext, filter, predicate)
     }
 
     @Readonly
@@ -111,40 +145,72 @@ open class UniqueMap() {
                 }
             }
 
+    /** @return A freshly allocated [List] snapshot of the uniques matching [uniqueTag], for cases that need to mutate
+     *  this map (or otherwise cannot use a live view) while iterating the result. */
     @Readonly
-    fun forEachMatchingTagUnique(uniqueTag: String, gameContext: GameContext, filter:(Unique)->Boolean, op: (Unique)->Unit) {
-        val list = tagUniqueMap[uniqueTag] ?: return
-        forEachMatchingUnique(list, gameContext, filter, op)
+    fun getMatchingTagUniquesSnapshot(uniqueTag: String, state: GameContext = GameContext.EmptyState): List<Unique> {
+        val list = ArrayList<Unique>()
+        forEachMatchingTagUnique(uniqueTag, state, NO_UNIQUE_FILTER) { list.add(it) }
+        return list
     }
 
     @Readonly
-    fun forEachMatchingUnique(list: List<Unique>, gameContext: GameContext, filter:(Unique)->Boolean, op: (Unique)->Unit) {
+    inline fun forEachMatchingTagUnique(uniqueTag: String, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline op: (Unique)->Unit)
+        = firstMatchingTagUniqueOrNull(uniqueTag, gameContext, filter) { op(it); false }
+
+    @Readonly
+    inline fun firstMatchingTagUniqueOrNull(uniqueTag: String, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
+        val list = tagUniqueMap[uniqueTag] ?: return null
+        return firstMatchingUniqueOrNull(list, gameContext, filter, predicate)
+    }
+
+    @Readonly
+    inline fun forEachMatchingUnique(list: List<Unique>, gameContext: GameContext, crossinline filter:(Unique)->Boolean, crossinline op: (Unique)->Unit) {
+        firstMatchingUniqueOrNull(list, gameContext, filter) { op(it); false }
+    }
+
+    @Readonly
+    inline fun firstMatchingUniqueOrNull(list: List<Unique>, gameContext: GameContext, filter:(Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
         for (i in 0..<list.size) {
             val unique = list[i]
             if (unique.isTimedTriggerable) continue
             if (!filter(unique)) continue
             if (!unique.conditionalsApply(gameContext)) continue
-            unique.forEachMultiplied(gameContext, op)
-        }
+            // This seems like it shouldn't be needed, but actually is since it loops over *active* Uniques,
+            // so we need to call the predicate for each multiplied unique, not each base unique.
+            val result = unique.firstMultipliedOrNull(gameContext, predicate)
+            if (result != null) return result        }
+        return null
     }
     
     @Readonly
-    fun hasMatchingUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) = 
-        getUniques(uniqueType).any { it.conditionalsApply(state) }
+    inline fun hasMatchingUnique(uniqueType: UniqueType, state: GameContext = GameContext.EmptyState) =
+        firstUniqueOrNull(uniqueType) { it.conditionalsApply(state) } != null
 
     @Readonly
-    fun hasMatchingTagUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
-        getTagUniques(uniqueTag)
-            .any { it.conditionalsApply(state) }
+    inline fun hasMatchingTagUnique(uniqueTag: String, state: GameContext = GameContext.EmptyState) =
+        firstTagUniqueOrNull(uniqueTag) { it.conditionalsApply(state) } != null
 
     @Readonly
     fun getAllUniques() = tagUniqueMap.values.asSequence().flatten()
     
     @Readonly
     // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getLocalTriggeredUniques
-    fun forEachUnique(op: (Unique)->Unit) = getAllUniques().forEach(op)
+    inline fun forEachUnique(crossinline op: (Unique)->Unit) = getAllUniques().forEach(op)
     @Readonly
-    fun forEachUnique(filter: (Unique)->Boolean, op: (Unique)->Unit) = getAllUniques().filter(filter).forEach(op)
+    inline fun forEachUnique(filter: (Unique)->Boolean, crossinline op: (Unique)->Unit) {
+        firstUniqueOrNull(filter) { op(it); false }
+    }
+
+    @Readonly
+    // UniqueMap lacks a way to iterate over all Uniques without allocations, so this is not *dramatically* faster than getAllUniques
+    fun firstUniqueOrNull(predicate: (Unique)->Boolean): Unique? = getAllUniques().firstOrNull(predicate)
+    @Readonly
+    inline fun firstUniqueOrNull(filter: (Unique)->Boolean, crossinline predicate: (Unique)->Boolean): Unique? {
+        for (unique in getAllUniques())
+            if (filter(unique) && predicate(unique)) return unique
+        return null
+    }
 
     @Readonly
     fun getTriggeredUniques(trigger: UniqueType, gameContext: GameContext,
@@ -152,6 +218,26 @@ open class UniqueMap() {
         return typedUniqueMap.values.asSequence().flatten().filter { unique ->
             unique.getModifiers(trigger).any(triggerFilter) && unique.conditionalsApply(gameContext)
         }.flatMap { it.getMultiplied(gameContext) }
+    }
+
+    @Readonly
+    inline fun forEachTriggeredUnique(trigger: UniqueType, gameContext: GameContext,
+                               crossinline triggerFilter: (Unique) -> Boolean = { true }, crossinline op: (Unique)->Unit) {
+        firstTriggeredUniqueOrNull(trigger, gameContext, triggerFilter) { op(it); false }
+    }
+
+    @Readonly
+    inline fun firstTriggeredUniqueOrNull(trigger: UniqueType, gameContext: GameContext,
+                                    triggerFilter: (Unique) -> Boolean = { true }, crossinline predicate: (Unique)->Boolean): Unique? {
+        for (unique in typedUniqueMap.values.asSequence().flatten()) {
+            if (!unique.getModifiers(trigger).any(triggerFilter) || !unique.conditionalsApply(gameContext))
+                continue
+            // This seems like it shouldn't be needed, but actually is since it loops over *active* Uniques,
+            // so we need to call the predicate for each multiplied unique, not each base unique.
+            val result = unique.firstMultipliedOrNull(gameContext, predicate)
+            if (result != null) return result
+        }
+        return null
     }
     
     companion object{


### PR DESCRIPTION
Replacing deprecated getTiles and getUnique calls in automation

This is part of a chain of PRs to clean up the methods for Automation, Battle, City, Civilization, MapGen, MapUnit, Models, and Ui. Total GameInfo.nextTurn performance improvement is 14.95% faster (https://docs.google.com/spreadsheets/d/1tjm7_uvMxiQmyOnWzM2lvqY2B5m29FfrVzjx3RflU1E/edit?gid=703144985#gid=703144985)

Signed-off-by: Ambeco <mooing_psycho_duck@yahoo.com>