### PR TITLE
Crude blocklist for malicious mod authors

### DIFF
--- a/android/assets/ExcludedModAuthors.txt
+++ b/android/assets/ExcludedModAuthors.txt
@@ -1,0 +1,1 @@
+ExecutorSignify

--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -34,6 +34,7 @@ private const val MULTIPLAYER_FILES_FOLDER = "MultiplayerGames"
 private const val AUTOSAVE_FILE_NAME = "Autosave"
 const val SETTINGS_FILE_NAME = "GameSettings.json"
 const val MOD_LIST_CACHE_FILE_NAME = "ModListCache.json"
+const val EXCLUDED_MOD_AUTHORS_FILE_NAME = "ExcludedModAuthors.txt"
 
 class UncivFiles(
     /**
@@ -363,6 +364,17 @@ class UncivFiles(
         }
         catch (ex: Exception){ // Not a huge deal if this fails
             Log.error("Error loading mod cache", ex)
+            return emptyList()
+        }
+    }
+    
+    fun loadExcludedModAuthors(): Iterable<String> {
+        val file = getLocalFile(EXCLUDED_MOD_AUTHORS_FILE_NAME)
+        if (!file.exists()) return emptyList()
+        try {
+            return file.reader().readLines()
+        } catch (ex: Exception) {
+            Log.error("Error loading mod author exclusion list", ex)
             return emptyList()
         }
     }

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -124,6 +124,7 @@ class ModManagementScreen private constructor(
     // Keep metadata and buttons in separate pools
     private val installedModInfo = previousInstalledMods ?: HashMap(RulesetCache.size)
     private val onlineModInfo = previousOnlineMods ?: game.files.loadModCache().associateByTo(HashMap()) { it.name }
+    private val excludedModAuthors = game.files.loadExcludedModAuthors()
     private val modButtons: HashMap<ModUIData, ModDecoratedButton> = HashMap(100)
 
     // cleanup - background processing needs to be stopped on exit and memory freed
@@ -346,7 +347,7 @@ class ModManagementScreen private constructor(
             val mod = ModUIData(repo, isUpdatedVersionOfInstalledMod)
             onlineModInfo[repo.name] = mod
             modButtons.remove(mod) // Remove *cached* mod button since we have NEW DATA
-            if (mod.matchesFilter(optionsManager.getFilter())) {
+            if (mod.matchesFilter(optionsManager.getFilter()) && mod.author() !in excludedModAuthors) {
                 onlineModsTable.add(getCachedModButton(mod)).row()
             }
         }
@@ -729,7 +730,7 @@ class ModManagementScreen private constructor(
         // We update y and height here, we do not replace the ModUIData instances do the referenced buttons stay valid.
         val sortedMods = onlineModInfo.values.asSequence().sortedWith(optionsManager.sortOnline.comparator)
         for (mod in sortedMods) {
-            if (!mod.matchesFilter(filter)) continue
+            if (!mod.matchesFilter(filter) || mod.author() in excludedModAuthors) continue
             onlineModsTable.add(getCachedModButton(mod)).row()
         }
 


### PR DESCRIPTION
Currently the highest starred mod has a readme that contains links to likely malware.

Before:
<img width="1980" height="1081" alt="image" src="https://github.com/user-attachments/assets/d6dbab2a-2aaf-438e-aaf3-6abc58aee77d" />

After:
<img width="1980" height="1081" alt="image" src="https://github.com/user-attachments/assets/7a706b85-b499-4bdd-a726-98c12a72cb19" />

It only excludes entries from the online mod list. It does not delete installed mods or similar.

Future work:
1. Better blocklist implementation
2. Automatically exclude mods that do not contain any relevant mod files