### PR TITLE
Fix "Connect road" with A-Star pathing enabled

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.automation.unit
 
+import com.unciv.Constants
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.MapUnitAction
 import com.unciv.logic.civilization.NotificationCategory
@@ -113,18 +114,13 @@ class RoadToAutomation(val civInfo: Civilization) {
         }
 
         // We need to check current movement again after we've (potentially) moved
-        if (unit.hasMovement()) {
-            // Repair pillaged roads first
-            if (currentTile.roadStatus != RoadStatus.None && currentTile.roadIsPillaged) {
-                currentTile.setRepaired()
-                return
-            }
-            if (shouldBuildRoadOnTile(currentTile) && currentTile.improvementInProgress != actualBestRoadAvailable.name) {
-                val improvement = actualBestRoadAvailable.improvement(civInfo.gameInfo.ruleset)!!
-                currentTile.startWorkingOnImprovement(improvement, civInfo, unit)
-                return
-            }
-        }
+        if (!unit.hasMovement()) return
+        // Repair pillaged roads first - try to build a new one if a mod removed repair
+        val repairImprovement = if (currentTile.roadStatus == RoadStatus.None || !currentTile.roadIsPillaged) null
+            else civInfo.gameInfo.ruleset.tileImprovements[Constants.repair]
+        val buildImprovement = if (!shouldBuildRoadOnTile(currentTile) || currentTile.improvementInProgress == actualBestRoadAvailable.name) null
+            else actualBestRoadAvailable.improvement(civInfo.gameInfo.ruleset)
+        (repairImprovement ?: buildImprovement)?.let { currentTile.startWorkingOnImprovement(it, civInfo, unit) }
     }
 
     /** Reset side effects from automation, return worker to non-automated state*/

--- a/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
@@ -15,12 +15,11 @@ import com.unciv.utils.debug
 import yairm210.purity.annotations.Readonly
 
 
