### PR TITLE
AI: pick the best tech and unit type instead of sampling randomly among weighted candidates

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -198,7 +198,6 @@ object Automation {
 
     @Readonly
     fun chooseMilitaryUnit(city: City, availableUnits: Sequence<BaseUnit>): BaseUnit? {
-        val rng = city.state.stateBasedRandom("Automation.chooseMilitaryUnit")
         val currentChoice = city.cityConstructions.getCurrentConstruction()
         if (currentChoice is BaseUnit && !currentChoice.isCivilian()) return currentChoice
 
@@ -257,16 +256,16 @@ object Automation {
                 .filter { isNavalMeleeUnit(it) }
                 .maxBy { it.cost }
         }
-        else { // randomize type of unit and take the most expensive of its kind
+        else { // take the strongest unit type we can build, best version of its kind
             val bestUnitsForType = hashMapOf<String, BaseUnit>()
             for (unit in militaryUnits) {
                 if (bestUnitsForType[unit.unitType] == null || bestUnitsForType[unit.unitType]!!.cost < unit.cost) {
                     bestUnitsForType[unit.unitType] = unit
                 }
             }
-            // Check the maximum force evaluation for the shortlist so we can prune useless ones (ie scouts)
             val bestForce = bestUnitsForType.maxOfOrNull { it.value.getForceEvaluation() } ?: return null
-            chosenUnit = bestUnitsForType.filterValues { it.uniqueTo != null || it.getForceEvaluation() > bestForce / 3 }.values.random(rng)
+            chosenUnit = bestUnitsForType.filterValues { it.uniqueTo != null || it.getForceEvaluation() > bestForce / 3 }
+                .values.maxBy { it.getForceEvaluation() }
         }
         return chosenUnit
     }

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -240,8 +240,6 @@ object NextTurnAutomation {
     }
 
     private fun chooseTechToResearch(civInfo: Civilization) {
-        val rng = civInfo.state.stateBasedRandom("NextTurnAutomation.chooseTechToResearch")
-
         @Readonly
         fun getGroupedResearchableTechs(): List<List<Technology>> {
             val researchableTechs = civInfo.gameInfo.ruleset.technologies.values
@@ -260,7 +258,7 @@ object NextTurnAutomation {
                 // Ignore rows where all techs have 0 weight
                 it.any { it.getWeightForAiDecision(stateForConditionals) > 0 }
             } ?: costs.last()
-            val chosenTech = mostExpensiveTechs.randomWeighted(rng) { it.getWeightForAiDecision(stateForConditionals) }
+            val chosenTech = mostExpensiveTechs.maxBy { it.getWeightForAiDecision(stateForConditionals) }
             civInfo.tech.getFreeTechnology(chosenTech.name)
         }
         if (civInfo.tech.techsToResearch.isEmpty()) {
@@ -273,11 +271,11 @@ object NextTurnAutomation {
             //Do not consider advanced techs if only one tech left in cheapest group
             val techToResearch: Technology =
                 if (cheapestTechs.size == 1 || costs.size == 1) {
-                    cheapestTechs.randomWeighted(rng) { it.getWeightForAiDecision(stateForConditionals) }
+                    cheapestTechs.maxBy { it.getWeightForAiDecision(stateForConditionals) }
                 } else {
-                    //Choose randomly between cheapest and second cheapest group
+                    //Consider both the cheapest and second cheapest group
                     val techsAdvanced = costs[1]
-                    (cheapestTechs + techsAdvanced).randomWeighted(rng) { it.getWeightForAiDecision(stateForConditionals) }
+                    (cheapestTechs + techsAdvanced).maxBy { it.getWeightForAiDecision(stateForConditionals) }
                 }
 
             civInfo.tech.techsToResearch.add(techToResearch.name)


### PR DESCRIPTION
## What

Two decision points where the AI already computes scores for its options and then randomizes among them instead of taking the best:

1. **Tech choice** (`NextTurnAutomation`): `randomWeighted` over `getWeightForAiDecision` → take the argmax.
2. **Military unit type** (`Automation.chooseMilitaryUnit`): uniform-random draw over all types above the force floor → take the strongest eligible type.

## Measured effect

Paired-seed A/B (the change applied to one civ vs three stock civs), fresh seeds throughout:

- **+6.1pp win rate, 14/16 fresh seeds, p=0.001** (pooled across two independent seed families, measured on current master)
- Effect **grows with player count** (+0.7pp in duels → +11.2pp at 8 civs — a tech/composition edge needs third parties to convert against) and is **difficulty-invariant** (Prince/King/Emperor all positive on identical seeds)
- Strongest with city-states in play: +12.6pp, t=6.9

## A caveat we want to flag honestly

**We don't know whether the randomization was intentional** — e.g. to make AI civs play more diversely. If variety is the design goal, there's a middle path with data behind it: restricting the random draw to the **top 2** candidates keeps most of the win (+4.9pp) while preserving some variety (top-3: +3.3pp; full argmax: +11.0pp in that experiment). Happy to rework the PR to top-K if that fits the project's intent better.

More context on the surrounding investigation: https://github.com/WhoIsJohannes/unciv-lab-findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)