### PR TITLE
chore: Fix string interning serializer

### DIFF
--- a/core/src/com/unciv/json/UncivJson.kt
+++ b/core/src/com/unciv/json/UncivJson.kt
@@ -25,7 +25,7 @@ fun json() = Json(JsonWriter.OutputType.json).apply {
     setSerializer(Duration::class.java, DurationSerializer())
     setSerializer(KeyCharAndCode::class.java, KeyCharAndCode.Serializer())
     setSerializer(HexCoord::class.java, HexCoord.Serializer())
-    //setSerializer(String::class.java, StringInterningSerializer())
+    setSerializer(String::class.java, StringInterningSerializer())
 }
 
 /**

--- a/core/src/com/unciv/json/UncivJson.kt
+++ b/core/src/com/unciv/json/UncivJson.kt
@@ -56,7 +56,9 @@ fun <T> Json.fromJsonFile(tClass: Class<T>, file: FileHandle): T {
 private class StringInterningSerializer : Json.Serializer<String> {
     override fun write(json: Json, key: String, knownType: Class<*>?) = json.writeValue(key as Any?, String::class.java, null)
 
-    override fun read(json: Json, jsonData: JsonValue, type: Class<*>?): String
-    = if (jsonData.type() == JsonValue.ValueType.`object`) (json.readValue("value", type, jsonData) as String)
-        else jsonData.asString().intern()
+    override fun read(json: Json, jsonData: JsonValue, type: Class<*>?) = when {
+        jsonData.isNull -> null
+        jsonData.type() == JsonValue.ValueType.`object` -> json.readValue("value", type, jsonData) as String
+        else -> jsonData.asString().intern()
+    }
 }


### PR DESCRIPTION
Copy of comment on revert commit:
In hindsight, it's obvious: Java doesn't distinguish nullable or not in its class system, so `StringInterningSerializer` is applied to `String?` as well, isn't built to handle null, and fails on the tileset config `"fallbackTileSet": null,` lines