### PR TITLE
Use streams for object -> save conversions

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -1,8 +1,6 @@
 package com.unciv
 
 import com.badlogic.gdx.*
-import com.unciv.UncivGame.Companion.Current
-import com.unciv.UncivGame.Companion.isCurrentInitialized
 import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.Version
@@ -315,7 +313,11 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         val newScreen = screenStack.last()
         setScreen(newScreen)
         newScreen.resume()
-        oldScreen.dispose()
+        // Disposing the old screen's stage must not happen while we're still inside its own touch event
+        // dispatch (e.g. this was called from a button's click listener) - see #15420/#15434: disposing
+        // the stage synchronously can crash with an NPE inside Gdx's ActorGestureListener when that
+        // in-flight dispatch resumes.
+        Concurrency.runOnGLThread { oldScreen.dispose() }
         return newScreen
     }
 
@@ -324,12 +326,13 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         val oldScreen = screenStack.removeLast()
         screenStack.addLast(newScreen)
         setScreen(newScreen)
-        oldScreen.dispose()
+        Concurrency.runOnGLThread { oldScreen.dispose() }
     }
 
     /** Resets the game to the stored world screen and automatically [disposes][Screen.dispose] all other screens. */
     fun resetToWorldScreen(): WorldScreen {
-        for (screen in screenStack.filter { it !is WorldScreen }) screen.dispose()
+        val screensToDispose = screenStack.filter { it !is WorldScreen }
+        Concurrency.runOnGLThread { for (screen in screensToDispose) screen.dispose() }
         screenStack.removeAll { it !is WorldScreen }
         val worldScreen = screenStack.last() as WorldScreen
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -36,7 +36,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.audio.MusicMood
 import com.unciv.ui.audio.MusicTrackChooserFlags
-import com.unciv.ui.screens.savescreens.Gzip
+import com.unciv.ui.screens.savescreens.FileConversions
 import com.unciv.ui.screens.worldscreen.status.NextTurnProgress
 import com.unciv.utils.DebugUtils
 import com.unciv.utils.debug
@@ -353,7 +353,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             .getInstance("SHA-1")
             .digest(json().toJson(this).toByteArray(Charsets.UTF_8))
         checksum = oldChecksum
-        return Gzip.encode(bytes)
+        return FileConversions.encode(bytes)
     }
 
     //endregion

--- a/core/src/com/unciv/logic/files/MapSaver.kt
+++ b/core/src/com/unciv/logic/files/MapSaver.kt
@@ -5,7 +5,7 @@ import com.unciv.UncivGame
 import com.unciv.json.json
 import com.unciv.logic.map.MapParameters
 import com.unciv.logic.map.TileMap
-import com.unciv.ui.screens.savescreens.Gzip
+import com.unciv.ui.screens.savescreens.FileConversions
 
 object MapSaver {
 
@@ -16,7 +16,7 @@ object MapSaver {
 
     fun mapFromSavedString(mapString: String): TileMap {
         val unzippedJson = try {
-            Gzip.unzip(mapString.trim())
+            FileConversions.unzip(mapString.trim())
         } catch (_: Exception) {
             mapString
         }
@@ -25,23 +25,16 @@ object MapSaver {
     fun mapToSavedString(tileMap: TileMap): String {
         tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign)
         val mapJson = json().toJson(tileMap)
-        return if (saveZipped) Gzip.zip(mapJson) else mapJson
+        return if (saveZipped) FileConversions.zip(mapJson) else mapJson
     }
 
     fun saveMap(mapName: String, tileMap: TileMap) {
         tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign)
-        val file = getMap(mapName)
-        if (saveZipped) {
-            Gzip.zippedOutputStream(file.write(false)).writer(Charsets.UTF_8).use {
-                json().toJson(tileMap, it)
-            }
-        } else {
-            json().toJson(tileMap, file)
-        }
+        FileConversions.writeJson(getMap(mapName), tileMap, saveZipped)
     }
 
     fun loadMap(mapFile: FileHandle): TileMap {
-        return openJsonReader(mapFile).use { json().fromJson(TileMap::class.java, it) }
+        return FileConversions.readJson(mapFile, TileMap::class.java)!!
     }
 
     fun getMaps(): Array<FileHandle> = UncivGame.Current.files.getLocalFile(mapsFolder).list()
@@ -53,14 +46,6 @@ object MapSaver {
     }
 
     fun loadMapPreview(mapFile: FileHandle): TileMap.Preview {
-        return openJsonReader(mapFile).use { json().fromJson(TileMap.Preview::class.java, it) }
-    }
-
-    /** Opens [file] for reading its JSON content, transparently gunzipping+base64-decoding if it's in that format,
-     *  falling back to reading it as plain text otherwise (e.g. if [saveZipped] was off when it was saved). */
-    private fun openJsonReader(file: FileHandle) = try {
-        Gzip.unzippedInputStream(file.read()).reader(Charsets.UTF_8)
-    } catch (ex: Exception) {
-        file.reader(Charsets.UTF_8.name())
+        return FileConversions.readJson(mapFile, TileMap.Preview::class.java)!!
     }
 }

--- a/core/src/com/unciv/logic/files/MapSaver.kt
+++ b/core/src/com/unciv/logic/files/MapSaver.kt
@@ -29,11 +29,19 @@ object MapSaver {
     }
 
     fun saveMap(mapName: String, tileMap: TileMap) {
-        getMap(mapName).writeString(mapToSavedString(tileMap), false, Charsets.UTF_8.name())
+        tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign)
+        val file = getMap(mapName)
+        if (saveZipped) {
+            Gzip.zippedOutputStream(file.write(false)).writer(Charsets.UTF_8).use {
+                json().toJson(tileMap, it)
+            }
+        } else {
+            json().toJson(tileMap, file)
+        }
     }
 
     fun loadMap(mapFile: FileHandle): TileMap {
-        return mapFromSavedString(mapFile.readString(Charsets.UTF_8.name()))
+        return openJsonReader(mapFile).use { json().fromJson(TileMap::class.java, it) }
     }
 
     fun getMaps(): Array<FileHandle> = UncivGame.Current.files.getLocalFile(mapsFolder).list()
