### PR TITLE
fix: reject ruleset objects that replace themselves

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -163,6 +163,8 @@ open class RulesetValidator protected constructor(
 
         if (building.replaces != null && building.uniqueTo == null)
             lines.add("${building.name} should replace ${building.replaces} but does not have uniqueTo assigned!")
+        if (building.replaces == building.name)
+            lines.add("${building.name} replaces itself!")
     }
 
     protected open fun addCityStateTypeErrors(lines: RulesetErrorList) {
@@ -246,6 +248,8 @@ open class RulesetValidator protected constructor(
         for (improvement in ruleset.tileImprovements.values) {
             if (improvement.replaces != null && improvement.uniqueTo == null)
                 lines.add("${improvement.name} should replace ${improvement.replaces} but does not have uniqueTo assigned!")
+            if (improvement.replaces == improvement.name)
+                lines.add("${improvement.name} replaces itself!")
             if (improvement.terrainsCanBeBuiltOn.isEmpty()
                 && !improvement.hasUnique(UniqueType.CanOnlyImproveResource)
                 && !improvement.hasUnique(UniqueType.Unbuildable)
@@ -491,6 +495,8 @@ open class RulesetValidator protected constructor(
 
         if (unit.replaces != null && unit.uniqueTo == null)
             lines.add("${unit.name} should replace ${unit.replaces} but does not have uniqueTo assigned!")
+        if (unit.replaces == unit.name)
+            lines.add("${unit.name} replaces itself!")
 
         if (unit.isMilitary && unit.strength == 0)  // Should only match ranged units with 0 strength
             lines.add("${unit.name} is a military unit but has no assigned strength!", sourceObject = unit)

--- a/tests/src/com/unciv/uniques/RulesetValidatorTests.kt
+++ b/tests/src/com/unciv/uniques/RulesetValidatorTests.kt
@@ -32,6 +32,76 @@ class RulesetValidatorTests {
         }
     }
 
+    private fun hasSelfReplacementError(game: TestGame, objectName: String): Boolean {
+        return game.ruleset.getErrorList().any {
+            it.errorSeverityToReport == RulesetErrorSeverity.Error
+                && it.text == "$objectName replaces itself!"
+        }
+    }
+
+    @Test
+    fun `ruleset validator rejects building that replaces itself`() {
+        val game = TestGame()
+        val building = game.createBuilding().apply { uniqueTo = "Test nation" }
+        building.replaces = building.name
+
+        assertTrue(hasSelfReplacementError(game, building.name))
+    }
+
+    @Test
+    fun `ruleset validator accepts building that replaces another building`() {
+        val game = TestGame()
+        val replacedBuilding = game.createBuilding()
+        val replacementBuilding = game.createBuilding().apply {
+            replaces = replacedBuilding.name
+            uniqueTo = "Test nation"
+        }
+
+        assertFalse(hasSelfReplacementError(game, replacementBuilding.name))
+    }
+
+    @Test
+    fun `ruleset validator rejects unit that replaces itself`() {
+        val game = TestGame()
+        val unit = game.createBaseUnit().apply { uniqueTo = "Test nation" }
+        unit.replaces = unit.name
+
+        assertTrue(hasSelfReplacementError(game, unit.name))
+    }
+
+    @Test
+    fun `ruleset validator accepts unit that replaces another unit`() {
+        val game = TestGame()
+        val replacedUnit = game.createBaseUnit()
+        val replacementUnit = game.createBaseUnit().apply {
+            replaces = replacedUnit.name
+            uniqueTo = "Test nation"
+        }
+
+        assertFalse(hasSelfReplacementError(game, replacementUnit.name))
+    }
+
+    @Test
+    fun `ruleset validator rejects tile improvement that replaces itself`() {
+        val game = TestGame()
+        val improvement = game.createTileImprovement().apply { uniqueTo = "Test nation" }
+        improvement.replaces = improvement.name
+
+        assertTrue(hasSelfReplacementError(game, improvement.name))
+    }
+
+    @Test
+    fun `ruleset validator accepts tile improvement that replaces another improvement`() {
+        val game = TestGame()
+        val replacedImprovement = game.createTileImprovement()
+        val replacementImprovement = game.createTileImprovement().apply {
+            replaces = replacedImprovement.name
+            uniqueTo = "Test nation"
+        }
+
+        assertFalse(hasSelfReplacementError(game, replacementImprovement.name))
+    }
+
     @Test
     fun `ruleset validator warns about spy name collision with ruleset object`() {
         val game = TestGame()


### PR DESCRIPTION
Extend the existing replacement validation in `RulesetValidator` for buildings, units, and tile improvements so an object whose `replaces` value equals its own name produces a ruleset error before gameplay initialization. A mod can define a building whose `replaces` value is its own name, which passes ruleset validation but later enters a recursive replacement loop when starting a game.

A building with `replaces` equal to its own name is reported as an error by the ruleset validator without entering replacement resolution; A base unit with `replaces` equal to its own name is reported as an error by the ruleset validator.

Fixes #15474
