### PR TITLE
AI should not see unexplored tiles for tile value

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -40,13 +40,22 @@ object CityLocationTileRanker {
         val possibleCityLocations = unit.getTile().getTilesInDistance(range)
             // Filter out tiles that we can't actually found on
             .filter { tile -> uniques.any { it.conditionalsApply(GameContext(unit = unit, tile = tile)) } }
+            .filter { unit.civ.hasExplored(it) }
             .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.getTile() == it || unit.movement.canMoveTo(it)) }
         val bestTilesToFoundCity = BestTilesToFoundCity()
         val baseTileMap = HashMap<Tile, Float>()
 
+        // Assume unexplored tiles are worth the average of the explored tiles around us
+        var unexploredTilePrior = 0f
+        val throwawayLuxuries = HashSet<TileResource>()
+        for (tile in unit.getTile().getTilesInDistance(range + 2))
+            // onCoast doesn't matter here, it does not change baseTileMap
+            if (unit.civ.hasExplored(tile)) rankTile(tile, unit.civ, false, throwawayLuxuries, baseTileMap, 0f)
+        if (baseTileMap.isNotEmpty()) unexploredTilePrior = baseTileMap.values.average().toFloat()
+
         val possibleTileLocationsWithRank = possibleCityLocations
             .map {
-                var tileValue = rankTileToSettle(it, unit.civ, nearbyCities, baseTileMap)
+                var tileValue = rankTileToSettle(it, unit.civ, nearbyCities, baseTileMap, unexploredTilePrior)
                 val distanceScore = (unit.currentTile.aerialDistanceTo(it) * distanceModifier).coerceIn(0f, 99f)
                 tileValue *= (100 - distanceScore) / 100
                 if (tileValue >= minimumValue)
@@ -92,7 +101,7 @@ object CityLocationTileRanker {
     }
 
     private fun rankTileToSettle(newCityTile: Tile, civ: Civilization, nearbyCities: Sequence<City>,
-                                 baseTileMap: HashMap<Tile, Float>): Float {
+                                 baseTileMap: HashMap<Tile, Float>, unexploredTilePrior: Float = 0f): Float {
         var tileValue = 0f
         tileValue += getDistanceToCityModifier(newCityTile, nearbyCities, civ)
 
@@ -132,7 +141,7 @@ object CityLocationTileRanker {
             //Ideally, we shouldn't really count the center tile, as it's converted into 1 production 2 food anyways with special cases treated above, but doing so can lead to AI moving settler back and forth until forever
             for (nearbyTile in newCityTile.getTilesAtDistance(i)) {
                 tiles++
-                tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap) * (3f / (i + 1))
+                tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap, unexploredTilePrior) * (3f / (i + 1))
                 //Tiles close to the city can be worked more quickly, and thus should gain higher weight.
             }
         }
