### PR TITLE
AStar#getMovementToTilesAtPosition correctly finds all tiles

### DIFF
--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -212,7 +212,7 @@ class PathingMap(
         if (!cache.nodesNeedingNeighbors.isEmpty) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
                 Log.debug("#getMovementToTilesAtPosition calculcating for $debugMapType $debugId")
-            bfsStepUntilDestination(cache, { _,node -> node.turns>0 && node.canMoveTo }, 1)
+            aStarStepUntilDestination(cache, null, 1)
         }
         getTilesSameTurn(cache)
         return tilesSameTurn
@@ -262,7 +262,7 @@ class PathingMap(
         bfsStepUntilDestination(fetchCache(), searchPredicate, timeLimitTurns)
         return results
     }
-    fun bfsAllMatchingTilesThisTurn(tilePredicate: EndSearchPredicate) = bfsAllMatchingTiles(0, tilePredicate)
+    fun bfsAllMatchingTilesThisTurn(tilePredicate: EndSearchPredicate) = bfsAllMatchingTiles(1, tilePredicate)
 
     private fun getTilesSameTurn(cache: PathingMapCache) {
         val tilesSameTurn = cache.tilesSameTurn

--- a/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
+++ b/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
@@ -93,16 +93,20 @@ internal class AStarPathfinder(
      * Separate init function so that this work can occur outside 
      */
     init {
+        require(timeLimitTurns > 0)
         require(timeLimitTurns < MAX_TURNS)
         // Add all the initial tiles to check to the priority queue
         cache.nodesNeedingNeighbors.forEachSetBit {
             val node = RouteNode(routeNodes[it])
-            if (node.initialized && node.turns <= timeLimitTurns) {
+            if (node.initialized && moveFromLessThanTimeLimit(node)) {
                 todo.add(PrioritizedNode(node, calculateUnderestimatedMovement(node)).bits)
                 tilesInTodo.put(it, node.damagingTiles)
             }
         }
     }
+    
+    private fun moveFromLessThanTimeLimit(node: RouteNode) = 
+        node.turns < timeLimitTurns-1 || (node.turns == timeLimitTurns-1 && node.moveUsedThisTurn < fpmFullMovement)
 
     // Heuristics for not-yet-calculated tiles here based on distance to target        
     @Readonly
@@ -137,7 +141,7 @@ internal class AStarPathfinder(
         val alreadyCalculatedNode = RouteNode(routeNodes[neighborTile.zeroBasedIndex])
         // If another thread already calculated the best route, then we can queue it and move on
         if (alreadyCalculatedNode.initialized && alreadyCalculatedNode.damagingTiles <= currentNode.damagingTiles) {
-            if (alreadyCalculatedNode.turns < timeLimitTurns)
+            if (moveFromLessThanTimeLimit(alreadyCalculatedNode))
                 todo.add(PrioritizedNode(alreadyCalculatedNode, calculateUnderestimatedMovement(alreadyCalculatedNode)).bits)
             tilesInTodo.put(neighborTile.zeroBasedIndex, alreadyCalculatedNode.damagingTiles)
             cache.nodesNeedingNeighbors.set(neighborTile.zeroBasedIndex)
@@ -226,7 +230,7 @@ internal class AStarPathfinder(
             } else {
                 val newNode = calculateNeighborNode(currentNode, neighborTile) ?: return null // calculate each neighbor
                 routeNodes[neighborTile.zeroBasedIndex] = newNode.bits
-                if (newNode.turns < timeLimitTurns)
+                if (moveFromLessThanTimeLimit(newNode))
                     todo.add(PrioritizedNode(newNode, calculateUnderestimatedMovement(newNode)).bits)
                 tilesInTodo.put(neighborTile.zeroBasedIndex, newNode.damagingTiles)
                 cache.nodesNeedingNeighbors.set(neighborTile.zeroBasedIndex)

--- a/tests/src/com/unciv/logic/map/PathingMapTest.kt
+++ b/tests/src/com/unciv/logic/map/PathingMapTest.kt
@@ -214,7 +214,7 @@ class PathingMapTest {
 //        assertNotEquals(path.toString(), path.firstEntry(), path.lastEntry())
         assertEquals("""
         -2     -1     +0     +1     +2    
-  +2     /      /     1/1.0  0/2.0  0/2.0 
+  +2     /      /      /     0/2.0  0/2.0 
   +1     /     0/2.0  0/2.0  0/1.0  0/2.0 
   +0    0/2.0  0/1.0  0/0.0S 0/1.0  0/2.0 
   -1    0/2.0  0/1.0  0/1.0  0/2.0   /    
@@ -282,7 +282,7 @@ class PathingMapTest {
     }
     
     @Test
-    fun findMatchingTilesInAttackRange_considersAttackRange() {
+    fun findMatchingTilesInAttackRange_ignoresAttackRange() {
         val evemyCiv = testGame.addBarbarianCiv()
         // Right side all hills, left side all roads.  A line of enemy warriors just north.
         for (tile in testGame.tileMap.tileList) {
@@ -299,30 +299,27 @@ class PathingMapTest {
         val pathing = PathingMap.createUnitPathingMap(unit)
         val attackableTiles = pathing.bfsAllMatchingTiles(1) { tile, _ -> tile.militaryUnit?.civ == evemyCiv}
         
-        // cant hit enemy at -5,2 because unit would have no movement left.
+        // cant hit enemy at -4,2 or 3,2 because unit would have no movement left.
         val expected = listOf(
-            HexCoord(-4,2),
             HexCoord(-3,2),
             HexCoord(-2,2),
             HexCoord(-1,2),
             HexCoord(0,2),
             HexCoord(1,2),
             HexCoord(2,2),
-            HexCoord(3,2),
         )
         val actual = attackableTiles.map {it.position}.sortedWith { l, r -> if (l.x != r.x) l.x.compareTo(r.x) else l.y.compareTo(r.y) }
         assertEquals(expected, actual)
         assertEquals("""
-        -6     -5     -4     -3     -2     -1     +0     +1     +2     +3    
-  +2     /      /     0/17.0* 0/17.0* 0/17.0* 0/17.0* 0/17.0* 0/17.0* 0/17.0* 0/17.0*
-  +1     /     1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/2.0  0/3.0  1/2.0 
-  +0    1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/0.0S 0/2.0  0/3.0  1/2.0 
-  -1    1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/1.0  0/3.0  1/2.0   /    
-  -2    1/0.5  0/3.0  0/2.5  0/2.0  0/1.5  0/1.5  0/2.0  0/3.0  1/2.0   /    
-  -3    1/0.5  0/3.0  0/2.5  0/2.0  0/2.0  0/2.0  0/3.0  1/2.0   /      /    
-  -4    1/0.5  0/3.0  0/2.5  0/2.5  0/2.5  0/2.5  0/3.0  1/2.0   /      /    
-  -5    1/0.5  0/3.0  0/3.0  0/3.0  0/3.0  0/3.0  1/1.0   /      /      /    
-  -6    1/0.5  1/0.5  1/0.5  1/0.5  1/0.5  1/0.5   /      /      /           
+        -5     -4     -3     -2     -1     +0     +1     +2    
+  +2     /      /     0/17.0* 0/17.0* 0/17.0* 0/17.0* 0/17.0* 0/17.0*
+  +1     /     0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/2.0  0/3.0 
+  +0    0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/0.0S 0/2.0  0/3.0 
+  -1    0/3.0  0/2.5  0/2.0  0/1.5  0/1.0  0/1.0  0/3.0   /    
+  -2    0/3.0  0/2.5  0/2.0  0/1.5  0/1.5  0/2.0  0/3.0   /    
+  -3    0/3.0  0/2.5  0/2.0  0/2.0  0/2.0  0/3.0   /      /    
+  -4    0/3.0  0/2.5  0/2.5  0/2.5  0/2.5  0/3.0   /      /    
+  -5    0/3.0  0/3.0  0/3.0  0/3.0  0/3.0   /      /      /    
 """, pathing.toDebugString())
         // And affirm full recalculation using cached tiles has same result.
         val actual2 = attackableTiles.map {it.position}.sortedWith { l, r -> if (l.x != r.x) l.x.compareTo(r.x) else l.y.compareTo(r.y) }


### PR DESCRIPTION
Previously, it would find *A* shortest path to the next turn, but when routes were equal, it could miss some edge tiles. If a later path search calculated those tiles, then subsequent calls to getMovementToTilesAtPosition would return correct results.

Solution was to simply stepUntilDestination with no destination with a 1-turn timeout.

This also would cause it to find one extra tile in all directions, but I've tightened the bounds on PathingMapAStarPathfinder#moveFromLessThanTimeLimit, so it no longer calculates tiles below the turn limit that have run out of movement. This prevents it from calculating the one extra tile in all directions.

This also revealed that the findMatchingTilesInAttackRange_considersAttackRange was (A) incorrectly listing enemies that we'd run out of movement and thus be unable to attack, and also (B) that it was ignoring attack range. I've fixed the expected results, and renamed it.

Extending PathingMap to be able to consider attack range is still an aspiration, and not yet built.

This addresses https://github.com/yairm210/Unciv/issues/15165, and https://github.com/yairm210/Unciv/issues/15179.  And *probably* https://github.com/yairm210/Unciv/issues/14711, but it's hard to be certain.