### PR TITLE
Fix missing translation entries

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1473,6 +1473,10 @@ Add or move to the top in all cities =
 Remove from the queue in all cities = 
 Disable = 
 Enable = 
+Disable in this city = 
+Enable in this city = 
+Disable in all cities = 
+Enable in all cities = 
 
 # Specialized Popups - Ask for text or numbers, file picker
 


### PR DESCRIPTION
In City Screen, `Disable in this city`, `Enable in this city`, `Disable in all cities`, `Enable in all cities` special orders (previously, entries were only `Enable` and `Disable` globally) are not translatable.

:exclamation::exclamation:
Not sure it is the good way to fix this, as `Enable`,  `Disable`, `in this city`, `in all cities` exist in the stringtables as **individual** entries. Maybe these translation entries are not correctly combined in the code itself.
:exclamation::exclamation:

Screenshots:

Before
<img width="396" height="158" alt="before" src="https://github.com/user-attachments/assets/3be5f89b-f57c-4ef4-adb9-ba2cb2924184" />

After
<img width="404" height="161" alt="after" src="https://github.com/user-attachments/assets/74721025-7cf1-4fd3-9de6-365d0815f6f7" />

