### PR TITLE
Timers report when app is paused

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -6,6 +6,7 @@ import com.unciv.UncivGame.Companion.isCurrentInitialized
 import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.Version
+import com.unciv.logic.automation.Timers
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.logic.files.UncivFiles
 import com.unciv.logic.multiplayer.Multiplayer
@@ -402,6 +403,7 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         val curGameInfo = gameInfo
         // Since we're pausing the game, we don't need to clone it before autosave - no one else will touch it
         if (curGameInfo != null) files.autosaves.requestAutoSaveUnCloned(curGameInfo)
+        Timers.singleton.endTiming()
         super.pause()
     }
 
@@ -440,7 +442,7 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         // DO NOT `exitProcess(0)` - bypasses all Gdx and GLFW cleanup
     }
 
-    private fun logRunningThreads() {
+private fun logRunningThreads() {
         val numThreads = Thread.activeCount()
         val threadList = Array(numThreads) { Thread() }
         Thread.enumerate(threadList)


### PR DESCRIPTION
When switching apps, phone goes to sleep, etc. This prevents it from accidentally including sleep time.  I kept trying to time for longer durations, but the phone screen kept sleeping after 30m, which threw off the times.