### PR TITLE
chore: Fix global policy diagram click to open legend intercepted by lines

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
@@ -214,6 +214,7 @@ class GlobalPoliticsDiagramGroup(
                 width = lineWidth
             )
             statusLine.color = relation.color
+            statusLine.touchable = Touchable.disabled
             val entry = WidgetEntry.Line(statusLine, relation, civ, otherCiv)
             hasLines += civ
             hasLines += otherCiv


### PR DESCRIPTION
Felt like an intermittent, random problem, so worth fixing