### PR TITLE
(MP) Record client version of latest turn submitted by each civ

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -141,6 +141,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     var totalTurnTimeSeconds = 0
     /** To calculate average turn time, we only count turns when controlled by a human. Additionally, offers backward compatibility. */
     var turnsPlayedAsHuman = 0
+    var lastTurnProcessedWithVersion: Version? = null
     
     /** The Civ's gold reserves. Public get, private set - please use [addGold] method to modify. */
     var gold = 0

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -309,6 +309,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         toReturn.playerMinutesBeforeForceResign = playerMinutesBeforeForceResign
         toReturn.totalTurnTimeSeconds = totalTurnTimeSeconds
         toReturn.turnsPlayedAsHuman = turnsPlayedAsHuman
+        toReturn.lastTurnProcessedWithVersion = lastTurnProcessedWithVersion
         toReturn.civName = civName
         toReturn.civID = civID
         toReturn.tech = tech.clone()

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -343,6 +343,8 @@ class TurnManager(val civInfo: Civilization) {
         civInfo.resetMilitaryMightCache()
 
         updateWinningCiv() // Maybe we did something this turn to win
+        
+        civInfo.lastTurnProcessedWithVersion = UncivGame.VERSION
     }
 
     fun updateWinningCiv() {


### PR DESCRIPTION
I have a long running multiplayer game with 25 participants. When there is an update that introduces important features or affects game balance, I would like the ability to check if anyone has forgotten to update their game.
This feature also helps with debugging if some players are experiencing issues while others do not (such as the recent issue with stat history not being recorded).

(No dedicated UI space for this, but can be found in the savefile.)