### PR TITLE
AStar correctly paths around allies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,6 +184,8 @@ project(":core") {
         "implementation"(rootProject.libs.kotlin.reflect)
 
         "implementation"(rootProject.libs.purity.annotations)
+        // androidx isn't actually android-specific and core/desktop are safe to depend on it
+        "implementation"(rootProject.libs.androidx.collection)
 
         "api"(rootProject.libs.bundles.ktor.client)
     }

--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.map
 
+import androidx.collection.MutableIntList
 import com.unciv.logic.automation.Timers.Companion.timeThis
 import com.unciv.logic.automation.civilization.MotivationToAttackAutomation
 import com.unciv.logic.automation.civilization.UseGoldAutomation
@@ -166,13 +167,14 @@ class PathingMap(
                 Log.debug("#getShortestPath returning no path to $destination for $debugMapType $debugId")
             return null
         }
-        val result = pathAsList(bestTarget, cache)
+        val result = if (bestTarget.damagingTiles == 0) pathAsListNoDamage(bestTarget, cache)
+            else pathAsListWithDamage(destination, cache)
         if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
             Log.debug("#getShortestPath returning ${result.map{it.position}} to $destination for $debugMapType $debugId")
         return result
     }
 
-    private fun pathAsList(targetNode: RouteNode, cache: PathingMapCache): MutableList<Tile> {
+    private fun pathAsListNoDamage(targetNode: RouteNode, cache: PathingMapCache): MutableList<Tile> {
         // Now routeNodes has the shortest route, so we extract it into a list and return
         var currentNode = targetNode
         val result = mutableListOf(currentNode.tile(tileMap))
@@ -181,13 +183,96 @@ class PathingMap(
             val parentTile = currentNode.parentTile(tileMap)
             val parentNode = RouteNode(cache.routeNodes[parentTile.zeroBasedIndex])
             if (parentTile.position == cache.key.startingPoint) break
-            if (parentNode.turns < turns && parentNode.endTurnWithoutMoreDamage && parentNode.canMoveTo) {
+            if (parentNode.turns < turns && parentNode.endTurnWithoutMoreDamage) {
                 result.add(parentTile)
                 turns = parentNode.turns
             }
             currentNode = parentNode
         }
         return result.asReversed()
+    }
+
+    /**
+     * Reconstructs the turn-by-turn waypoint list for the already-found route ending at
+     * [targetTile], for the case where the route DOES take damage somewhere.
+     *
+     * The cached RouteNode chain's own turns/moveUsedThisTurn bookkeeping can be slightly ahead of
+     * its own physical parentTile chain -- e.g. a damage-free retroactive pause anchors moveUsedThisTurn
+     * and turns to an *earlier* tile than the immediate physical predecessor, so comparing those
+     * fields between physically-adjacent nodes doesn't reliably reproduce per-hop cost or turn
+     * boundaries. So instead we rewalk the (already known, physically correct) tile chain from
+     * scratch, recomputing per-hop cost/damage directly -- cheap, since it's only O(path length),
+     * not O(search).
+     * */
+    private fun pathAsListWithDamage(targetTile: Tile, cache: PathingMapCache): MutableList<Tile> {
+        // get the whole list of tiles in the selected path, and reverse it
+        val pathTileIndecies = MutableIntList(16)
+        var walkTile = targetTile
+        while (walkTile.position != cache.key.startingPoint) {
+            pathTileIndecies.add(walkTile.zeroBasedIndex)
+            val node = RouteNode(cache.routeNodes[walkTile.zeroBasedIndex])
+            walkTile = node.parentTile(tileMap)
+        }
+        pathTileIndecies.reverse()
+
+        // now recalculate the optimal stop positions
+        val startTile = tileMap[cache.key.startingPoint]
+        val fpmFullMovement = cache.key.fullMove
+        val result = mutableListOf<Tile>()
+        fun addWaypoint(tile: Tile) {
+            if (tile != startTile && (result.isEmpty() || result.last() != tile)) result.add(tile)
+        }
+        var moveThisTurn = FPM_ZERO
+        var previousTile = startTile
+        var previousNode = RouteNode(cache.routeNodes[startTile.zeroBasedIndex])
+        var lastFullSafeTile = startTile
+        var moveSinceFullSafe = FPM_ZERO
+        var lastStoppableTile = startTile
+        var moveSinceStoppable = FPM_ZERO
+        for (i in 0..<pathTileIndecies.size) {
+            val nextTile = tileMap.tileList[pathTileIndecies[i]]
+            val nextNode = RouteNode(cache.routeNodes[nextTile.zeroBasedIndex])
+            val moveCost = if (!nextNode.endTurnWithoutMoreDamage) cost(previousTile, nextTile)
+                else if (nextNode.turns == previousNode.turns) nextNode.moveUsedThisTurn - previousNode.moveUsedThisTurn
+                else nextNode.moveUsedThisTurn
+
+            if (previousNode.endTurnWithoutMoreDamage && !nextNode.endTurnWithoutMoreDamage) {
+                lastFullSafeTile = previousTile
+                moveSinceFullSafe = FPM_ZERO
+            }
+            if (previousNode.canStopOn && !nextNode.canStopOn) {
+                lastStoppableTile = previousTile
+                moveSinceStoppable = FPM_ZERO
+            }
+            moveSinceFullSafe += moveCost
+            moveSinceStoppable += moveCost
+
+            moveThisTurn += moveCost
+            if (moveThisTurn > fpmFullMovement) { // choose best place to end the turn
+                val endTurnTile: Tile
+                if (moveSinceFullSafe < moveThisTurn) { // end turn on last tile that was non-damaging
+                    endTurnTile = lastFullSafeTile
+                    moveThisTurn = moveSinceFullSafe
+                } else if (moveSinceStoppable < moveThisTurn) { // end turn on last stoppable tile
+                    endTurnTile = lastStoppableTile
+                    moveThisTurn = moveSinceStoppable
+                } else { //end turn on previous tile
+                    endTurnTile = previousTile
+                    moveThisTurn = moveCost
+                }
+                addWaypoint(endTurnTile)
+                lastFullSafeTile = endTurnTile
+                lastStoppableTile = endTurnTile
+                moveSinceFullSafe = moveThisTurn
+                moveSinceStoppable = moveThisTurn
+            }
+            previousTile = nextTile
+            previousNode = nextNode
+        }
+        // The destination is always the final waypoint, whether or not it happened to also be a
+        // forced turn-boundary above.
+        addWaypoint(targetTile)
+        return result
     }
 
 
@@ -501,5 +586,13 @@ class PathingMap(
         private fun isLandTileCanAttackThrough(civInfo: Civilization, tile: Tile, targetCiv: Civilization): Boolean {
             return tile.isLand && isTileCanAttackThrough(civInfo, tile, targetCiv)
         }
+    }
+}
+
+private fun MutableIntList.reverse() {
+    for (i in 0..<size / 2) {
+        val temp = get(i)
+        set(i, get(size - 1 - i))
+        set(size - 1 - i,  temp)
     }
 }

--- a/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
+++ b/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
@@ -25,6 +25,7 @@ import com.unciv.utils.Log
 import com.unciv.utils.LongPriorityQueue
 import com.unciv.utils.forEachSetBit
 import org.jetbrains.annotations.VisibleForTesting
+import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.InternalState
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
@@ -81,7 +82,7 @@ internal class AStarPathfinder(
     private val initialBufferSize = tileMap.tileMatrix.size + tileMap.tileMatrix[0].size
     internal val tilesInTodo: IntIntMap = IntIntMap(initialBufferSize)
     private val fpmFullMovement = cache.key.fullMove
-
+    @Cache private var damageFreeAnchorCost = FPM_ZERO
     /**
      * Frontier priority queue for managing the tiles to be checked.
      * Tiles are ordered based on their priority, determined by the cumulative cost so far and the
@@ -161,23 +162,57 @@ internal class AStarPathfinder(
         return true
     }
 
+    /**
+     * Find the previous tile where stopping does not incur damage
+     * 
+     * Tiles that incur damage are assumed to be rare, so we save bits in the node by not storing where the previous
+     * non-damaging parent is. So in the rare cases we'd end up stopping on a damaging tile, we transitively check parents
+     * to find the previous tile where stopping does not incur damage.
+     */
+    @Readonly
+    private fun findDamageFreeAnchor(startNode: RouteNode, neighborTile: Tile, firstHopCost: FixedPointMovement): RouteNode {
+        val startingPoint = cache.key.startingPoint
+        var ancestor = startNode
+        var totalCost = firstHopCost
+        while (true) {
+            if (totalCost >= fpmFullMovement) {
+                if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
+                    Log.debug("#findDamageFreeAnchor gave up short of ${neighborTile.position}: ${ancestor.tile(tileMap).position} is already $totalCost away, for $debugMapType $debugId")
+                return RouteNode() // this ancestor is already too far; anything earlier is even farther
+            }
+            if (ancestor.canStopOn && ancestor.endTurnWithoutMoreDamage) {
+                damageFreeAnchorCost = totalCost
+                return ancestor
+            }
+            val ancestorTile = ancestor.tile(tileMap)
+            val parentTile = ancestor.parentTile(tileMap)
+            if (parentTile == ancestorTile) {
+                if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
+                    Log.debug("#findDamageFreeAnchor reached the search's root looking for ${neighborTile.position} with nothing damage-free usable, for $debugMapType $debugId")
+                return RouteNode() // reached the search's root with nothing usable
+            }
+            ancestor = RouteNode(routeNodes[parentTile.zeroBasedIndex])
+            totalCost = (totalCost + cost(ancestor.tile(tileMap), ancestorTile)).coerceAtMost(RouteNode.MAX_MOVE_THIS_TURN)
+        }
+    }
+
     // This can use more than the remaining movement, but that's correct behavior.
     // https://yairm210.medium.com/multi-turn-pathfinding-7136bd0bdaf0
-    private fun calculateNeighborNode(currentNode: RouteNode, neighborTile: Tile): RouteNode? {
+    private fun calculateNeighborNode(currentNode: RouteNode, neighborTile: Tile): RouteNode {
         val currentTile = currentNode.tile(tileMap)
         val startingPoint = cache.key.startingPoint
         val damagingTiles = currentNode.damagingTiles
         val cost = cost(currentTile, neighborTile).coerceAtMost(fpmFullMovement)
-        val newUsedMovement = (currentNode.moveUsedThisTurn + cost).coerceAtMost(fpmFullMovement)
         val canMoveTo = currentNode.turns > 0 || moveToPredicate(neighborTile)
         val endTurnThereDamage = endTurnDamage(neighborTile).coerceAtMost(1)
-        val newMountainMovement = when {
-                currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0 -> cost // first entering mountains
-                !currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0 -> currentNode.pbmMoveThisTurn + cost
-                else ->FPM_ZERO // ignored in this case
-            }.coerceAtMost(fpmFullMovement)
-        val thisTurnPassThroughOrSafeEndTurn = (newUsedMovement < fpmFullMovement) || (canMoveTo && endTurnThereDamage == 0)
-        val nextTurnPassThroughOrEndTurn = (newUsedMovement < fpmFullMovement) || canMoveTo
+        val neighborDamaging = endTurnThereDamage != 0
+        val trueSafe = canMoveTo && !neighborDamaging
+        val moveSinceStoppable = (currentNode.moveSinceStoppable + cost).coerceAtMost(RouteNode.MAX_MOVE_THIS_TURN)
+        val newMoveSinceStoppable = if (canMoveTo) FPM_ZERO else moveSinceStoppable
+        val midTurn = currentNode.moveUsedThisTurn < fpmFullMovement
+        val usedSoFar = if (midTurn) currentNode.moveUsedThisTurn else FPM_ZERO
+        val newUsedMovement = (usedSoFar + cost).coerceAtMost(fpmFullMovement)
+        val thisTurnPassThroughOrSafeEndTurn = newUsedMovement < fpmFullMovement || trueSafe
         val relationship = relationshipLevel(neighborTile)
 
         fun log(verb: String, context: String) {
@@ -190,42 +225,52 @@ internal class AStarPathfinder(
             )
         }
         fun newNode(
-            pauseBeforeMountainMove: FixedPointMovement, moveThisTurn: FixedPointMovement,
+            newMoveSinceStoppable: FixedPointMovement, newUsedMovement: FixedPointMovement,
             turnDelta: Int, newDamagingTiles: Int = damagingTiles
         ) = RouteNode(
-            neighborTile, relationship, pauseBeforeMountainMove, moveThisTurn,
-            currentNode.turns + turnDelta,  currentTile, canMoveTo, newDamagingTiles
+            neighborTile, relationship, newMoveSinceStoppable, newUsedMovement,
+            currentNode.turns + turnDelta,  currentTile, newDamagingTiles, neighborDamaging,
         )
-        if (currentNode.moveUsedThisTurn < fpmFullMovement  && thisTurnPassThroughOrSafeEndTurn) {
+        if ((midTurn || currentNode.canStopOn) && thisTurnPassThroughOrSafeEndTurn) {
             // if we can move to the next tile, and then either end our turn safely or move away, then we do so.
-            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                log("queuing", "for same turn")
-            return newNode(newMountainMovement, newUsedMovement, 0)
-        } else if (currentNode.endTurnWithoutMoreDamage && currentNode.canMoveTo && nextTurnPassThroughOrEndTurn) {
-            // If we can safely end our turn on the current tile, and then either end our turn or move away, then we do so.
-            log("queuing", "for next turn")
-            return newNode(newMountainMovement, cost, 1)
-        } else if (currentNode.endTurnWithoutMoreDamage && currentNode.canMoveTo && !canMoveTo) {
-            // Cannot end our turn on the next tile, nor pass through it. Possibly because it's occupied by a unit.
-            // Classic #getDistanceToTiles requires we populate the node, so populate it, but do not return it.
-            log("stubbing", "as occupied")
-            val occupiedNode = newNode(newMountainMovement, cost, 1)
-            routeNodes[neighborTile.zeroBasedIndex] = occupiedNode.bits
-            cache.addedNeighborNodes.clear(neighborTile.zeroBasedIndex)
-            return null
-        } else if (currentNode.pbmMoveThisTurn < fpmFullMovement) {
-            // If we could have moved here if we'd paused before entering mountains, then
-            // pretend we paused before entering the mountains.
-            log("queuing", "with retroactive pause before mountains")
-            return newNode(newMountainMovement, newMountainMovement, 1)
+            val turnsDelta = if (midTurn) 0 else 1
+            log("queuing", "for normal movement")
+            return newNode(newMoveSinceStoppable,newUsedMovement, turnsDelta)
+        } else if (!canMoveTo && moveSinceStoppable < fpmFullMovement) {
+            // If we could have moved here if we'd paused before entering unstoppable tiles
+            // (usually allied units), pretend we paused before entering the mountains.
+            // TODO: Eliminate endTurnDamage call.
+            val retreatDamagingTiles = if (currentNode.canStopOn)
+                    (damagingTiles + endTurnDamage(currentTile).coerceAtMost(1)).coerceAtMost(MAX_DAMAGING_TILES)
+                else damagingTiles
+            val turnsDelta = if (currentNode.canStopOn) 1 else 0
+            log("queing", "with retroactive pause")
+            return newNode(moveSinceStoppable, moveSinceStoppable, turnsDelta, retreatDamagingTiles)
+        } else if (!canMoveTo) {
+            // Even pausing as early as possible wasn't enough: it's simply not reachable this way,
+            // and hopefully another tile finds a route to it later.
+            log("skipping", " as unreachable")
+            return RouteNode() // uninitialized -- see this function's return-type docs
+        }
+
+        // canMoveTo is true, so we CAN stop here -- but it's damaging, and we've run out of budget
+        // to push past it. Before accepting the damage, look backward for a nearer damage-free
+        // anchor to retroactively pause at instead, taking no damage at all.
+        val damageFreeAnchor = findDamageFreeAnchor(currentNode, neighborTile, cost)
+        if (damageFreeAnchor.initialized) {
+            log("queing", "with retroactive pause before mountains")
+            return RouteNode(
+                neighborTile, relationship, FPM_ZERO, damageFreeAnchorCost,
+                damageFreeAnchor.turns + 1, currentTile, damageFreeAnchor.damagingTiles, neighborDamaging,
+            )
         } else {
             // Ending our turn here takes damage. We'll add the neighbor tile, but the damage
-            // means its neighbors will be calculated at a super low priority.
-            // In the meantime, another tile might find a route here that doesn't require taking damage,
-            // which is the ONLY scenario where a tile can get recalculated.
-            val newDamageTiles = (damagingTiles + endTurnThereDamage).coerceAtMost(RouteNode.MAX_DAMAGING_TILES)
-            log("queuing", "with taking damage")
-            return newNode(cost, cost, 1, newDamageTiles)
+            // means its neighbors will be calculated at a super low priority. In the meantime, another
+            // tile might find a route here that doesn't require taking damage, which is the ONLY
+            // scenario where a tile can get recalculated.
+            val newDamageTiles = (damagingTiles + endTurnThereDamage).coerceAtMost(MAX_DAMAGING_TILES)
+            log("queing", "with taking damage")
+            return newNode(FPM_ZERO, cost, 1, newDamageTiles)
         }
     }
 
@@ -239,7 +284,8 @@ internal class AStarPathfinder(
             if (!neighborNeedsCalcuating(currentNode, neighborTile)) {
                 RouteNode(routeNodes[neighborTile.zeroBasedIndex])
             } else {
-                val newNode = calculateNeighborNode(currentNode, neighborTile) ?: return null // calculate each neighbor
+                val newNode = calculateNeighborNode(currentNode, neighborTile)
+                if (!newNode.initialized) return null
                 routeNodes[neighborTile.zeroBasedIndex] = newNode.bits
                 if (moveFromLessThanTimeLimit(newNode))
                     todo.add(PrioritizedNode(newNode, calculateUnderestimatedMovement(newNode)).bits)

--- a/core/src/com/unciv/logic/map/PathingMapCache.kt
+++ b/core/src/com/unciv/logic/map/PathingMapCache.kt
@@ -53,10 +53,20 @@ import java.util.Locale
  * - [relationshipLevel]: Used as a tie-breaker when pathing through tiles owned by different civs.
  *   Unowned tiles are considered Allies. Stored as (7-ordinal), so that Ally=0, and is the highest
  *   priority. In the future, this can be reduced to 2, or even 1 bits, if needed.
- * - [pbmMoveThisTurn]: (pbm=PauseBeforeMountains) How much movement we would have used this turn, if
- *   we had ended a turn right before entering damaging terrain.  0 if the terrain is not damaging.
- *   This is used to retroactively calculate how far we could enter mountains if we had already
- *   moved some before entering damaging terrain. This is stored as fixed-point, base 30, in 9 bits.
+ * - [moveSinceStoppable]: How much movement we would have used this turn, if we had ended a turn
+ *   at the last place we could physically stop at all -- entirely unrelated to damage. 0 whenever
+ *   this tile is itself such a place, which is also (see [canStopOn]) exactly when this tile is
+ *   itself stoppable, so [canStopOn] is derived from this field rather than stored separately.
+ *   This is used to retroactively calculate how far we could have moved if we'd otherwise be
+ *   forced to end our turn on a tile we can't stop on at all (occupied, foreign territory, etc).
+ *   The retreat tile found this way can itself be damaging, but that needs no extra lookup: it's
+ *   always either the current tile (if IT is stoppable -- the only way this field is ever zero)
+ *   or already folded into the current tile's own damagingTiles (if not) -- see
+ *   [AStarPathfinder.calculateNeighborNode]'s `!canMoveTo` case.
+ *   Avoiding damage specifically is a different, harder concern, handled by a genuine on-demand
+ *   backward search (see [AStarPathfinder.findDamageFreeAnchor]) rather than by this field -- see
+ *   the KNOWN LIMITATION note on [AStarPathfinder.calculateNeighborNode] for why. This is stored as
+ *   fixed-point, base 30, in 9 bits.
  * - [moveUsedThisTurn]: How much movement we have used this turn so far.  This is stored as
  *   fixed-point, base 30, in 9 bits.
  * - [turns]: The number of turns used so far. Tiles reachable on the current turn have turns=0. We
@@ -72,7 +82,17 @@ import java.util.Locale
  *   use 14 to represent "no parent tile" (such as for the root node). Since the values are always
  *   even, we do not store the last bit, so this only takes 3 bits. This is never zero, which
  *   guarantees that an initialized RouteNode is never zero.
- * - [canMoveTo]: True if the unit can end turn on the tile, or it's multiple turns away.
+ * - [canStopOn]: True if the unit can end turn on the tile, or it's multiple turns away. Derived
+ *   from [moveSinceStoppable] being zero rather than stored as its own bit (see its docs above) --
+ *   this used to be a separate bit here, freed up once that invariant was established.
+ * - [endTurnWithoutMoreDamage]: True if THIS tile itself does NOT cause end-turn damage, regardless
+ *   of whether we actually ended a turn on it. Unlike [damagingTiles] (which only tallies damage
+ *   actually taken, i.e. only increments on tiles a turn ended on), this is set unconditionally for
+ *   every tile, including ones merely passed through -- letting a cheap single backward pass over
+ *   the route (see [PathingMap.pathAsListNoDamage]) tell a genuine "turns" boundary apart from a
+ *   tile that merely happens to be reachable within the same nominal turn number, without
+ *   recomputing anything, and letting [AStarPathfinder.findDamageFreeAnchor] check a candidate
+ *   anchor's own damage status without recomputing [AStarPathfinder.endTurnDamage] either.
  * - `padding`: In a RouteNode, the other remaining 12 bits of underestimatedTotal just hold zeroes,
  *   for now.
  * - [damagingTiles]: How many tiles that cause end-turn damage have been crossed to reach this tile.
@@ -80,6 +100,10 @@ import java.util.Locale
  *   long routes that do not take damage are prioritized over shorter routes that take damage,
  *   emulating prior behavior, while also allowing cache reuse.  We only store up to 3 damaging
  *   tiles, so this takes 2 bits.
+ *   KNOWN LIMITATION: being the primary sort key does NOT guarantee the globally minimal
+ *   damagingTiles count on every possible map -- see the comment on
+ *   [AStarPathfinder.calculateNeighborNode] for why (in short: it's a resource-constrained
+ *   shortest path problem, and we keep one label per tile rather than a full Pareto frontier).
  * - `sign bit`: Zero.  We *could* use it for values, but then we'd have to handle negative values
  *   in the comparison, which might involve negation and other complexity when reading other
  *   fields. Far safer and eaiser and faster to just keep it zero.
@@ -93,26 +117,26 @@ value class RouteNode(val bits: Long=0L) {
     constructor(
         tile: Tile,
         relationshipLevel: RelationshipLevel,
-        pauseBeforeMountainMove: FixedPointMovement,
+        moveSinceStoppable: FixedPointMovement,
         moveThisTurn: FixedPointMovement,
         turns: Int,
         parentTile: Tile,
-        moveTo: Boolean,
         damagingTiles: Int,
+        damaging: Boolean,
     ) : this(
         toTileIdxBits(tile) or
             toRelationshipLevelBits(relationshipLevel) or
-            toPbmMoveThisTurnBits(pauseBeforeMountainMove) or
+            toMoveSinceStoppableBits(moveSinceStoppable) or
             toMoveThisTurnBits(moveThisTurn) or
             toTurnsBits(turns) or
             toParentClockDirBits(tile, parentTile) or
-            toMoveToBits(moveTo) or
-            toDamagingTilesBits(damagingTiles)
+            toDamagingTilesBits(damagingTiles) or
+            toDamagingBits(damaging)
     ) {
         require(tile.zeroBasedIndex < tile.tileMap.tileList.size) { "tileList ${tile.zeroBasedIndex} exceeds max ${tile.tileMap.tileList.size}" }
         require(tile.tileMap.tileList.size <= TILE_IDX_LO_MASK) { "tileList ${tile.tileMap.tileList.size} exceeds max $TILE_IDX_LO_MASK" }
-        require(pauseBeforeMountainMove >= 0) { "pauseBeforeMountainMoveThisTurn $pbmMoveThisTurn must be positive" }
-        require(pauseBeforeMountainMove <= MAX_MOVE_THIS_TURN) { "pauseBeforeMountainMoveThisTurn $pbmMoveThisTurn exceeds max $MAX_MOVE_THIS_TURN" }
+        require(moveSinceStoppable >= 0) { "moveSinceStoppableThisTurn $moveSinceStoppable must be positive" }
+        require(moveSinceStoppable <= MAX_MOVE_THIS_TURN) { "moveSinceStoppableThisTurn $moveSinceStoppable exceeds max $MAX_MOVE_THIS_TURN" }
         require(moveThisTurn >= 0) { "moveThisTurn $moveThisTurn must be positive" }
         require(moveThisTurn <= MAX_MOVE_THIS_TURN) { "moveThisTurn $moveThisTurn exceeds max $MAX_MOVE_THIS_TURN" }
         require(turns >= 0) { "turns $turns must be positive" }
@@ -129,12 +153,11 @@ value class RouteNode(val bits: Long=0L) {
     private val relationshipLevelBits: Long get() {require(initialized); return ((bits shr RELATIONSHIP_LEVEL_OFFSET) and RELATIONSHIP_LEVEL_LO_MASK) }
     val relationshipLevel: RelationshipLevel get() = RelationshipLevel.entries[MAX_RELATIONSHIP_LEVEL - relationshipLevelBits.toInt()]
 
-    val pbmMoveThisTurn: FixedPointMovement get() {
+    val moveSinceStoppable: FixedPointMovement get() {
         require(initialized)
-        val bits = ((bits shr PBM_MOVE_THIS_TURN_OFFSET) and PBM_MOVE_THIS_TURN_LO_MASK)
+        val bits = ((bits shr MOVE_SINCE_STOPPABLE_OFFSET) and MOVE_SINCE_STOPPABLE_LO_MASK)
         return FixedPointMovement.fpmFromFixedPointBits(bits.toInt())
     }
-    val endTurnWithoutMoreDamage: Boolean get() = bits and PBM_MOVE_THIS_TURN_HI_MASK == 0L
 
     val moveUsedThisTurn: FixedPointMovement get() {
         require(initialized)
@@ -152,14 +175,18 @@ value class RouteNode(val bits: Long=0L) {
         return tileMap.getClockPositionNeighborTile(tile(tileMap), idx)!!
     }
 
-    val canMoveTo: Boolean get() { require(initialized); return (bits and MOVE_TO_HI_MASK) == MOVE_TO_HI_MASK}
+    // See moveSinceStoppable's docs above: it resets to zero exactly when a tile is itself
+    // stoppable, so canMoveTo is derived from it rather than stored as its own bit.
+    val canStopOn: Boolean get() = moveSinceStoppable == FPM_ZERO
+
+    val endTurnWithoutMoreDamage: Boolean get() { require(initialized); return ((bits shr DAMAGING_OFFSET) and 1L) == 0L }
 
     val damagingTiles: Int get() { require(initialized); return ((bits shr DAMAGE_TILES_OFFSET) and DAMAGE_TILES_LO_MASK).toInt() }
 
     // parentClockDir can never be 0, so all zeroes means uninitialized
     val initialized: Boolean get() = bits != 0L
 
-    internal val isNoPathingNode: Boolean get() = pbmMoveThisTurn.bits == PBM_MOVE_THIS_TURN_LO_MASK.toInt()
+    internal val isNoPathingNode: Boolean get() = moveSinceStoppable.bits == MOVE_SINCE_STOPPABLE_LO_MASK.toInt()
 
     @Readonly
     override fun toString() = "RouteNode[tile=$tileIdx, turns=$turns, moveUsedThisTurn=$moveUsedThisTurn]"
@@ -178,14 +205,14 @@ value class RouteNode(val bits: Long=0L) {
         private const val MAX_RELATIONSHIP_LEVEL = 7
         @Suppress("unused")
         private val relationshipReq = require(RelationshipLevel.entries.size == MAX_RELATIONSHIP_LEVEL + 1)
-        // bits 23-31 (9b = 512values = 25.55move) are the base-30 movement used since entering
-        // damaging terrain, if any.  Zero if not in damaging terrain.
-        private const val PBM_MOVE_THIS_TURN_OFFSET = RELATIONSHIP_LEVEL_OFFSET + RELATIONSHIP_LEVEL_BIT_COUNT
-        private const val PBM_MOVE_THIS_TURN_BIT_COUNT = 9
-        private const val PBM_MOVE_THIS_TURN_LO_MASK = (0x1L shl PBM_MOVE_THIS_TURN_BIT_COUNT) - 1L
-        private const val PBM_MOVE_THIS_TURN_HI_MASK = PBM_MOVE_THIS_TURN_LO_MASK shl PBM_MOVE_THIS_TURN_OFFSET
+        // bits 23-31 (9b = 512values = 25.55move) are the base-30 movement used since the last
+        // tile we could physically stop on at all. Zero exactly when this tile is itself such a
+        // place, which is also exactly when canMoveTo is true (see its docs above).
+        private const val MOVE_SINCE_STOPPABLE_OFFSET = RELATIONSHIP_LEVEL_OFFSET + RELATIONSHIP_LEVEL_BIT_COUNT
+        private const val MOVE_SINCE_STOPPABLE_BIT_COUNT = 9
+        private const val MOVE_SINCE_STOPPABLE_LO_MASK = (0x1L shl MOVE_SINCE_STOPPABLE_BIT_COUNT) - 1L
         // bits 32-40 (9b = 512values = 25.55move) are the base-30 movement used on this turn.
-        private const val MOVE_THIS_TURN_OFFSET = PBM_MOVE_THIS_TURN_OFFSET + PBM_MOVE_THIS_TURN_BIT_COUNT
+        private const val MOVE_THIS_TURN_OFFSET = MOVE_SINCE_STOPPABLE_OFFSET + MOVE_SINCE_STOPPABLE_BIT_COUNT
         private const val MOVE_THIS_TURN_BIT_COUNT = 9
         private const val MOVE_THIS_TURN_LO_MASK = (0x1L shl MOVE_THIS_TURN_BIT_COUNT) - 1L
         val MAX_MOVE_THIS_TURN = FixedPointMovement.fpmFromFixedPointBits(MOVE_THIS_TURN_LO_MASK.toInt())
@@ -207,13 +234,10 @@ value class RouteNode(val bits: Long=0L) {
         private const val PARENT_TILE_LO_MASK = (0x1L shl PARENT_TILE_BIT_COUNT) - 1L
         private const val NO_PARENT_TILE_BITS = 7L
         private const val NO_PARENT_TILE_VALUE = 14
-        // [RouteNode] bit 50 (1b = 2values) tracks if we can "move to" a tile.
-        // Aka either we can path through it, or it contains an enemy.
-        private const val MOVE_TO_OFFSET = PARENT_TILE_OFFSET + PARENT_TILE_BIT_COUNT
-        private const val MOVE_TO_BIT_COUNT = 1
-        private const val MOVE_TO_LO_MASK = (0x1L shl MOVE_TO_BIT_COUNT) - 1L
-        private const val MOVE_TO_HI_MASK = MOVE_TO_LO_MASK shl MOVE_TO_OFFSET
-        // [RouteNode] bits 52-60 (10b) are padding bits, only used by PrioritizedNode's underestimatedTotal field
+        // [RouteNode] bit 50 tracks whether THIS tile itself is damaging, unconditionally.
+        private const val DAMAGING_OFFSET = PARENT_TILE_OFFSET + PARENT_TILE_BIT_COUNT
+        // [RouteNode] bits 51-60 (10b) are also padding, only used by PrioritizedNode's
+        // underestimatedTotal field.
         // bits 61-62 (2b = 4turns) are the number of turns ended in damaging tiles.
         private const val DAMAGE_TILES_OFFSET = UNDERESTIMATED_TOTAL_OFFSET + UNDERESTIMATED_TOTAL_BIT_COUNT
         private const val DAMAGE_TILES_BIT_COUNT = 2
@@ -224,14 +248,11 @@ value class RouteNode(val bits: Long=0L) {
         private fun toParentClockDirBits(tile: Tile, parentTile: Tile): Long
             = (if (tile == parentTile) NO_PARENT_TILE_BITS else tile.tileMap.getNeighborTileClockPosition(tile, parentTile)/2L) shl PARENT_TILE_OFFSET
         @Pure
-        private fun toMoveToBits(canMoveTo: Boolean): Long
-            = if (canMoveTo) MOVE_TO_HI_MASK else 0L
-        @Pure
         private fun toMoveThisTurnBits(moveThisTurn: FixedPointMovement): Long
             = moveThisTurn.bits.toLong() shl MOVE_THIS_TURN_OFFSET
         @Pure
-        private fun toPbmMoveThisTurnBits(pbmMoveThisTurn: FixedPointMovement): Long
-            = pbmMoveThisTurn.bits.toLong() shl PBM_MOVE_THIS_TURN_OFFSET
+        private fun toMoveSinceStoppableBits(moveSinceStoppable: FixedPointMovement): Long
+            = moveSinceStoppable.bits.toLong() shl MOVE_SINCE_STOPPABLE_OFFSET
         @Readonly
         private fun toTileIdxBits(tile: Tile): Long
             = (tile.zeroBasedIndex.toLong() shl TILE_IDX_OFFSET)
@@ -241,6 +262,9 @@ value class RouteNode(val bits: Long=0L) {
         @Pure
         private fun toDamagingTilesBits(damagingTiles: Int): Long
             = (damagingTiles.toLong() shl DAMAGE_TILES_OFFSET)
+        @Pure
+        private fun toDamagingBits(damaging: Boolean): Long
+            = (if (damaging) 1L else 0L) shl DAMAGING_OFFSET
         @Pure
         private fun toRelationshipLevelBits(relationshipLevel: RelationshipLevel): Long
             = (MAX_RELATIONSHIP_LEVEL - relationshipLevel.ordinal).toLong() shl RELATIONSHIP_LEVEL_OFFSET
@@ -253,8 +277,8 @@ value class RouteNode(val bits: Long=0L) {
             MAX_MOVE_THIS_TURN,
             turn,
             tile,
-            false,
             MAX_DAMAGING_TILES,
+            false,
         )
         @Pure
         fun rootNode(tile: Tile, moveThisTurn: FixedPointMovement) = RouteNode(
@@ -264,8 +288,8 @@ value class RouteNode(val bits: Long=0L) {
             moveThisTurn,
             0,
             tile,
-            true,
             0,
+            false, // irrelevant: the root is never a candidate parentTile in pathAsListNoDamage
         )
     }
 }
@@ -475,7 +499,7 @@ internal class PathingMapCache private constructor(
             val tag =
                 if (node.turns == 0 && node.moveUsedThisTurn == FPM_ZERO) 'S'
                 else if (tile == destination) 'D'
-                else if (!node.endTurnWithoutMoreDamage) '*'
+                else if (!node.canStopOn) '*'
                 else ' '
             if (node.turns == Int.MAX_VALUE) // cannot move to this tile
                 format(" -/---%s", tag)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ ktxCore = "1.16.0"
 ktxRuntime = "2.10.3"
 desugar = "2.1.5"
 
+androidxCollection = "1.4.5"
+
 
 [libraries]
 #note - thanks to the subproject problem Studio won't properly recognize what is used or not:
@@ -69,6 +71,8 @@ clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt
 
 jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 jna-platform = { group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna" }
+
+androidx-collection = { group = "androidx.collection", name = "collection", version.ref = "androidxCollection" }
 
 android-ktx-core = { group = "androidx.core", name = "core-ktx", version.ref = "ktxCore" }
 android-desugar = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar" }

--- a/tests/src/com/unciv/logic/map/PathfindingTests.kt
+++ b/tests/src/com/unciv/logic/map/PathfindingTests.kt
@@ -246,6 +246,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_alliedCivilianAtEndOfTurn_doesEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Worker", civInfo, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
@@ -263,6 +264,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_neutralCivilianAtEndOfTurn_doesNotEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Worker", neutralCiv, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
@@ -280,6 +282,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_enemyCivilianAtEndOfTurn_doesEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Worker", barbarianCiv, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
@@ -296,6 +299,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_alliedMilitaryAtEndOfTurn_doesNotEndTurnOnMilitary() {
         verticalWall(2, {tile -> testGame.addUnit("Warrior", civInfo, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
@@ -313,6 +317,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_neutralMilitaryAtEndOfTurn_doesNotEndTurnOnMilitary() {
         verticalWall(2, {tile -> testGame.addUnit("Warrior", neutralCiv, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
@@ -330,6 +335,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_enemyMilitaryAtEndOfTurn_cannotPathThrough() {
         verticalWall(2, {tile -> testGame.addUnit("Warrior", barbarianCiv, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf<Tile>(), paths)
@@ -347,6 +353,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_alliedCityAtEndOfTurn_doesEndTurnOnCity() {
         verticalWall(2, {tile -> testGame.addCity(civInfo, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
@@ -381,6 +388,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_military_enemyCityAtEndOfTurn_cannotPathThrough() {
         verticalWall(2, {tile -> testGame.addCity(barbarianCiv, tile)})
+        testGame.addUnit("Warrior", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Warrior", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf<Tile>(), paths)
@@ -397,6 +405,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_alliedCivilivanAtEndOfTurn_doesNotEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Worker", civInfo, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
@@ -414,6 +423,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_neutralCivilivanAtEndOfTurn_doesNotEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Worker", neutralCiv, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
@@ -431,6 +441,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_enemyCivilivanAtEndOfTurn_doesNotEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Worker", barbarianCiv, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
@@ -447,6 +458,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_alliedMilitaryAtEndOfTurn_doesEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Warrior", civInfo, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
@@ -464,6 +476,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_neutralMilitaryAtEndOfTurn_doesNotEndTurnOnCivilian() {
         verticalWall(2, {tile -> testGame.addUnit("Warrior", neutralCiv, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(paths.toString(), listOf(1,3,4), paths.map { it.position.x })
@@ -481,6 +494,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_enemyMilitaryAtEndOfTurn_cannotPathThrough() {
         verticalWall(2, {tile -> testGame.addUnit("Warrior", barbarianCiv, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf<Tile>(), paths)
@@ -498,6 +512,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_alliedCityAtEndOfTurn_doesEndTurnOnCity() {
         verticalWall(2, {tile -> testGame.addCity(civInfo, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf(testGame.tileMap[2,2], testGame.tileMap[4,4]), paths)
@@ -532,6 +547,7 @@ class PathfindingTests(private val pathfindingAlgorithm: PathfindingAlgorithm) {
     @Test
     fun getShortestPath_civilian_enemyCityAtEndOfTurn_cannotPathThrough() {
         verticalWall(2, {tile -> testGame.addCity(barbarianCiv, tile)})
+        testGame.addUnit("Worker", civInfo, testGame.tileMap[1,1])
         val unit = testGame.addUnit("Worker", civInfo, originTile)
         val paths = unit.movement.getShortestPath(testGame.tileMap[4,4])
         assertEquals(listOf<Tile>(), paths)

--- a/tests/src/com/unciv/logic/map/PathingMapTest.kt
+++ b/tests/src/com/unciv/logic/map/PathingMapTest.kt
@@ -6,12 +6,14 @@ import com.unciv.logic.map.PathingMap.Companion.VERBOSE_PATHFINDING_LOGS
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.FixedPointMovement.Companion.fpmFromMovement
 import com.unciv.logic.map.FixedPointMovement.Companion.fpmFromFixedPointBits
+import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
 import com.unciv.testing.BaseTestRunner
 import com.unciv.testing.TestGame
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,7 +53,6 @@ class PathingMapTest {
         val attackRange = (1 shl 4) or 1 // 5 bits. value is 17
         val damagingTiles = 3
         val underestimatedTotal = fpmFromFixedPointBits((1 shl 13) or 1) //15 bits. value is 8193 aka 409.65move
-        val canMoveTo = true
 
         val node = RouteNode(
             tile,
@@ -60,19 +61,20 @@ class PathingMapTest {
             moveThisTurn,
             turns,
             parentTile,
-            canMoveTo,
-            damagingTiles
+            damagingTiles,
+            true
         )
 
         assertEquals(tile.zeroBasedIndex, node.tileIdx)
         assertEquals(tile, node.tile(testGame.tileMap))
         assertEquals(12, node.parentClockDir)
         assertEquals(parentTile, node.parentTile(testGame.tileMap))
-        assertEquals(true, node.canMoveTo)
+        assertEquals(false, node.canStopOn)
         assertEquals(moveThisTurn, node.moveUsedThisTurn)
-        assertEquals(pbmMoveThisTurn, node.pbmMoveThisTurn)
+        assertEquals(pbmMoveThisTurn, node.moveSinceStoppable)
         assertEquals(turns, node.turns)
         assertEquals(damagingTiles, node.damagingTiles)
+        assertEquals(false, node.endTurnWithoutMoreDamage)
         assertEquals(relationship, node.relationshipLevel)
         assertEquals(true, node.initialized)
 
@@ -85,7 +87,7 @@ class PathingMapTest {
         assertEquals(tile, reRouteNode.tile(testGame.tileMap))
         // PrioritizedNode drops parentTile
         assertEquals(moveThisTurn, reRouteNode.moveUsedThisTurn)
-        assertEquals(pbmMoveThisTurn, reRouteNode.pbmMoveThisTurn)
+        assertEquals(pbmMoveThisTurn, reRouteNode.moveSinceStoppable)
         assertEquals(turns, reRouteNode.turns)
         assertEquals(damagingTiles, reRouteNode.damagingTiles)
         assertEquals(relationship, reRouteNode.relationshipLevel)
@@ -180,20 +182,19 @@ class PathingMapTest {
             HexCoord(0, 8),
         ), path?.map { it.position })
         assertEquals("""
-        -4     -3     -2     -1     +0     +1     +2     +3     +4    
-  +8                                3/3.0D 4/3.0*  /      /      /    
-  +7                         4/3.0* 3/2.0* 3/2.0* 3/2.0* 3/3.0*  /    
-  +6                   /     3/2.0* 2/2.0* 2/2.0* 2/2.0* 3/3.0*  /    
-  +5            /     3/2.0* 2/2.0* 2/1.0  2/1.0* 2/2.0* 3/3.0* 3/1.0*
-  +4     /     3/3.0* 2/2.0* 2/1.0* 1/3.0  2/3.0* 2/3.0* 2/3.0* 3/1.0*
-  +3     /     3/3.0* 2/2.0* 2/3.0* 1/2.0* 1/2.0* 1/2.0* 1/3.0* 2/1.0*
-  +2     /     3/3.0* 2/3.0* 1/2.0* 0/2.0* 0/2.0* 0/2.0* 1/3.0* 2/1.0*
-  +1    3/1.0* 2/3.0* 1/2.0* 0/2.0* 0/1.0  0/1.0* 0/2.0* 1/3.0* 2/1.0*
-  +0    3/1.0* 1/3.0* 0/2.0* 0/1.0* 0/0.0S 0/1.0* 0/2.0* 1/3.0* 2/1.0*
-  -1    2/1.0* 1/3.0* 0/2.0* 0/1.0* 0/1.0* 0/2.0* 1/3.0* 2/1.0*  /    
-  -2    2/1.0* 1/3.0* 0/2.0* 0/2.0* 0/2.0* 1/3.0* 2/1.0*  /      /    
-  -3    2/1.0* 1/3.0* 1/3.0* 1/3.0* 1/3.0* 2/1.0*  /      /      /    
-  -4    2/1.0* 2/1.0* 2/1.0* 2/1.0* 2/1.0*  /      /      /      /    
+        -3     -2     -1     +0     +1     +2     +3    
+  +8                         3/3.0D 4/1.0   /      /    
+  +7                  4/1.0  3/2.0  3/2.0  3/2.0  3/1.0 
+  +6            /     3/2.0  2/2.0  2/2.0  2/2.0  3/1.0 
+  +5     /     3/2.0  2/2.0  2/1.0  2/1.0  2/2.0  3/1.0 
+  +4    3/1.0  2/2.0  2/1.0  1/3.0  2/1.0  2/2.0  3/1.0 
+  +3    3/1.0  2/2.0  2/1.0  1/2.0  1/2.0  1/2.0  2/1.0 
+  +2    3/1.0  2/2.0  1/2.0  0/2.0  0/2.0  0/2.0  1/1.0 
+  +1    3/1.0  1/2.0  0/2.0  0/1.0  0/1.0  0/2.0  1/1.0 
+  +0    2/1.0  0/2.0  0/1.0  0/0.0S 0/1.0  0/2.0  1/1.0 
+  -1    1/1.0  0/2.0  0/1.0  0/1.0  0/2.0  1/1.0   /    
+  -2    1/1.0  0/2.0  0/2.0  0/2.0  1/1.0   /      /    
+  -3    1/1.0  1/1.0  1/1.0  1/1.0   /      /      /    
 """, pathing.toDebugString(target))
         // And affirm cache
         assertEquals(path, pathing.getShortestPath(target)!!)
@@ -340,5 +341,165 @@ class PathingMapTest {
         assertEquals(expected, attackableTiles.map {it.position})
         // And affirm full recalculation using cached tiles has same result.
         assertEquals(expected, pathing.bfsAllMatchingTilesThisTurn { tile, _ -> tile.civilianUnit?.civ == civInfo}.map {it.position})
+    }
+
+    @Test
+    fun safeCacheIsPreferredOverDamageCacheWhenBothReachTargetEquallyFast() {
+        // Two routes of identical length from origin to target: one straight through a Mountain
+        // (damaging), one around through Plains (safe). The safe, damage-free route must win.
+        testGame.setTileTerrain(HexCoord(1, 0), "Mountain")
+        val civ = testGame.addCiv("Land units may cross [Mountain] tiles after the first [Great General] is earned")
+        civ.passThroughImpassableUnlocked = true
+        civ.passableImpassables.add("Mountain")
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 3
+        val unit = testGame.addUnit(baseUnit.name, civ, originTile)
+        val target = testGame.getTile(HexCoord(2, 0))
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val path = pathing.getShortestPath(target)
+
+        assertEquals(listOf(target), path)
+        val node = pathing.getCachedNode(target)
+        assertEquals(0, node.damagingTiles)
+    }
+
+    @Test
+    fun onlyRouteIsThroughDamage_stillFindsItViaDamageCache() {
+        // Everything is mountains except a corridor: origin, one Mountain, then the target. With
+        // only 1 movement, crossing the Mountain is unavoidable and forces ending a turn on it.
+        for (tile in testGame.tileMap.tileList) {
+            testGame.setTileTerrain(tile.position, "Mountain")
+        }
+        testGame.setTileTerrain(HexCoord(0, 0), "Plains")
+        testGame.setTileTerrain(HexCoord(2, 0), "Plains")
+        val civ = testGame.addCiv("Land units may cross [Mountain] tiles after the first [Great General] is earned")
+        civ.passThroughImpassableUnlocked = true
+        civ.passableImpassables.add("Mountain")
+
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 1
+        val unit = testGame.addUnit(baseUnit.name, civ, originTile)
+        val target = testGame.getTile(HexCoord(2, 0))
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val path = pathing.getShortestPath(target)
+
+        assertEquals(listOf(testGame.getTile(HexCoord(1,0)), target), path)
+        val node = pathing.getCachedNode(target)
+        assertEquals(1, node.damagingTiles)
+    }
+
+    @Test
+    fun chainOfMultipleDamagingTilesIsCrossedAndTallied() {
+        // Everything is mountains except a corridor with 3 consecutive Mountain tiles to cross,
+        // forced to stop on each one in turn (1 movement per turn).
+        for (tile in testGame.tileMap.tileList) {
+            testGame.setTileTerrain(tile.position, "Mountain")
+        }
+        testGame.setTileTerrain(HexCoord(0, 0), "Plains")
+        testGame.setTileTerrain(HexCoord(4, 0), "Plains")
+        val civ = testGame.addCiv("Land units may cross [Mountain] tiles after the first [Great General] is earned")
+        civ.passThroughImpassableUnlocked = true
+        civ.passableImpassables.add("Mountain")
+
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 1
+        val unit = testGame.addUnit(baseUnit.name, civ, originTile)
+        val target = testGame.getTile(HexCoord(4, 0))
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val path = pathing.getShortestPath(target)
+
+        assertEquals(listOf(
+            testGame.getTile(HexCoord(1, 0)),
+            testGame.getTile(HexCoord(2, 0)),
+            testGame.getTile(HexCoord(3, 0)),
+            target,
+        ), path)
+        val node = pathing.getCachedNode(target)
+        // Ending our turn there is the only option, crossing all 3 damaging tiles along the way.
+        assertEquals(3, node.damagingTiles)
+    }
+
+    @Test
+    fun occupiedTileDoesNotInterfereWithDamageAccounting() {
+        // The direct route is blocked by another unit; the detour crosses a Mountain instead.
+        // The two concepts (blocked-for-ending-turn vs damage) must not interfere with each other.
+        testGame.setTileTerrain(HexCoord(1, 0), "Grassland")
+        testGame.setTileTerrain(HexCoord(1, -1), "Mountain")
+        testGame.setTileTerrain(HexCoord(2, -1), "Grassland")
+        testGame.setTileTerrain(HexCoord(2, 0), "Grassland")
+        val civ = testGame.addCiv("Land units may cross [Mountain] tiles after the first [Great General] is earned")
+        civ.passThroughImpassableUnlocked = true
+        civ.passableImpassables.add("Mountain")
+        val blockerCiv = testGame.addCiv()
+        testGame.addUnit("Warrior", blockerCiv, testGame.getTile(HexCoord(1, 0)))
+
+        val baseUnit = testGame.createBaseUnit()
+        baseUnit.movement = 3
+        val unit = testGame.addUnit(baseUnit.name, civ, originTile)
+        val target = testGame.getTile(HexCoord(2, 0))
+
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val path = pathing.getShortestPath(target)
+
+        assertEquals(listOf(target), path)
+    }
+
+    @Test
+    fun canRetroactivelyPauseOnADamagingTileToPushPastAnUnstoppableTileAfterIt() {
+        for (tile in testGame.tileMap.tileList) {
+            testGame.setTileTerrain(tile.position, "Ocean")
+        }
+        testGame.setTileTerrain(HexCoord(0, 0), "Plains")
+        testGame.setTileTerrain(HexCoord(0, 1), "Mountain")
+        testGame.setTileTerrain(HexCoord(0, 2), "Plains")
+        testGame.setTileTerrain(HexCoord(0, 3), "Plains")
+        civInfo.passThroughImpassableUnlocked = true
+        civInfo.passableImpassables.add("Mountain")
+        testGame.addUnit("Warrior", civInfo, testGame.getTile(HexCoord(0, 2)))
+
+        val unit = testGame.addUnit("Warrior", civInfo, originTile)
+        unit.currentMovement = 2f
+        val target = testGame.getTile(HexCoord(0, 3))
+        val pathing = PathingMap.createUnitPathingMap(unit)
+        val path = pathing.getShortestPath(target)
+
+        assertEquals(listOf(testGame.getTile(HexCoord(0, 1)), target), path)
+        assertEquals(1, pathing.getCachedNode(target).damagingTiles)
+    }
+
+    @Test
+    fun manyWarriorsConvergingOnRoad_doNotQueueSingleFile() {
+        for (x in -8..8)
+            testGame.getTile(HexCoord(x, 0)).setRoadStatus(RoadStatus.Road, civInfo)
+        for (tile in testGame.tileMap.tileList)
+            tile.setExplored(civInfo, true)
+        //make 18 warriors between [-8,-8] and [-7,0]
+        val warriors = ArrayList<MapUnit>()
+        for (tile in testGame.tileMap.tileList) {
+            if (tile.position.x < -6 && tile.position.y<1)
+                warriors.add(testGame.addUnit("Warrior", civInfo, tile))
+        }
+        assertEquals(18, warriors.size)
+        // tell all 19 warriors to move 15 tiles to the right, and 8 up.
+        val targets = warriors.map {
+            val x = it.getTile().position.x+15
+            val y = it.getTile().position.y+8
+            testGame.tileMap[x,y]
+        }
+        // Ideally, moving these 15 tiles takes them 8 turns
+        repeat(8) {
+            for (warrior in warriors)
+                warrior.currentMovement = 2f
+            for ((warrior, target) in warriors.zip(targets))
+                warrior.movement.headTowards(target)
+        }
+        // Ensure all warriors moved more than halfway, and didn't end up single-file
+        for (warrior in warriors) {
+            val position = warrior.getTile().position
+            assertTrue("$warrior at $position should have moved to x>0", position.x > 0)
+        }
     }
 }


### PR DESCRIPTION
PathingMapAStarPathfinder:
- navigating around unstoppable tiles (allies) was wrong, and units would move single file. pauseBeforeMountain logic was also wrong, causing units to waste movement in edge cases. However, pauseBeforeMountain logic was *almost* right for moving around allies, so now that retroactive pause movement logic applies to unstoppable tiles, and new logic handles damaging tiles.

Claude-Session: https://claude.ai/code/session_01A9mmUjRLBiynYRrAYFCVwS