### PR TITLE
Add experiment group for AI simulation

### DIFF
--- a/core/src/com/unciv/logic/simulation/Simulation.kt
+++ b/core/src/com/unciv/logic/simulation/Simulation.kt
@@ -25,7 +25,7 @@ class Simulation(
     private val threadsNumber: Int = 1,
     private val maxTurns: Int = 500,
     private val statTurns: List<Int> = listOf(),
-    private val experimentGroup: Set<String> = emptySet()
+    private val civIdsInExperimentGroup: Set<String> = emptySet()
 ) {
     private val maxSimulations = threadsNumber * simulationsPerThread
     private val majorCivs = newGameInfo.civilizations.filter { !it.isSpectator() && it.isMajorCiv() }.map { it.civID }
@@ -55,7 +55,7 @@ class Simulation(
     private val printAvgCityPop = false
 
     init{
-        DebugUtils.EXPERIMENT_GROUP = experimentGroup
+        DebugUtils.CIV_IDS_IN_EXPERIMENT_GROUP = civIdsInExperimentGroup
         for (civ in majorCivs) {
             this.numWins[civ] = MutableInt(0)
             winRateByVictory[civ] = mutableMapOf()
@@ -252,9 +252,9 @@ class Simulation(
 
     fun text(): String {
         var outString = ""
-        if (experimentGroup.isNotEmpty()) {
-            outString += groupText("Experiment group", majorCivs.filter { it in experimentGroup })
-            outString += groupText("Control group", majorCivs.filter { it !in experimentGroup })
+        if (civIdsInExperimentGroup.isNotEmpty()) {
+            outString += groupText("Experiment group", majorCivs.filter { it in civIdsInExperimentGroup })
+            outString += groupText("Control group", majorCivs.filter { it !in civIdsInExperimentGroup })
         }
         for (civ in majorCivs) {
 

--- a/core/src/com/unciv/logic/simulation/Simulation.kt
+++ b/core/src/com/unciv/logic/simulation/Simulation.kt
@@ -6,6 +6,7 @@ import com.unciv.logic.GameInfo
 import com.unciv.logic.GameStarter
 import com.unciv.logic.automation.Timers
 import com.unciv.models.metadata.GameSetupInfo
+import com.unciv.utils.DebugUtils
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.joinAll
@@ -23,7 +24,8 @@ class Simulation(
     val simulationsPerThread: Int = 1,
     private val threadsNumber: Int = 1,
     private val maxTurns: Int = 500,
-    private val statTurns: List<Int> = listOf()
+    private val statTurns: List<Int> = listOf(),
+    private val experimentGroup: Set<String> = emptySet()
 ) {
     private val maxSimulations = threadsNumber * simulationsPerThread
     private val majorCivs = newGameInfo.civilizations.filter { !it.isSpectator() && it.isMajorCiv() }.map { it.civID }
@@ -53,6 +55,7 @@ class Simulation(
     private val printAvgCityPop = false
 
     init{
+        DebugUtils.EXPERIMENT_GROUP = experimentGroup
         for (civ in majorCivs) {
             this.numWins[civ] = MutableInt(0)
             winRateByVictory[civ] = mutableMapOf()
@@ -224,8 +227,35 @@ class Simulation(
         return "@$turnStr: $statStr avg=${summaryStats[Stat.SUM]!!.value.toFloat() / summaryStats[Stat.NUM]!!.value.toFloat()} cnt=${summaryStats[Stat.NUM]!!.value}\n"
     }
 
+    /** Win rate and p-value for the group as a whole */
+    private fun groupText(groupName: String, groupCivs: List<String>): String {
+        if (groupCivs.isEmpty()) return ""
+        val numSteps = max(steps.size, 1)
+        val groupWins = groupCivs.sumOf { numWins[it]!!.value }
+        val expWinRate = groupCivs.size.toFloat() / numMajorCivs
+        val winRate = String.format("%.1f", groupWins * 100f / numSteps)
+        val expected = String.format("%.1f", expWinRate * 100f)
+
+        var outString = "\n$groupName (${groupCivs.joinToString()}):\n"
+        outString += "$winRate% total win rate (expected $expected% if no effect)\n"
+        if (numSteps * expWinRate >= 10 && numSteps * (1 - expWinRate) >= 10) {
+            val pval = binomialTest(groupWins.toDouble(), numSteps.toDouble(), expWinRate.toDouble(), "greater")
+            outString += "one-tail binomial pval = $pval\n"
+        }
+        for (victory in UncivGame.Current.gameInfo!!.ruleset.victories.keys) {
+            val winsVictory = groupCivs.sumOf { winRateByVictory[it]!![victory]!!.value } * 100 / max(groupWins, 1)
+            outString += "$victory: $winsVictory%    "
+        }
+        outString += "\n"
+        return outString
+    }
+
     fun text(): String {
         var outString = ""
+        if (experimentGroup.isNotEmpty()) {
+            outString += groupText("Experiment group", majorCivs.filter { it in experimentGroup })
+            outString += groupText("Control group", majorCivs.filter { it !in experimentGroup })
+        }
         for (civ in majorCivs) {
 
             val numSteps = max(steps.size, 1)

--- a/core/src/com/unciv/utils/DebugUtils.kt
+++ b/core/src/com/unciv/utils/DebugUtils.kt
@@ -23,9 +23,9 @@ object DebugUtils {
      */
     var SIMULATE_UNTIL_TURN: Int = 0
 
-    /** Civs (by civID) running experimental AI code in a simulation, so a change can be A/B tested against the unchanged AI.
-     *  Gate experimental code with `if (civInfo.civID in DebugUtils.EXPERIMENT_GROUP)`; the simulation reports the group's win rate.
+    /** For A/B testing against the unchanged AI.
+     *  Gate experimental code with `if (civInfo.civID in DebugUtils.CIV_IDS_IN_EXPERIMENT_GROUP)`.
      */
-    var EXPERIMENT_GROUP: Set<String> = emptySet()
+    var CIV_IDS_IN_EXPERIMENT_GROUP: Set<String> = emptySet()
 
 }

--- a/core/src/com/unciv/utils/DebugUtils.kt
+++ b/core/src/com/unciv/utils/DebugUtils.kt
@@ -23,4 +23,9 @@ object DebugUtils {
      */
     var SIMULATE_UNTIL_TURN: Int = 0
 
+    /** Civs (by civID) running experimental AI code in a simulation, so a change can be A/B tested against the unchanged AI.
+     *  Gate experimental code with `if (civInfo.civID in DebugUtils.EXPERIMENT_GROUP)`; the simulation reports the group's win rate.
+     */
+    var EXPERIMENT_GROUP: Set<String> = emptySet()
+
 }

--- a/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
@@ -60,8 +60,16 @@ internal object ConsoleLauncher {
         newGame.gameParameters.victoryTypes = ArrayList(newGame.ruleset.victories.keys)
         UncivGame.Current.gameInfo = newGame
 
-
-        val simulation = Simulation(newGame, 500, 8)
+        // Use in AI logic as:
+        //
+        // import com.unciv.utils.DebugUtils
+        // if (civInfo.civID in DebugUtils.EXPERIMENT_GROUP) {
+        // ...
+        // }
+        //
+        // Pass an empty set (default) to disable the feature
+        val experimentGroup = setOf(simulationCiv1)
+        val simulation = Simulation(newGame, 500, 8, experimentGroup=experimentGroup)
         //Unless the effect size is very large, you'll typically need a large number of games to get a statistically significant result
 
         simulation.start()

--- a/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
@@ -60,16 +60,7 @@ internal object ConsoleLauncher {
         newGame.gameParameters.victoryTypes = ArrayList(newGame.ruleset.victories.keys)
         UncivGame.Current.gameInfo = newGame
 
-        // Use in AI logic as:
-        //
-        // import com.unciv.utils.DebugUtils
-        // if (civInfo.civID in DebugUtils.EXPERIMENT_GROUP) {
-        // ...
-        // }
-        //
-        // Pass an empty set (default) to disable the feature
-        val experimentGroup = setOf(simulationCiv1)
-        val simulation = Simulation(newGame, 500, 8, experimentGroup=experimentGroup)
+        val simulation = Simulation(newGame, 500, 8)
         //Unless the effect size is very large, you'll typically need a large number of games to get a statistically significant result
 
         simulation.start()

--- a/docs/Developers/Testing-AI-changes.md
+++ b/docs/Developers/Testing-AI-changes.md
@@ -19,7 +19,7 @@ Within the `desktop\src\ConsoleLauncher.kt` file, you can adjust the number of s
 
 Recommend using generic civs with no Uniques. You can see the code add a generic `Nation` to the `ruleset` object.
 
-To A/B test an AI change, pass the civs that should use the new behavior as the `experimentGroup` parameter of `Simulation`, e.g. `Simulation(newGame, 50, 8, experimentGroup = setOf("Nation1", "Nation2"))`, and gate the changed code with `if (civInfo.civID in DebugUtils.EXPERIMENT_GROUP)`. You can also run more complicated experiments (e.g. three different AI behaviors) by using the Nation Name constant as the control switch.
+To A/B test an AI change, pass the civs that should use the new behavior as the `civIdsInExperimentGroup` parameter of `Simulation`, e.g. `Simulation(newGame, 50, 8, civIdsInExperimentGroup = setOf("Nation1", "Nation2"))`, and gate the changed code with `if (civInfo.civID in DebugUtils.CIV_IDS_IN_EXPERIMENT_GROUP)`. You can also run more complicated experiments (e.g. three different AI behaviors) by using the Nation Name constant as the control switch.
 
 You can also adjust the game parameters and map parameters. To get more consistent results, turning off Natural Wonders and Barbarians can help.
 
@@ -35,4 +35,4 @@ It is a good habit to validate your expectations for which Civ would win, how th
 
 The p-value is also reported, showing based on the winrate how likely this result is in a binomial test. If this value is very small, then there is a low chance this arose out of random chance and that your changes made a statistically significant change in the overall winrate. Running 200-400 Sims is usually a good baseline point.
 
-When an `experimentGroup` is set, the report starts with the combined win rate and p-value of the experiment group and of the control group (all other civs).
+When `civIdsInExperimentGroup` is set, the report starts with the combined win rate and p-value of the experiment group and of the control group (all other civs).

--- a/docs/Developers/Testing-AI-changes.md
+++ b/docs/Developers/Testing-AI-changes.md
@@ -17,7 +17,9 @@ Execute the ConsoleLauncher Build Configuration set up above. Results should app
 
 Within the `desktop\src\ConsoleLauncher.kt` file, you can adjust the number of simulations to run, which nations to use, etc.
 
-Recommend using generic civs with no Uniques. You can see the code add a generic `Nation` to the `ruleset` object, and you can key different behavior throughout the code using the Nation Name constant as the control switch.
+Recommend using generic civs with no Uniques. You can see the code add a generic `Nation` to the `ruleset` object.
+
+To A/B test an AI change, pass the civs that should use the new behavior as the `experimentGroup` parameter of `Simulation`, e.g. `Simulation(newGame, 50, 8, experimentGroup = setOf("Nation1", "Nation2"))`, and gate the changed code with `if (civInfo.civID in DebugUtils.EXPERIMENT_GROUP)`. You can also run more complicated experiments (e.g. three different AI behaviors) by using the Nation Name constant as the control switch.
 
 You can also adjust the game parameters and map parameters. To get more consistent results, turning off Natural Wonders and Barbarians can help.
 
@@ -32,3 +34,5 @@ By default the console will report the number of wins per civ, type of win, and 
 It is a good habit to validate your expectations for which Civ would win, how they would win, and any changes in the reported values. Some changes won't show up in the win rates, so are better tested by making a scenario in the Map Editor or with the in-game Console then testing the AI behaviors.
 
 The p-value is also reported, showing based on the winrate how likely this result is in a binomial test. If this value is very small, then there is a low chance this arose out of random chance and that your changes made a statistically significant change in the overall winrate. Running 200-400 Sims is usually a good baseline point.
+
+When an `experimentGroup` is set, the report starts with the combined win rate and p-value of the experiment group and of the control group (all other civs).


### PR DESCRIPTION
Current AI simulation only reports p-value and stats for individual nations, but for larger scale tests we often want to apply the change to multiple nations, either for statistical efficiency or to test the interaction of the new strategy with itself.

This PR allows explicitly designating a set of nations as the experiment group, and prints the stats for experiment/control group. Also, it allows much cleaner gating in AI logic as below.

It can be disabled simply by not passing the `experimentGroup` parameter to `Simulation`.

ConsoleLauncher.kt:
```
val experimentGroup = setOf(simulationCiv1, simulationCiv2)
val simulation = Simulation(newGame, 500, 8, experimentGroup=experimentGroup)
```

In AI logic:
```
import com.unciv.utils.DebugUtils

if (civInfo.civID in DebugUtils.EXPERIMENT_GROUP) {
...
}
```

Example log:
```
nation4 won Scientific victory on turn 213
Simulation step (64/4000)

Experiment group (nation1, nation2):
35.9% total win rate (expected 50.0% if no effect)
one-tail binomial pval = 0.9877755284191692
Scientific: 86%    Cultural: 0%    Domination: 13%    Diplomatic: 0%    Time: 0%    

Control group (nation3, nation4):
64.1% total win rate (expected 50.0% if no effect)
one-tail binomial pval = 0.012224471580830842
Scientific: 78%    Cultural: 0%    Domination: 21%    Diplomatic: 0%    Time: 0%    

nation1:
20.3% total win rate 
one-tail binomial pval = 0.8067618844248277
Scientific: 100%    Cultural: 0%    Domination: 0%    Diplomatic: 0%    Time: 0%    
Scientific: 228    Cultural: 0    Domination: 0    Diplomatic: 0    Time: 0    avg turns
@END: popSum avg=64.53125 cnt=64

nation2:
15.6% total win rate 
one-tail binomial pval = 0.9583677437761202
Scientific: 70%    Cultural: 0%    Domination: 30%    Diplomatic: 0%    Time: 0%    
Scientific: 241    Cultural: 0    Domination: 181    Diplomatic: 0    Time: 0    avg turns
@END: popSum avg=48.375 cnt=64

nation3:
29.7% total win rate 
one-tail binomial pval = 0.19323811557517234
Scientific: 84%    Cultural: 0%    Domination: 15%    Diplomatic: 0%    Time: 0%    
Scientific: 225    Cultural: 0    Domination: 194    Diplomatic: 0    Time: 0    avg turns
@END: popSum avg=83.671875 cnt=64

nation4:
34.4% total win rate 
one-tail binomial pval = 0.04163225622387978
Scientific: 72%    Cultural: 0%    Domination: 27%    Diplomatic: 0%    Time: 0%    
Scientific: 226    Cultural: 0    Domination: 206    Diplomatic: 0    Time: 0    avg turns
@END: popSum avg=81.40625 cnt=64

Average speed: 37.8 turns/s 
Average game duration: 5.9s
Total time: 6m 17.6s
```