-/** Responsible for automation the "build road to" action
- * This is *pretty bad code* overall and needs to be cleaned up */
+/** Responsible for automating the "build road to" action
+ *  This is *pretty bad code* overall and needs to be cleaned up */
 class RoadToAutomation(val civInfo: Civilization) {
 
     private val actualBestRoadAvailable: RoadStatus = civInfo.tech.getBestRoadAvailable()
-
 
     /**
      * Automate the process of connecting a road between two points.
@@ -33,19 +32,19 @@ class RoadToAutomation(val civInfo: Civilization) {
      * - End automation upon finish
      */
     // TODO: Caching
-    // TODO: Hide the automate road button if road is not unlocked
     @Suppress("UNUSED_PARAMETER")  // tilesWhereWeWillBeCaptured may be useful in the future
-    fun automateConnectRoad(unit: MapUnit, tilesWhereWeWillBeCaptured: Set<Tile>){
+    fun automateConnectRoad(unit: MapUnit, tilesWhereWeWillBeCaptured: Set<Tile>) {
         if (actualBestRoadAvailable == RoadStatus.None) return
 
         var currentTile = unit.getTile()
 
-
-        if (unit.automatedRoadConnectionDestination == null){
+        if (unit.automatedRoadConnectionDestination == null) {
             stopAndCleanAutomation(unit)
             return
         }
 
+        fun notify(msg: String) =
+            unit.civ.addNotification(msg, MapUnitAction(unit), NotificationCategory.Units, NotificationIcon.Construction)
 
         val destinationTile = unit.civ.gameInfo.tileMap[unit.automatedRoadConnectionDestination!!]
 
@@ -59,7 +58,7 @@ class RoadToAutomation(val civInfo: Civilization) {
             if (foundPath == null) {
                 Log.debug("WorkerAutomation: $unit -> connect road failed")
                 stopAndCleanAutomation(unit)
-                unit.civ.addNotification("Connect road failed!", MapUnitAction(unit), NotificationCategory.Units, NotificationIcon.Construction)
+                notify("Connect road failed!")
                 return
             }
 
@@ -76,11 +75,11 @@ class RoadToAutomation(val civInfo: Civilization) {
         if (currTileIndex == -1) {
             Log.debug("$unit -> was moved off its connect road path. Operation cancelled.")
             stopAndCleanAutomation(unit)
-            unit.civ.addNotification("Connect road cancelled!", MapUnitAction(unit), NotificationCategory.Units, unit.name)
+            notify("Connect road cancelled!")
             return
         }
 
-        /* Can not build a road on this tile, try to move on.
+        /* Cannot build a road on this tile, try to move on.
         * The worker should search for the next furthest tile in the path that:
         * - It can move to
         * - Can be improved/upgraded
@@ -88,7 +87,7 @@ class RoadToAutomation(val civInfo: Civilization) {
         if (unit.hasMovement() && !shouldBuildRoadOnTile(currentTile)) {
             if (currTileIndex == pathToDest.size - 1) { // The last tile in the path is unbuildable or has a road.
                 stopAndCleanAutomation(unit)
-                unit.civ.addNotification("Connect road completed", MapUnitAction(unit), NotificationCategory.Units, unit.name)
+                notify("Connect road completed")
                 return
             }
 
@@ -98,11 +97,8 @@ class RoadToAutomation(val civInfo: Civilization) {
 
                 // Create a new list with tiles where the index is greater than currTileIndex
                 val futureTiles = pathToDest.asSequence()
-                    .dropWhile { it != unit.currentTile.position }
-                    .drop(1)
+                    .drop(currTileIndex + 1)
                     .map { tileMap[it] }
-
-
 
                 for (futureTile in futureTiles) { // Find the furthest tile we can reach in this turn, move to, and does not have a road
                     if (unit.movement.canReachInCurrentTurn(futureTile) && unit.movement.canMoveTo(futureTile)) { // We can at least move to this tile
@@ -113,15 +109,17 @@ class RoadToAutomation(val civInfo: Civilization) {
                     }
                 }
 
-                unit.movement.moveToTile(nextTile)
-                currentTile = unit.getTile()
+                if (nextTile.position != currentTile.position) {
+                    unit.movement.moveToTile(nextTile)
+                    currentTile = unit.getTile()
+                }
             }
         }
 
         // We need to check current movement again after we've (potentially) moved
         if (unit.hasMovement()) {
             // Repair pillaged roads first
-            if (currentTile.roadStatus != RoadStatus.None && currentTile.roadIsPillaged){
+            if (currentTile.roadStatus != RoadStatus.None && currentTile.roadIsPillaged) {
                 currentTile.setRepaired()
                 return
             }
@@ -134,14 +132,14 @@ class RoadToAutomation(val civInfo: Civilization) {
     }
 
     /** Reset side effects from automation, return worker to non-automated state*/
-    fun stopAndCleanAutomation(unit: MapUnit){
+    fun stopAndCleanAutomation(unit: MapUnit) {
         unit.automated = false
         unit.action = null
         unit.automatedRoadConnectionDestination = null
         unit.automatedRoadConnectionPath = null
-        unit.currentTile.stopWorkingOnImprovement()
+        if (unit.currentTile.getTileImprovementInProgress()?.isRoad() == true)
+            unit.currentTile.stopWorkingOnImprovement()
     }
-
 
     /** Conditions for whether it is acceptable to build a road on this tile */
     @Readonly

--- a/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadToAutomation.kt
@@ -1,12 +1,10 @@
 package com.unciv.logic.automation.unit
 
-import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.MapUnitAction
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.HexCoord
-import com.unciv.logic.map.MapPathing
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
@@ -52,9 +50,7 @@ class RoadToAutomation(val civInfo: Civilization) {
 
         // The path does not exist, create it
         if (pathToDest == null) {
-            val foundPath: List<Tile>? = 
-                if (UncivGame.Current.settings.useAStarPathfinding) unit.movement.getRoadPath(destinationTile)
-                else MapPathing.getRoadPath(unit.civ, unit.getTile(), destinationTile)
+            val foundPath: List<Tile>? = unit.movement.getRoadPath(destinationTile)
             if (foundPath == null) {
                 Log.debug("WorkerAutomation: $unit -> connect road failed")
                 stopAndCleanAutomation(unit)

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -884,9 +884,13 @@ class UnitMovement(val unit: MapUnit) {
         return distanceToTiles
     }
 
+    /**
+     *  Get a road path for the "Connect road" unit action. A valid path must include the current tile.
+     */
     @Readonly
     fun getRoadPath(destinationTile: Tile): List<Tile>? =
-        if (UncivGame.Current.settings.useAStarPathfinding) roadPathing.getShortestPath(destinationTile)
+        if (UncivGame.Current.settings.useAStarPathfinding)
+            roadPathing.getShortestPath(destinationTile)?.let { listOf(unit.currentTile) + it }
         else MapPathing.getRoadPath(unit.civ, unit.getTile(), destinationTile)
 
     fun getAerialPathsToCities(): HashMap<Tile, ArrayList<Tile>> {

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -56,7 +56,7 @@ class UnitMovement(val unit: MapUnit) {
     class ParentTileAndTotalMovement(val tile: Tile, val parentTile: Tile, val totalMovement: Float)
 
     @Readonly fun isUnknownTileWeShouldAssumeToBePassable(tile: Tile) = !unit.civ.hasExplored(tile)
-    
+
     /**
      * Gets the tiles the unit could move to at [position] with [unitMovement].
      * Does not consider if tiles can actually be entered, use canMoveTo for that.
@@ -162,7 +162,7 @@ class UnitMovement(val unit: MapUnit) {
             val damageFreePath = getShortestPath(destination, true)
             if (damageFreePath.isNotEmpty()) return damageFreePath
         }
-        
+
         if (destination.neighbors.none { isUnknownTileWeShouldAssumeToBePassable(it) || canPassThrough(it) }) {
             // edge case where this all of the tiles around the destination are
             // explored and known the unit can't pass through any of thoes tiles so we know a priori that no path exists
@@ -205,7 +205,7 @@ class UnitMovement(val unit: MapUnit) {
             val comparison: Comparator<Tile> = if (unit.type.isLandUnit())
                 compareBy({!it.isLand}, {it.aerialDistanceTo(destination)}, ::isUnfriendlyCityState)
             else compareBy({it.aerialDistanceTo(destination)}, ::isUnfriendlyCityState)
-            
+
             val tilesByPreference = tilesToCheck.sortedWith(comparison)
 
             for (tileToCheck in tilesByPreference) {
@@ -242,7 +242,7 @@ class UnitMovement(val unit: MapUnit) {
 
                         return path
                     }
-                    
+
                     if (movementTreeParents.containsKey(reachableTile)) continue // We cannot be faster than anything existing...
                     if (!isUnknownTileWeShouldAssumeToBePassable(reachableTile) &&
                         !canMoveToCache.getOrPut(reachableTile) { canMoveTo(reachableTile) })
@@ -703,9 +703,9 @@ class UnitMovement(val unit: MapUnit) {
      * Leave it as default unless you know what [canMoveTo] does.
      */
     @Readonly
-    fun canMoveTo(tile: Tile, assumeCanPassThrough: Boolean = false, allowSwap: Boolean = false, includeOtherEscortUnit: Boolean = true) = 
+    fun canMoveTo(tile: Tile, assumeCanPassThrough: Boolean = false, allowSwap: Boolean = false, includeOtherEscortUnit: Boolean = true) =
         getCannotMoveToReason(tile, assumeCanPassThrough, allowSwap, includeOtherEscortUnit) == null
-    
+
     enum class CannotMoveToReason{
         TerrainImpassable,
         BoatCannotGoOnLand,
@@ -717,7 +717,7 @@ class UnitMovement(val unit: MapUnit) {
         TileIsNotEmpty,
         NoAirUnitTransport,
     }
-    
+
     @Readonly
     fun getCannotMoveToReason(tile: Tile, assumeCanPassThrough: Boolean = false, allowSwap: Boolean = false, includeOtherEscortUnit: Boolean = true): CannotMoveToReason? {
         if (unit.baseUnit.isAirUnit())
@@ -741,9 +741,9 @@ class UnitMovement(val unit: MapUnit) {
         // can skip checking for airUnit since not a city
             (tile.militaryUnit == null || (allowSwap && tile.militaryUnit!!.owner == unit.owner))
                 && (tile.civilianUnit == null || tile.civilianUnit!!.owner == unit.owner || unit.civ.isAtWarWith(tile.civilianUnit!!.civ))
-        
+
         if (!tileIsEmpty) return CannotMoveToReason.TileIsNotEmpty
-        
+
         return null
     }
 
@@ -791,9 +791,9 @@ class UnitMovement(val unit: MapUnit) {
      * Leave it as default unless you know what [canPassThrough] does.
      */
     @Readonly
-    fun canPassThrough(tile: Tile, includeOtherEscortUnit: Boolean = true): Boolean 
+    fun canPassThrough(tile: Tile, includeOtherEscortUnit: Boolean = true): Boolean
         = cannotPassThroughReason(tile, includeOtherEscortUnit) == null
-    
+
     @Readonly
     fun cannotPassThroughReason(tile: Tile, includeOtherEscortUnit: Boolean = true): CannotMoveToReason? {
         if (tile.isImpassible()) {
@@ -866,7 +866,7 @@ class UnitMovement(val unit: MapUnit) {
         if (UncivGame.Current.settings.useAStarPathfinding) {
             if (!considerZoneOfControl) require(includeOtherEscortUnit)
             val pathingMap = if (!considerZoneOfControl) aStarPathingWithoutZoneControl
-                else if (includeOtherEscortUnit || !unit.isEscorting()) aStarPathing 
+                else if (includeOtherEscortUnit || !unit.isEscorting()) aStarPathing
                 else aStarPathingWithoutEscort
             return pathingMap.getMovementToTilesAtPosition()
         }
@@ -882,7 +882,7 @@ class UnitMovement(val unit: MapUnit) {
 
         return distanceToTiles
     }
-    
+
     @Readonly
     fun getRoadPath(destinationTile: Tile): List<Tile>? = roadPathing.getShortestPath(destinationTile)
 

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.BFS
 import com.unciv.logic.map.HexCoord
 import com.unciv.logic.map.HexMath
+import com.unciv.logic.map.MapPathing
 import com.unciv.logic.map.PathingMap
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
@@ -884,7 +885,9 @@ class UnitMovement(val unit: MapUnit) {
     }
 
     @Readonly
-    fun getRoadPath(destinationTile: Tile): List<Tile>? = roadPathing.getShortestPath(destinationTile)
+    fun getRoadPath(destinationTile: Tile): List<Tile>? =
+        if (UncivGame.Current.settings.useAStarPathfinding) roadPathing.getShortestPath(destinationTile)
+        else MapPathing.getRoadPath(unit.civ, unit.getTile(), destinationTile)
 
     fun getAerialPathsToCities(): HashMap<Tile, ArrayList<Tile>> {
         var tilesToCheck = ArrayList<Tile>()

--- a/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
@@ -508,9 +508,7 @@ class WorldMapHolder(
                 selectedUnitView.isExplored(tileView)
 
             if (validTile) {
-                val roadPath: List<Tile>? =
-                    if (UncivGame.Current.settings.useAStarPathfinding) selectedUnit.movement.getRoadPath(selectedUnit.getTile())
-                    else MapPathing.getRoadPath(selectedUnit.civ, selectedUnit.getTile(), tile)
+                val roadPath: List<Tile>? = selectedUnit.movement.getRoadPath(tile)
                 launchOnGLThread {
                     if (roadPath == null) { // give the regular tile overlays with no road connection
                         addTileOverlays(tileView)

--- a/tests/src/com/unciv/logic/map/PathfindingTests.kt
+++ b/tests/src/com/unciv/logic/map/PathfindingTests.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.map
 
 import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.logic.automation.unit.RoadToAutomation
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.map.tile.RoadStatus
@@ -741,5 +742,20 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
         val path = worker.movement.getRoadPath(destination) ?: emptyList()
         // Assert
         assertTrue("getRoadPath must contain both endpoints", originTile in path && destination in path)
+    }
+
+    @Test
+    fun connectRoadAction() {
+        // Arrange
+        civInfo.tech.addTechnology("The Wheel", false)
+        val worker = testGame.addUnit("Worker", civInfo, originTile)
+        val destination = testGame.getTile(5, 3)
+        worker.automatedRoadConnectionDestination = destination.position
+        // Act
+        val auto = RoadToAutomation(civInfo)
+        auto.automateConnectRoad(worker, emptySet())
+        // Assert
+        assertTrue("Worker must have queued a Road", originTile.improvementInProgress == RoadStatus.Road.name)
+        assertTrue("Worker must have a path", worker.automatedRoadConnectionPath?.isNotEmpty() == true)
     }
 }

--- a/tests/src/com/unciv/logic/map/PathfindingTests.kt
+++ b/tests/src/com/unciv/logic/map/PathfindingTests.kt
@@ -730,4 +730,16 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
                 apply(tile)
         }
     }
+
+    @Test
+    fun connectRoadPathingMustIncludeBothEndpoints() {
+        // Arrange
+        civInfo.tech.addTechnology("The Wheel", false)
+        val worker = testGame.addUnit("Worker", civInfo, originTile)
+        val destination = testGame.getTile(5, 3)
+        // Act
+        val path = worker.movement.getRoadPath(destination) ?: emptyList()
+        // Assert
+        assertTrue("getRoadPath must contain both endpoints", originTile in path && destination in path)
+    }
 }


### PR DESCRIPTION
#### Fixes
- Fixes #15447 
- Connect road would repair pillaged roads on the path instantly instead of doing the Repair action in its allotted time, even if a mod removed the Repair improvement
- With A-star enabled, the "Connect road" action would not show the planned path before committing it
- In rare edge cases, a stopping "Connect road" could clear improvement progress on non-road improvements
- Does NOT fix: A-star "Connect road" paths can be wild mad bull, going long detours where classic is just fine. I neglected to preserve the save, might try to stage a fake later.

#### Questions:
- Which of the unit tests for the #15447 would you prefer? At this stage, a drop and force-push is simple to choose one, and both might be overkill.
- Do we need a unit test checking the insta-repair thing?
- Pathing returns are not clear in all cases whether they include the end points or not - Investigate?