### PR TITLE
PathingMap cleanup and linting

### DIFF
--- a/core/src/com/unciv/logic/map/PathingMap.kt
+++ b/core/src/com/unciv/logic/map/PathingMap.kt
@@ -156,7 +156,7 @@ class PathingMap(
         val targetNode = RouteNode(cache.routeNodes[destination.zeroBasedIndex])
         if (!targetNode.initialized  && !cache.nodesNeedingNeighbors.isEmpty) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#getShortestPath(${destination.position}) calculcating for $debugMapType $debugId")
+                Log.debug("#getShortestPath(${destination.position}) calculating for $debugMapType $debugId")
             aStarStepUntilDestination(cache, destination, maxTurns)
         }
         val bestTarget =  RouteNode(cache.routeNodes[destination.zeroBasedIndex])
@@ -211,7 +211,7 @@ class PathingMap(
         // include enemies we would otherwise reach this turn.
         if (!cache.nodesNeedingNeighbors.isEmpty) {
             if (VERBOSE_PATHFINDING_LOGS == cache.key.startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#getMovementToTilesAtPosition calculcating for $debugMapType $debugId")
+                Log.debug("#getMovementToTilesAtPosition calculating for $debugMapType $debugId")
             aStarStepUntilDestination(cache, null, 1)
         }
         getTilesSameTurn(cache)

--- a/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
+++ b/core/src/com/unciv/logic/map/PathingMapAStarPathfinder.kt
@@ -171,50 +171,61 @@ internal class AStarPathfinder(
         val newUsedMovement = (currentNode.moveUsedThisTurn + cost).coerceAtMost(fpmFullMovement)
         val canMoveTo = currentNode.turns > 0 || moveToPredicate(neighborTile)
         val endTurnThereDamage = endTurnDamage(neighborTile).coerceAtMost(1)
-        val newMountainMovement =
-            (if (currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0) cost // first entering mountains
-            else if (!currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0) currentNode.pbmMoveThisTurn + cost
-            else FPM_ZERO // ignored in this case
-                ).coerceAtMost(fpmFullMovement)
+        val newMountainMovement = when {
+                currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0 -> cost // first entering mountains
+                !currentNode.endTurnWithoutMoreDamage && endTurnThereDamage > 0 -> currentNode.pbmMoveThisTurn + cost
+                else ->FPM_ZERO // ignored in this case
+            }.coerceAtMost(fpmFullMovement)
         val thisTurnPassThroughOrSafeEndTurn = (newUsedMovement < fpmFullMovement) || (canMoveTo && endTurnThereDamage == 0)
         val nextTurnPassThroughOrEndTurn = (newUsedMovement < fpmFullMovement) || canMoveTo
         val relationship = relationshipLevel(neighborTile)
-        
+
+        fun log(verb: String, context: String) {
+            if (VERBOSE_PATHFINDING_LOGS != startingPoint && VERBOSE_PATHFINDING_LOGS != ALWAYS_LOG) return
+            // Use printf style formatting, not kotlin templates, late vs. early, potentially wasted evaluation
+            Log.debug(
+                "#calculateAndQueue %s %s %s %s, for %s %s (%s)",
+                currentTile.position, verb, neighborTile.position, context,
+                debugMapType, debugId, canMoveTo
+            )
+        }
+        fun newNode(
+            pauseBeforeMountainMove: FixedPointMovement, moveThisTurn: FixedPointMovement,
+            turnDelta: Int, newDamagingTiles: Int = damagingTiles
+        ) = RouteNode(
+            neighborTile, relationship, pauseBeforeMountainMove, moveThisTurn,
+            currentNode.turns + turnDelta,  currentTile, canMoveTo, newDamagingTiles
+        )
         if (currentNode.moveUsedThisTurn < fpmFullMovement  && thisTurnPassThroughOrSafeEndTurn) {
             // if we can move to the next tile, and then either end our turn safely or move away, then we do so.
             if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} for same turn, for $debugMapType $debugId")
-            return RouteNode(neighborTile, relationship, newMountainMovement, newUsedMovement, currentNode.turns,  currentTile, canMoveTo, damagingTiles)
+                log("queuing", "for same turn")
+            return newNode(newMountainMovement, newUsedMovement, 0)
         } else if (currentNode.endTurnWithoutMoreDamage && currentNode.canMoveTo && nextTurnPassThroughOrEndTurn) {
             // If we can safely end our turn on the current tile, and then either end our turn or move away, then we do so.
-            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} for next turn, for $debugMapType $debugId ($canMoveTo)")
-            return RouteNode(neighborTile, relationship, newMountainMovement, cost, currentNode.turns + 1, currentTile, canMoveTo, damagingTiles)
+            log("queuing", "for next turn")
+            return newNode(newMountainMovement, cost, 1)
         } else if (currentNode.endTurnWithoutMoreDamage && currentNode.canMoveTo && !canMoveTo) {
             // Cannot end our turn on the next tile, nor pass through it. Possibly because it's occupied by a unit.
             // Classic #getDistanceToTiles requires we populate the node, so populate it, but do not return it.
-            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} stubbing ${neighborTile.position} as occupied, for $debugMapType $debugId (false)")
-            val occupiedNode =  RouteNode(neighborTile, relationship, newMountainMovement, cost, currentNode.turns+1, currentTile, canMoveTo, damagingTiles)
+            log("stubbing", "as occupied")
+            val occupiedNode = newNode(newMountainMovement, cost, 1)
             routeNodes[neighborTile.zeroBasedIndex] = occupiedNode.bits
-            cache.addedNeighborNodes.set(neighborTile.zeroBasedIndex)
             cache.addedNeighborNodes.clear(neighborTile.zeroBasedIndex)
             return null
         } else if (currentNode.pbmMoveThisTurn < fpmFullMovement) {
             // If we could have moved here if we'd paused before entering mountains, then
             // pretend we paused before entering the mountains.
-            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with retroactive pause before mountains, for $debugMapType $debugId ($canMoveTo)")
-            return RouteNode(neighborTile, relationship, newMountainMovement, newMountainMovement, currentNode.turns + 1, currentTile, canMoveTo, damagingTiles)
+            log("queuing", "with retroactive pause before mountains")
+            return newNode(newMountainMovement, newMountainMovement, 1)
         } else {
             // Ending our turn here takes damage. We'll add the neighbor tile, but the damage
-            // means it's neighbors will be calculated at a super low priority.
+            // means its neighbors will be calculated at a super low priority.
             // In the meantime, another tile might find a route here that doesn't require taking damage,
             // which is the ONLY scenario where a tile can get recalculated.
-            val newDamageTiles = (damagingTiles + endTurnThereDamage).coerceAtMost(MAX_DAMAGING_TILES)
-            if (VERBOSE_PATHFINDING_LOGS == startingPoint || VERBOSE_PATHFINDING_LOGS == ALWAYS_LOG)
-                Log.debug("#calculateAndQueue ${currentTile.position} queing ${neighborTile.position} with taking damage, for $debugMapType $debugId ($canMoveTo)")
-            return RouteNode(neighborTile, relationship, cost, cost, currentNode.turns + 1, currentTile, canMoveTo, newDamageTiles)
+            val newDamageTiles = (damagingTiles + endTurnThereDamage).coerceAtMost(RouteNode.MAX_DAMAGING_TILES)
+            log("queuing", "with taking damage")
+            return newNode(cost, cost, 1, newDamageTiles)
         }
     }
 