@@ -45,15 +53,14 @@ object MapSaver {
     }
 
     fun loadMapPreview(mapFile: FileHandle): TileMap.Preview {
-        return mapPreviewFromSavedString(mapFile.readString())
+        return openJsonReader(mapFile).use { json().fromJson(TileMap.Preview::class.java, it) }
     }
 
-    private fun mapPreviewFromSavedString(mapString: String): TileMap.Preview {
-        val unzippedJson = try {
-            Gzip.unzip(mapString.trim())
-        } catch (_: Exception) {
-            mapString
-        }
-        return json().fromJson(TileMap.Preview::class.java, unzippedJson)
+    /** Opens [file] for reading its JSON content, transparently gunzipping+base64-decoding if it's in that format,
+     *  falling back to reading it as plain text otherwise (e.g. if [saveZipped] was off when it was saved). */
+    private fun openJsonReader(file: FileHandle) = try {
+        Gzip.unzippedInputStream(file.read()).reader(Charsets.UTF_8)
+    } catch (ex: Exception) {
+        file.reader(Charsets.UTF_8.name())
     }
 }

--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -19,7 +19,7 @@ import com.unciv.models.metadata.doMigrations
 import com.unciv.models.metadata.isMigrationNecessary
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.ui.screens.modmanager.ModUIData
-import com.unciv.ui.screens.savescreens.Gzip
+import com.unciv.ui.screens.savescreens.FileConversions
 import com.unciv.logic.CompatibilityVersion
 import com.unciv.utils.Concurrency
 import com.unciv.logic.GameInfoSerializationVersion
