### PR TITLE
Allow assigning "key" mappings to extra mouse buttons

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -37,6 +37,7 @@ import com.unciv.ui.components.extensions.GdxKeyCodeFixes.valueOf
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.ActorAttachments
 import com.unciv.ui.components.input.KeyCharAndCode
+import com.unciv.ui.components.input.VirtualMouseButtonKeys
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onChange
@@ -473,6 +474,7 @@ object GdxKeyCodeFixes {
         DEL -> "Del"  // Gdx would name this "Forward Delete"
         BACKSPACE -> "Backspace"  // Gdx would name this "Delete"
         else -> Input.Keys.toString(keyCode)
+            ?: VirtualMouseButtonKeys.fromKey(keyCode)?.label
             ?: ""
     }
 
@@ -481,7 +483,8 @@ object GdxKeyCodeFixes {
         "Del" -> DEL
         "Backspace" -> BACKSPACE
         else -> {
-            val code = Input.Keys.valueOf(name)
+            val code = VirtualMouseButtonKeys.fromLabel(name)?.keyCode
+                ?: Input.Keys.valueOf(name)
             if (code == -1) UNKNOWN else code
         }
     }

--- a/core/src/com/unciv/ui/components/input/VirtualMouseButtonKeys.kt
+++ b/core/src/com/unciv/ui/components/input/VirtualMouseButtonKeys.kt
@@ -1,0 +1,28 @@
+package com.unciv.ui.components.input
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.Input
+import com.unciv.ui.components.extensions.GdxKeyCodeFixes
+import com.unciv.ui.screens.basescreen.UncivStage
+
+/**
+ *  Used to enable mapping unused mouse buttons to virtual keys, and allowing users to assign them as keyboard bindings
+ *
+ *  * [UncivStage] implements mapping to virtual keystrokes
+ *  * [GdxKeyCodeFixes] handles visualization for the key bindings options page
+ */
+enum class VirtualMouseButtonKeys(val button: Int, val keyCode: Int, val label: String) {
+    Middle(Input.Buttons.MIDDLE, 200, "Mouse middle button"),
+    Back(Input.Buttons.BACK, 201, "Mouse back button"),
+    Forward(Input.Buttons.FORWARD, 202, "Mouse forward button"),
+    ;
+
+    fun keyDown() = Gdx.input.inputProcessor?.keyDown(keyCode)
+    fun keyUp() = Gdx.input.inputProcessor?.keyUp(keyCode)
+
+    companion object {
+        fun fromButton(button: Int) = entries.firstOrNull { it.button == button }
+        fun fromKey(keyCode: Int) = entries.firstOrNull { it.keyCode == keyCode }
+        fun fromLabel(label: String) = entries.firstOrNull { it.label == label }
+    }
+}

--- a/core/src/com/unciv/ui/screens/basescreen/UncivStage.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/UncivStage.kt
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.utils.viewport.Viewport
 import com.unciv.logic.event.Event
 import com.unciv.logic.event.EventBus
+import com.unciv.ui.components.input.VirtualMouseButtonKeys
 import com.unciv.ui.crashhandling.wrapCrashHandling
 import com.unciv.ui.crashhandling.wrapCrashHandlingUnit
 import com.unciv.ui.screens.basescreen.BaseScreen.Companion.enableSceneDebug
@@ -88,14 +89,17 @@ class UncivStage(viewport: Viewport) : Stage(viewport, getBatch()) {
 
     override fun touchDown(screenX: Int, screenY: Int, pointer: Int, button: Int): Boolean {
         mouseOverDebugImpl?.touchDown(this, screenX, screenY, pointer, button)
+        if (VirtualMouseButtonKeys.fromButton(button)?.keyDown() == true) return true
         return { super.touchDown(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
     }
 
     override fun touchDragged(screenX: Int, screenY: Int, pointer: Int) =
             { super.touchDragged(screenX, screenY, pointer) }.wrapCrashHandling()() ?: true
 
-    override fun touchUp(screenX: Int, screenY: Int, pointer: Int, button: Int) =
-            { super.touchUp(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
+    override fun touchUp(screenX: Int, screenY: Int, pointer: Int, button: Int): Boolean {
+        if (VirtualMouseButtonKeys.fromButton(button)?.keyUp() == true) return true
+        return { super.touchUp(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
+    }
 
     override fun mouseMoved(screenX: Int, screenY: Int) =
             { super.mouseMoved(screenX, screenY) }.wrapCrashHandling()() ?: true


### PR DESCRIPTION
Feature listed as "alternate" in #15483

Notable:
- GLFW already limits possible mouse buttons to a max of 8, assigning a const to each. If mad gamer mouses have more, they're dropped here.
- `DefaultLwjgl3Input` reduces that further to only 5, dropping the rest in `toGdxButton(glfwButton)`. If we were manic to support more, we'd have to subclass and inject that class...

Happily, that limits testing, and yay all three extra "keys" work.

#### Question:
That `GdxKeyCodeFixes` object really doesn't belong in components.extensions, it belongs in components.input just as the four extensions on `Input` below it - shall I include a refactor here?