--- a/core/src/com/unciv/logic/map/PathingMapCache.kt
+++ b/core/src/com/unciv/logic/map/PathingMapCache.kt
@@ -270,34 +270,56 @@ value class RouteNode(val bits: Long=0L) {
     }
 }
 
+/**
+ * ### Fixed-point movement value (base 30) for pathfinding, avoiding heap allocations.
+ * 
+ * This class represents movement distances using fixed-point arithmetic with a scaling
+ * base of 30, meaning 1.0f movement = 30 internal units. This allows integer arithmetic
+ * without floating-point overhead during A* pathfinding.
+ *
+ * #### Constraint:
+ * FPM values are constrained to a few bits when packed into routing node structures
+ * (see [RouteNode.pbmMoveThisTurn]: 9 bits, [RouteNode.moveUsedThisTurn]: 9 bits, [PrioritizedNode.underestimatedTotal]: 14 bits).
+ * The internal `bits` field must fit within [0, 16384) for multi-turn movement costs, or [0, 512) for single-turn costs.
+ * Valid multi-turn movement values therefore range from 0.0f to 546.1f, and single-turn ones from 0f to 17.03333f.
+ *
+ * #### Rounding:
+ * Non-integer Float -> FixedPointMovement rounds to nearest 1/30th via HALF_UP.
+ * FixedPointMovement -> Float holds the closest value that Float supports, which is *never* exact.
+ * Ergo, FPM->Float->FPM round trips losslessly, but Float->FPM->Float will be rounded to a value 
+ * extremely close to a multiple of 1/30th.
+ *
+ * @property bits The internal fixed-point representation (0 to 16384 exclusive).
+ */
 @JvmInline
 value class FixedPointMovement private constructor(val bits: Int) {
+    // Not all of these are currently used, but are present to ensure correctnes for future usage.
+    // Operator coverage is complete for "fpm" on the left, but intentionally incomplete for Inf/Float on the left.
     @Pure operator fun plus(other: FixedPointMovement) = FixedPointMovement(bits + other.bits)
     @Pure operator fun plus(value: Int) = FixedPointMovement(bits + value * MOVE_SPEED_BASE)
     @Pure operator fun plus(value: Float) = FixedPointMovement(bits + fpmFromMovement(value).bits)
     @Pure operator fun minus(other: FixedPointMovement) = FixedPointMovement(bits - other.bits)
     @Pure operator fun minus(value: Int) = FixedPointMovement(bits - value * MOVE_SPEED_BASE)
     @Pure operator fun minus(value: Float) = FixedPointMovement(bits - fpmFromMovement(value).bits)
+    @Pure operator fun times(other: FixedPointMovement) = FixedPointMovement((bits.toLong() * other.bits / MOVE_SPEED_BASE).toInt())
     @Pure operator fun times(multiplier: Int) = FixedPointMovement(bits * multiplier)
     @Pure operator fun times(multiplier: Float) = fpmFromMovement(bits * multiplier)
-    // #times(FixedPointMovement) is currently unused, but implemented here because I'm afraid
-    // someone will implement it later, and forget the division.
-    @Pure operator fun times(other: FixedPointMovement) = FixedPointMovement((bits.toLong() * other.bits / MOVE_SPEED_BASE).toInt())
-    @Pure operator fun div(other: FixedPointMovement) = FixedPointMovement((bits.toLong() * other.bits * MOVE_SPEED_BASE).toInt())
-    @Pure operator fun div(multiplier: Int) = FixedPointMovement(bits / multiplier)
-    @Pure operator fun div(multiplier: Float) = fpmFromMovement(bits / multiplier)
+    @Pure operator fun div(other: FixedPointMovement) = FixedPointMovement((bits.toLong() * MOVE_SPEED_BASE / other.bits).toInt())
+    @Pure operator fun div(divisor: Int) = FixedPointMovement(bits / divisor)
+    @Pure operator fun div(divisor: Float) = fpmFromMovement(bits / divisor)
     @Pure operator fun compareTo(other: FixedPointMovement) = bits.compareTo(other.bits)
     @Pure operator fun compareTo(other: Int) = bits.compareTo((other * MOVE_SPEED_BASE))
+    @Pure operator fun compareTo(other: Float) = compareTo(fpmFromMovement(other))
 
     @Pure fun toFloat() = bits / 30f
     @Pure fun coerceAtMost(max: FixedPointMovement) = FixedPointMovement(bits.coerceAtMost(max.bits))
     @Pure fun coerceAtLeast(min: FixedPointMovement) = FixedPointMovement(bits.coerceAtLeast(min.bits))
     @Pure fun coerceIn(min: FixedPointMovement, max: FixedPointMovement) = FixedPointMovement(bits.coerceIn(min.bits, max.bits))
 
-    override fun toString() = toFloat().toString()
-
+    override fun toString() = "FPM{$bits/30=${toFloat()}}"
+    
     companion object {
-        const val MOVE_SPEED_BASE = 30
+        private const val MOVE_SPEED_BASE = 30
         val FPM_ZERO = FixedPointMovement(0)
         val FPM_POINT_FIVE = FixedPointMovement(MOVE_SPEED_BASE/2)
         val FPM_ONE = FixedPointMovement(MOVE_SPEED_BASE)

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -866,7 +866,7 @@ class UnitMovement(val unit: MapUnit) {
         if (UncivGame.Current.settings.useAStarPathfinding) {
             if (!considerZoneOfControl) require(includeOtherEscortUnit)
             val pathingMap = if (!considerZoneOfControl) aStarPathingWithoutZoneControl
-                else if (includeOtherEscortUnit || !unit.isEscorting()) aStarPathing 
+                else if (includeOtherEscortUnit || !unit.isEscorting()) aStarPathing
                 else aStarPathingWithoutEscort
             return pathingMap.getMovementToTilesAtPosition()
         }

--- a/tests/src/com/unciv/logic/map/FixedPointMovementTest.kt
+++ b/tests/src/com/unciv/logic/map/FixedPointMovementTest.kt
@@ -1,0 +1,198 @@
+package com.unciv.logic.map
+
+import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestCase
+import com.unciv.testing.runTestParcours
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.roundToInt
+
+
+@RunWith(GdxTestRunner::class) // Note: Only benefit is support of our stdout redirection and MeasureDuration annotation
+class FixedPointMovementTest {
+
+    @Test
+    fun testRoundtripIntegerMovements() {
+        // All integer movements should roundtrip cleanly through Float
+        runTestParcours(
+            "Integer roundtrip: Int -> FPM -> Float -> Int",
+            { movement: Int ->
+                FixedPointMovement.fpmFromMovement(movement).toFloat().roundToInt()
+            },
+            0, 0,
+            1, 1,
+            5, 5,
+            10, 10,
+            50, 50,
+            -1, -1,
+            -5, -5,
+            -50, -50
+        )
+    }
+
+    @Test
+    fun testRoundtripHalfMovements() {
+        // Test roundtrip of .5 fractional movements (should be exact with HALF_UP)
+        runTestParcours(
+            "Half-unit roundtrip: 0.5 -> FPM -> Float preserves .5 fraction",
+            { movement: Float ->
+                FixedPointMovement.fpmFromMovement(movement).toFloat()
+            },
+            0.5f, 0.5f,
+            1.5f, 1.5f,
+            2.5f, 2.5f,
+            5.5f, 5.5f,
+            10.5f, 10.5f,
+            -0.5f, -0.5f,
+            -1.5f, -1.5f,
+            -10.5f, -10.5f
+        )
+    }
+
+    @Test
+    fun testHALFUPRoundingEdgeCases() {
+        // Test that HALF_UP rounds away from zero with values that fall exactly BETWEEN two representable fixed-point values
+        runTestParcours("Test fpm HALF_UP rounding",
+            { input: Float -> FixedPointMovement.fpmFromMovement(input).toFloat() },
+            1.4166666f, 1.4333333f, // 1.41666... (= 42.5/30) is halfway between 42/30 and 43/30: Should round UP to 43/30 ≈ 1.4333
+            0.48333332f, 0.5f,      // 0.48333... (= 14.5/30) is halfway between 14/30 and 15/30: Should round UP to 15/30 = 0.5
+            0.4833333f, 0.46666667f  // Just below midpoint: should round DOWN
+        )
+    }
+
+    @Test
+    fun testArithmeticMaintainsRoundingForHalves() {
+        // Verify that arithmetic operations on half-value FPMs work correctly
+        val half = FixedPointMovement.fpmFromMovement(0.5f)
+        val oneAndHalf = FixedPointMovement.fpmFromMovement(1.5f)
+
+        // 0.5 + 1.5 = 2.0 exactly
+        val sum = half + oneAndHalf
+        Assert.assertEquals(2.0f, sum.toFloat(), 0.0001f)
+
+        // 0.5 * 2 = 1.0
+        val doubled = half * 2
+        Assert.assertEquals(1.0f, doubled.toFloat(), 0.0001f)
+
+        // 1.5 / 3 = 0.5
+        val halved = oneAndHalf / 3
+        Assert.assertEquals(0.5f, halved.toFloat(), 0.0001f)
+    }
+
+    @Test
+    fun testComparisonWithFixedPointValues() {
+        runTestParcours(
+            "FPM compareTo FPM",
+            { pair: Pair<Float, Float> ->
+                val a = FixedPointMovement.fpmFromMovement(pair.first)
+                val b = FixedPointMovement.fpmFromMovement(pair.second)
+                a.compareTo(b)
+            },
+            0.5f to 0.5f, 0,
+            1.0f to 0.5f, 1,
+            0.5f to 1.0f, -1,
+            -1.0f to 1.0f, -1,
+            -1.0f to -0.5f, -1
+        )
+    }
+
+    @Test
+    fun testComparisonWithInt() {
+        runTestParcours(
+            "FPM compareTo Int",
+            { pair: Pair<Float, Int> ->
+                val fpm = FixedPointMovement.fpmFromMovement(pair.first)
+                fpm.compareTo(pair.second)
+            },
+            0.5f to 0, 1,      // 0.5 > 0
+            1.0f to 1, 0,      // 1.0 == 1
+            0.5f to 1, -1,     // 0.5 < 1
+            2.0f to 1, 1       // 2.0 > 1
+        )
+    }
+
+    @Test
+    fun testComparisonWithFloat() {
+        runTestParcours(
+            "FPM compareTo Float",
+            { pair: Pair<Float, Float> ->
+                val fpm = FixedPointMovement.fpmFromMovement(pair.first)
+                fpm.compareTo(pair.second)
+            },
+            0.5f to 0.5f, 0,
+            1.0f to 0.5f, 1,
+            0.5f to 1.0f, -1,
+            -0.5f to -0.5f, 0
+        )
+    }
+
+    @Test
+    fun testOperatorPlusPreservesValues() {
+        runTestParcours(
+            "FPM + various types",
+            { (input: Float, other: Any): Pair<Float, Any> ->
+                val fpm = FixedPointMovement.fpmFromMovement(input)
+                when (other) {
+                    is Int -> fpm + other
+                    is Float -> fpm + other
+                    is FixedPointMovement -> fpm + other
+                    else -> error("Unknown type")
+                }.toFloat()
+            },
+            1.0f to 1, 2.0f,
+            0.5f to 0.5f, 1.0f,
+            1.5f to 1, 2.5f,
+            4.2f to FixedPointMovement.fpmFromMovement(4.8f), 9f
+        )
+    }
+
+    @Test
+    fun testCoercionMethods() {
+        val min = FixedPointMovement.fpmFromMovement(1.0f)
+        val max = FixedPointMovement.fpmFromMovement(5.0f)
+        val value = FixedPointMovement.fpmFromMovement(3.0f)
+
+        Assert.assertEquals(3.0f, value.coerceIn(min, max).toFloat(), 0.0001f)
+        Assert.assertEquals(1.0f, FixedPointMovement.fpmFromMovement(0.5f).coerceAtLeast(min).toFloat(), 0.0001f)
+        Assert.assertEquals(5.0f, FixedPointMovement.fpmFromMovement(6.0f).coerceAtMost(max).toFloat(), 0.0001f)
+    }
+
+    @Test
+    fun testDivisionKnownValues() = runTestParcours(
+        "FPM / FPM",
+        { (dividend: Float, divisor: Float): Pair<Float, Float> ->
+            (FixedPointMovement.fpmFromMovement(dividend) / FixedPointMovement.fpmFromMovement(divisor)).toFloat()
+        },
+        // Integer fixed-point truncates some quotients; only assert pairs that stay exact.
+        1.0f to 2.0f, 0.5f,
+        2.0f to 2.0f, 1.0f,
+        3.0f to 2.0f, 1.5f,
+        0.1f to 3.0f, 0.033333335f
+    )
+
+    @Test
+    fun testMultiplicationKnownValues() = runTestParcours(
+        "FPM * FPM",
+        { (a: Float, b: Float): Pair<Float, Float> ->
+            (FixedPointMovement.fpmFromMovement(a) * FixedPointMovement.fpmFromMovement(b)).toFloat()
+        },
+        1.0f to 2.0f, 2.0f,
+        //1.5f to 1.5f, 2.25f, Nope: That's not exactly representable as FPM
+        1.5f to 1.6666667f, 2.5f,
+        6.0f to 7.0f, 42.0f,
+        0.03333333f to 3f, 0.1f
+    )
+
+    @Test
+    fun testRepresentativePrimeBitsFloatRoundtrip() {
+        // FPM is squeezed into max. 14 bits in routing nodes; test representatives within that range.
+        val parcours =
+            intArrayOf(2, 3, 5, 7, 11, 13, 29, 31, 61, 127, 257, 509, 1021, 2047, 4093, 8191)
+                .map { TestCase(FixedPointMovement.fpmFromFixedPointBits(it), it) }
+                .toTypedArray()
+        runTestParcours("FPM with representative bit patterns", *parcours) {
+            FixedPointMovement.fpmFromMovement(it.toFloat()).bits
+        }
+    }
+}


### PR DESCRIPTION
Imported from commits made by SomeTroglodyte:
- https://github.com/yairm210/Unciv/commit/adae9972b51a8ef40c9a70a77b17d6a0409f3075
  - did NOT import anything, or move the files to separate folders.
- https://github.com/yairm210/Unciv/commit/ae8f65c9baeab2e8f1efad8b195df6e643f9565a
  - fixed spelling errors
- https://github.com/yairm210/Unciv/commit/ae8f65c9baeab2e8f1efad8b195df6e643f9565a (and also https://github.com/yairm210/Unciv/commit/1aec9a5bcc422a579f95d9876d568f2fe74b1f7e)
  - Did NOT import anything. Not sure why these new tests have whole new customized ruleset.
- https://github.com/yairm210/Unciv/commit/ae8f65c9baeab2e8f1efad8b195df6e643f9565a
  - fixed if-chain -> when
  - adding log and newNode helper methods in pathing
- https://github.com/yairm210/Unciv/commit/adbac83b650ceb9f58f5bfc21a22118e920849ee
  - Fixed FixedPointMovement.div
  - Did NOT extend Comparable<FixedPointMovement>
  - Did NOT make fpmFromFixedPointBits(int) or Float.toFixedPointMove @VisibleForTesting/internal.
  - Did NOT import test for #15165, as it was complex, and covered by #15475
- https://github.com/yairm210/Unciv/commit/8f7aa79f3802833b93712b4b8023b2cd2ed471be
  - FixedPointMovement docs, and clearer toString.
- https://github.com/yairm210/Unciv/commit/6e85884d0d53e85e4d7ab017262f40a8bd6d3e75
   - Imported tests