@@ -178,13 +178,7 @@ class UncivFiles(
         try {
             debug("Saving GameInfo %s to %s", game.gameId, file.path())
             game.version = CompatibilityVersion.CURRENT_COMPATIBILITY_VERSION
-            if (saveZipped) {
-                Gzip.zippedOutputStream(file.write(false)).writer(Charsets.UTF_8).use {
-                    json().toJson(game, it)
-                }
-            } else {
-                json().toJson(game, file)
-            }
+            FileConversions.writeJson(file, game, saveZipped)
             saveCompletionCallback(null)
         } catch (ex: Exception) {
             saveCompletionCallback(ex)
@@ -256,10 +250,10 @@ class UncivFiles(
         if (gameFile.length() == 0L) throw emptyFile(gameFile)
 
         val gameInfo = try {
-            openJsonReader(gameFile).use { json().fromJson(GameInfo::class.java, it) }
+            FileConversions.readJson(gameFile, GameInfo::class.java)
         } catch (ex: Exception) {
             Log.error("Exception while deserializing GameInfo JSON", ex)
-            val onlyVersion = openJsonReader(gameFile).use { json().fromJson(GameInfoSerializationVersion::class.java, it) }
+            val onlyVersion = FileConversions.readJson(gameFile, GameInfoSerializationVersion::class.java)!!
             throw IncompatibleGameInfoVersionException(onlyVersion.version, ex)
         } ?: throw UncivShowableException("The file data seems to be corrupted.")
 
@@ -271,16 +265,8 @@ class UncivFiles(
         return gameInfo
     }
 
-    /** Opens [file] for reading its JSON content, transparently gunzipping+base64-decoding if it's in that format,
-     *  falling back to reading it as plain text otherwise (e.g. if [saveZipped] was off when it was saved). */
-    private fun openJsonReader(file: FileHandle) = try {
-        Gzip.unzippedInputStream(file.read()).reader(Charsets.UTF_8)
-    } catch (ex: Exception) {
-        file.reader(Charsets.UTF_8.name())
-    }
-
     fun loadGamePreviewFromFile(gameFile: FileHandle): GameInfoPreview {
-        val preview = json().fromJson(GameInfoPreview::class.java, gameFile)
+        val preview = FileConversions.readJson(gameFile, GameInfoPreview::class.java)
             ?: throw emptyFile(gameFile)
         preview.migrateCivID()
         return preview
@@ -444,7 +430,7 @@ class UncivFiles(
         fun gameInfoFromString(gameData: String): GameInfo {
             val fixedData = gameData.trim().replace("\r", "").replace("\n", "")
             val unzippedJson = try {
-                Gzip.unzip(fixedData)
+                FileConversions.unzip(fixedData)
             } catch (ex: Exception) {
                 fixedData
             }
@@ -469,7 +455,7 @@ class UncivFiles(
          * @throws SerializationException
          */
         fun gameInfoPreviewFromString(gameData: String): GameInfoPreview {
-            val preview = json().fromJson(GameInfoPreview::class.java, Gzip.unzip(gameData))
+            val preview = json().fromJson(GameInfoPreview::class.java, FileConversions.unzip(gameData))
             preview.migrateCivID()
             return preview
         }
@@ -481,12 +467,12 @@ class UncivFiles(
             if (updateChecksum) game.checksum = game.calculateChecksum()
             val plainJson = json().toJson(game)
 
-            return if (forceZip ?: saveZipped) Gzip.zip(plainJson) else plainJson
+            return if (forceZip ?: saveZipped) FileConversions.zip(plainJson) else plainJson
         }
 
         /** Returns gzipped serialization of preview [game] */
         fun gameInfoToString(game: GameInfoPreview): String {
-            return Gzip.zip(json().toJson(game))
+            return FileConversions.zip(json().toJson(game))
         }
 
         private val charsForbiddenInFileNames = setOf('\\', '/', ':')

--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -177,11 +177,12 @@ class UncivFiles(
     fun saveGame(game: GameInfo, file: FileHandle, saveCompletionCallback: (Exception?) -> Unit = ::rethrowIfNotNull) {
         try {
             debug("Saving GameInfo %s to %s", game.gameId, file.path())
+            game.version = CompatibilityVersion.CURRENT_COMPATIBILITY_VERSION
             if (saveZipped) {
-                val string = gameInfoToString(game)
-                file.writeString(string, false, Charsets.UTF_8.name())
+                Gzip.zippedOutputStream(file.write(false)).writer(Charsets.UTF_8).use {
+                    json().toJson(game, it)
+                }
             } else {
-                game.version = CompatibilityVersion.CURRENT_COMPATIBILITY_VERSION
                 json().toJson(game, file)
             }
             saveCompletionCallback(null)
@@ -252,11 +253,30 @@ class UncivFiles(
             loadGameFromFile(getSave(gameName))
 
     fun loadGameFromFile(gameFile: FileHandle): GameInfo {
-        val gameData = gameFile.readString(Charsets.UTF_8.name())
-        if (gameData.isNullOrBlank()) {
-            throw emptyFile(gameFile)
+        if (gameFile.length() == 0L) throw emptyFile(gameFile)
+
+        val gameInfo = try {
+            openJsonReader(gameFile).use { json().fromJson(GameInfo::class.java, it) }
+        } catch (ex: Exception) {
+            Log.error("Exception while deserializing GameInfo JSON", ex)
+            val onlyVersion = openJsonReader(gameFile).use { json().fromJson(GameInfoSerializationVersion::class.java, it) }
+            throw IncompatibleGameInfoVersionException(onlyVersion.version, ex)
+        } ?: throw UncivShowableException("The file data seems to be corrupted.")
+
+        if (gameInfo.version > CompatibilityVersion.CURRENT_COMPATIBILITY_VERSION) {
+            // this means there wasn't an immediate error while serializing, but this version will cause other errors later down the line
+            throw IncompatibleGameInfoVersionException(gameInfo.version)
         }
-        return gameInfoFromString(gameData)
+        gameInfo.setTransients()
+        return gameInfo
+    }
+
+    /** Opens [file] for reading its JSON content, transparently gunzipping+base64-decoding if it's in that format,
+     *  falling back to reading it as plain text otherwise (e.g. if [saveZipped] was off when it was saved). */
+    private fun openJsonReader(file: FileHandle) = try {
+        Gzip.unzippedInputStream(file.read()).reader(Charsets.UTF_8)
+    } catch (ex: Exception) {
+        file.reader(Charsets.UTF_8.name())
     }
 
     fun loadGamePreviewFromFile(gameFile: FileHandle): GameInfoPreview {

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -38,7 +38,6 @@ import com.unciv.ui.popups.closeAllPopups
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
 import com.unciv.ui.screens.worldscreen.WorldScreen
-import com.unciv.utils.Concurrency
 import com.unciv.view.CityView
 import com.unciv.view.CivView
 import com.unciv.view.TileView
@@ -546,12 +545,7 @@ class CityScreen(
         val newCityScreen = CityScreen(viewableCities[indexOfNextCity], ambiencePlayer = passOnCityAmbiencePlayer())
         newCityScreen.mapScrollPane.zoom(mapScrollPane.scaleX) // Retain zoom
         newCityScreen.update()
-        // Disposing this screen's stage must not happen while we're still inside its own touch event
-        // dispatch (as we are here, called from a button's click listener) - see #15420: clicking two
-        // arrow buttons with different mouse buttons at once can leave another button's gesture listener
-        // mid-dispatch on this stage, and disposing the stage synchronously then crashes with an NPE
-        // inside Gdx's ActorGestureListener when that in-flight dispatch resumes.
-        Concurrency.runOnGLThread { game.replaceCurrentScreen(newCityScreen) }
+        game.replaceCurrentScreen(newCityScreen)
     }
 
     // Don't use passOnCityAmbiencePlayer here - continuing play on the replacement screen would be nice,

--- a/core/src/com/unciv/ui/screens/savescreens/FileConversions.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/FileConversions.kt
@@ -1,5 +1,7 @@
 package com.unciv.ui.screens.savescreens
 
+import com.badlogic.gdx.files.FileHandle
+import com.unciv.json.json
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -8,7 +10,7 @@ import java.util.Base64
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
-object Gzip {
+object FileConversions {
 
     fun zip(data: String): String {
         val bos = ByteArrayOutputStream()
@@ -23,13 +25,35 @@ object Gzip {
     }
 
     /** Wraps [output]: bytes written to the result are gzip-compressed, then base64-encoded into [output]. */
-    fun zippedOutputStream(output: OutputStream): OutputStream =
+    private fun zippedOutputStream(output: OutputStream): OutputStream =
         GZIPOutputStream(Base64.getEncoder().wrap(output))
 
     /** Wraps [input], which must contain base64-encoded gzip data: bytes read from the result are the decompressed original. */
-    fun unzippedInputStream(input: InputStream): InputStream =
+    private fun unzippedInputStream(input: InputStream): InputStream =
         GZIPInputStream(Base64.getDecoder().wrap(input))
 
     /** Plain base64 encoding, no gzip - e.g. for encoding a checksum digest as text. */
     fun encode(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
+
+    /** Reads [file] as JSON of [type], transparently gunzip+base64-decoding it if that's how it was saved -
+     *  otherwise (or if that fails), falls back to reading it as plain JSON text. */
+    fun <T> readJson(file: FileHandle, type: Class<T>): T? {
+        val reader = try {
+            unzippedInputStream(file.read()).reader(Charsets.UTF_8)
+        } catch (ex: Exception) {
+            file.reader(Charsets.UTF_8.name())
+        }
+        return reader.use { json().fromJson(type, it) }
+    }
+
+    /** Writes [obj] as JSON to [file], gzip-compressing and base64-encoding it first if [zip] is true. */
+    fun writeJson(file: FileHandle, obj: Any, zip: Boolean) {
+        if (zip) {
+            zippedOutputStream(file.write(false)).writer(Charsets.UTF_8).use {
+                json().toJson(obj, it)
+            }
+        } else {
+            json().toJson(obj, file)
+        }
+    }
 }

--- a/core/src/com/unciv/ui/screens/savescreens/Gzip.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/Gzip.kt
@@ -1,50 +1,35 @@
 package com.unciv.ui.screens.savescreens
 
-import com.badlogic.gdx.utils.Base64Coder
-import java.io.BufferedReader
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.io.InputStreamReader
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.Base64
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
 object Gzip {
 
-    fun zip(data: String): String = encode(compress(data))
-    fun unzip(data: String): String  = decompress(decode(data))
-
-    private fun compress(data: String): ByteArray {
-        val bos = ByteArrayOutputStream(data.length)
-        val gzip = GZIPOutputStream(bos)
-        gzip.write(data.toByteArray())
-        gzip.close()
-        val compressed = bos.toByteArray()
-        bos.close()
-        return compressed
+    fun zip(data: String): String {
+        val bos = ByteArrayOutputStream()
+        zippedOutputStream(bos).use { it.write(data.toByteArray(Charsets.UTF_8)) }
+        return bos.toString(Charsets.UTF_8.name())
     }
 
-    private fun decompress(compressed: ByteArray): String {
-        val bis = ByteArrayInputStream(compressed)
-        val gis = GZIPInputStream(bis)
-        val br = BufferedReader(InputStreamReader(gis, Charsets.UTF_8))
-        val sb = StringBuilder()
-        var line: String? = br.readLine()
-        while (line != null) {
-            sb.append(line)
-            line = br.readLine()
+    fun unzip(data: String): String {
+        return unzippedInputStream(ByteArrayInputStream(data.toByteArray(Charsets.UTF_8))).use {
+            it.readBytes().toString(Charsets.UTF_8)
         }
-        br.close()
-        gis.close()
-        bis.close()
-        return sb.toString()
     }
 
+    /** Wraps [output]: bytes written to the result are gzip-compressed, then base64-encoded into [output]. */
+    fun zippedOutputStream(output: OutputStream): OutputStream =
+        GZIPOutputStream(Base64.getEncoder().wrap(output))
 
-    fun encode(bytes: ByteArray): String {
-        return String(Base64Coder.encode(bytes))
-    }
+    /** Wraps [input], which must contain base64-encoded gzip data: bytes read from the result are the decompressed original. */
+    fun unzippedInputStream(input: InputStream): InputStream =
+        GZIPInputStream(Base64.getDecoder().wrap(input))
 
-    private fun decode(base64Str: String): ByteArray {
-        return Base64Coder.decode(base64Str)
-    }
+    /** Plain base64 encoding, no gzip - e.g. for encoding a checksum digest as text. */
+    fun encode(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
 }

--- a/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
@@ -21,7 +21,6 @@ import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.popups.LoadingPopup
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.ToastPopup
@@ -196,7 +195,7 @@ class LoadGameScreen : LoadOrSaveScreen() {
             return
         }
         try {
-            Gdx.app.clipboard.contents = if (gameText[0] == '{') Gzip.zip(gameText) else gameText
+            Gdx.app.clipboard.contents = if (gameText[0] == '{') FileConversions.zip(gameText) else gameText
             launchOnGLThread {
                 ToastPopup("'[${file.name()}]' copied to clipboard!", this@LoadGameScreen)
             }


### PR DESCRIPTION
Inspired by #15435

Currently converting an in memory game goes through several conversions to get to a base64, gzipped, json:

In-mem objects -> json string -> gzipped bytes -> base64 string

The target of which is usually either a local file, or the clipboard.

Gzip conversion is the only one where I wouldn't be able to write a stream version myself, the rest (json serialize/base64/byte-string) are very straightforward

So for cases of save/load to/from files, we can ideally get rid of all intermediate memory usage entirely!
And for cases of clipboard, we'll only have to get the final, relatively small string in-memory before we lob it off to the clipboard (technically in-mem, but in android - where the problems are - it's not **app memory** but **global memory** so it doesn't count towards out app limit) 

For now, I'm leaving PlatformSaverLoader - for platform-specific custom locations - out of this, but if this works well there's no reason we shouldn't migrate them too

Regarding the placement of the jsonifying and json-reader parts, the more I look at it the more obvious it is that there should be a central location for all parts of the pipeline including the json part; That means that the name Gzip is wildly wrong, still looking for a good name 🤔

There are many changes in this PR: There's a technical change, and there's an "API of file conversions" change; I'm wondering if to split this to first make the API change, and only in a later version change the background way we actually do the conversions.