@@ -171,7 +180,9 @@ object CityLocationTileRanker {
     }
 
     private fun rankTile(rankTile: Tile, civ: Civilization, onCoast: Boolean, newUniqueLuxuryResources: HashSet<TileResource>,
-                         baseTileMap: HashMap<Tile, Float>): Float {
+                         baseTileMap: HashMap<Tile, Float>, unexploredTilePrior: Float = 0f): Float {
+        // Unexplored tiles are unknown - estimate them as an average tile instead of reading the actual map
+        if (!civ.hasExplored(rankTile)) return unexploredTilePrior
         if (rankTile.getCity() != null) return -1f
         var locationSpecificTileValue = 0f
         // Don't settle near but not on the coast

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -46,12 +46,11 @@ object CityLocationTileRanker {
         val baseTileMap = HashMap<Tile, Float>()
 
         // Assume unexplored tiles are worth the average of the explored tiles around us
-        var unexploredTilePrior = 0f
         val throwawayLuxuries = HashSet<TileResource>()
         for (tile in unit.getTile().getTilesInDistance(range + 2))
             // onCoast doesn't matter here, it does not change baseTileMap
             if (unit.civ.hasExplored(tile)) rankTile(tile, unit.civ, false, throwawayLuxuries, baseTileMap, 0f)
-        if (baseTileMap.isNotEmpty()) unexploredTilePrior = baseTileMap.values.average().toFloat()
+        val unexploredTilePrior = if (baseTileMap.isEmpty()) 0f else baseTileMap.values.average().toFloat()
 
         val possibleTileLocationsWithRank = possibleCityLocations
             .map {

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -12,6 +12,7 @@ import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.utils.DebugUtils
 import yairm210.purity.annotations.Readonly
 
 object CityLocationTileRanker {
@@ -60,6 +61,9 @@ object CityLocationTileRanker {
             bestTilesToFoundCity.bestTile = bestReachableTile.first
             bestTilesToFoundCity.bestTileRank = bestReachableTile.second
         }
+
+        if (DebugUtils.SHOW_SETTLER_SCORES)
+            DebugUtils.SETTLER_SCORES = bestTilesToFoundCity.tileRankMap.entries.associate { it.key.position to it.value }
 
         return bestTilesToFoundCity
     }

--- a/core/src/com/unciv/ui/components/tilegroups/layers/TileLayerMisc.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/layers/TileLayerMisc.kt
@@ -26,6 +26,7 @@ import com.unciv.utils.DebugUtils
 import kotlin.math.atan2
 import kotlin.math.min
 import kotlin.math.pow
+import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
 private class MapArrow(val targetTile: Tile, val arrowType: MapArrowType, val strings: TileSetStrings) {
@@ -351,6 +352,22 @@ class TileLayerMisc(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup, si
             })
         }
 
+        if (DebugUtils.SHOW_SETTLER_SCORES) {
+            val score = DebugUtils.SETTLER_SCORES[tileGroup.tileView.position()]
+            if (score != null) {
+                val label = score.roundToInt().toString()
+                val tileW = tileGroup.width
+                val tileH = tileGroup.height
+                startingLocationIcons.add(label.toLabel(Color.GOLD, 14).apply {
+                    touchable = Touchable.disabled
+                    setOrigin(Align.center)
+                    x = tileX + (tileW - width) / 2 + 15f
+                    y = tileY + (tileH - height) / 2
+                    tileGroup.layerMisc.addOwnedActor(this)
+                })
+            }
+        }
+
         val tilemap = tile.tileMap
 
         if (tilemap.startingLocationsByNation.isEmpty())
@@ -477,7 +494,7 @@ class TileLayerMisc(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup, si
 
 
     override fun doUpdate(viewingCiv: CivView?) {
-        if (tileGroup !is WorldTileGroup || DebugUtils.SHOW_TILE_COORDS)
+        if (tileGroup !is WorldTileGroup || DebugUtils.SHOW_TILE_COORDS || DebugUtils.SHOW_SETTLER_SCORES)
             updateStartingLocationIcon(true)
         updateArrows()
     }

--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -31,6 +31,7 @@ internal class DebugTab(
         addCheckbox("Supercharged", DebugUtils::SUPERCHARGED)
         addCheckbox("View entire map", DebugUtils::VISIBLE_MAP, updateWorld = true)
         addCheckbox("Show coordinates on tiles", DebugUtils::SHOW_TILE_COORDS, updateWorld = true)
+        addCheckbox("Show settler scores on tiles", DebugUtils::SHOW_SETTLER_SCORES, updateWorld = true)
         addCheckbox("Show tile image locations", DebugUtils::SHOW_TILE_IMAGE_LOCATIONS, updateWorld = true)
 
         val curGameInfo = game.gameInfo

--- a/core/src/com/unciv/utils/DebugUtils.kt
+++ b/core/src/com/unciv/utils/DebugUtils.kt
@@ -1,5 +1,7 @@
 package com.unciv.utils
 
+import com.unciv.logic.map.HexCoord
+
 object DebugUtils {
 
     /**
@@ -13,6 +15,12 @@ object DebugUtils {
     var SHOW_TILE_COORDS: Boolean = false
     
     var SHOW_TILE_IMAGE_LOCATIONS: Boolean = false
+
+    /** This flag paints the last computed settler tile ranking onto the map tiles. */
+    var SHOW_SETTLER_SCORES: Boolean = false
+
+    /** Last settler tile ranking computed by CityLocationTileRanker, for [SHOW_SETTLER_SCORES]. */
+    var SETTLER_SCORES: Map<HexCoord, Float> = emptyMap()
 
     /** For when you need to test something in an advanced game and don't have time to faff around */
     var SUPERCHARGED: Boolean = false


### PR DESCRIPTION
For settler logic, when AI ranks tiles to decide where to settle, it uses the information in unexplored tiles which should not be available. This PR blocks that, and assigns average tile value to unexplored tiles.

Simulation with 1600 games, 2 players, Tiny, King: 50.9% win rate (p=0.2266), so it doesn't meaningfully hurt AI performance either (the slight win is probably just luck).

Also, the first commit adds a debug option to show settler scores, which works basically the same as 'show coordinates' but with the latest settler scores (check screenshots below). I found this very useful, and I think it would be a nice tool for future development, as I believe better settling is perhaps the most important knob for improving AI performance.

Before: 
(the scores don't change with exploration, since it uses all tile information anyway)
<img width="960" height="516" alt="before-1" src="https://github.com/user-attachments/assets/8cb909a8-31a9-49ff-8551-f2e0c801e090" />
<img width="960" height="516" alt="before-2" src="https://github.com/user-attachments/assets/0df56d4d-10e2-4b4a-af31-a7e7f977f97c" />

After:
(relevant tile scores change with exploration)
<img width="960" height="516" alt="after-1" src="https://github.com/user-attachments/assets/16cb9287-868e-49d4-8dd3-e900799a95ac" />
<img width="960" height="516" alt="after-2" src="https://github.com/user-attachments/assets/c260074f-547f-4a11-9d0d-d738562d17a3" />
