### PR TITLE
Fix improvement picker allowing unresearched feature removals

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
@@ -332,7 +332,7 @@ class ImprovementPickerScreen(
                 removalImprovement = ruleset.tileImprovements[removalName]
                 if (removalImprovement != null) {
                     // Check for removals that need a tech that's not yet researched
-                    val cannotRemoveReport = getProblemReport(tileWithoutLastTerrain!!, null, removalImprovement!!)
+                    val cannotRemoveReport = getProblemReport(tile, null, removalImprovement!!)
                     if (cannotRemoveReport != null) proposedSolutions.addAll(cannotRemoveReport.proposedSolutions)
                     proposedSolutions.add("${Constants.remove}[${tile.lastTerrain.name}] first" to removalImprovement!!.makeLink())
                 }

--- a/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
@@ -12,6 +12,7 @@ import com.unciv.GUI
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.ImprovementBuildingProblem
 import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueType
@@ -33,6 +34,8 @@ import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.input.onDoubleClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.cityscreen.CityScreen
+import com.unciv.logic.civilization.Civilization
+import org.jetbrains.annotations.VisibleForTesting
 import kotlin.math.roundToInt
 
 class ImprovementPickerScreen(
@@ -44,6 +47,99 @@ class ImprovementPickerScreen(
     companion object {
         /** Return true if we can report improvements associated with the [problems] (or there are no problems for it at all). */
         fun canReport(problems: Collection<ImprovementBuildingProblem>) = problems.all { it.reportable }
+
+        /** Whether the picker would offer Pick now! for remove-then-build on [improvement], or null if hidden. */
+        @VisibleForTesting
+        fun isRemoveFirstQueueableForTests(tile: Tile, unit: MapUnit, improvement: TileImprovement): Boolean? {
+            val report = buildProblemReport(tile, unit, improvement) ?: return null
+            if (!report.suggestRemoval) return null
+            return report.isQueueable()
+        }
+
+        private class ProblemReport {
+            var suggestRemoval = false
+            var removalImprovement: TileImprovement? = null
+            /** `first` is the text, `second` the Civilopedia link */
+            val proposedSolutions = mutableSetOf<Pair<String, String?>>()
+            fun isEmpty() = proposedSolutions.isEmpty()
+            fun isQueueable() = removalImprovement != null && proposedSolutions.size == 1
+        }
+
+        private fun cloneTileWithoutLastTerrain(tile: Tile): Tile? {
+            val ruleset = tile.tileMap.gameInfo.ruleset
+            if (Constants.remove + tile.lastTerrain.name !in ruleset.tileImprovements) return null
+            val newTile = tile.clone(addUnits = false)
+            newTile.setTerrainTransients()
+            newTile.removeTerrainFeature(newTile.lastTerrain.name)
+            return newTile
+        }
+
+        private fun buildProblemReport(tile: Tile, unit: MapUnit, improvement: TileImprovement): ProblemReport? {
+            val gameInfo = tile.tileMap.gameInfo
+            return buildProblemReport(
+                tile,
+                cloneTileWithoutLastTerrain(tile),
+                improvement,
+                unit,
+                gameInfo.ruleset,
+                gameInfo.getCurrentPlayerCivilization(),
+                gameInfo.ruleset.modOptions.constants.maxImprovementTechErasForward.takeUnless { it < 0 } ?: Int.MAX_VALUE
+            )
+        }
+
+        private fun buildProblemReport(
+            tile: Tile,
+            tileWithoutLastTerrain: Tile?,
+            improvement: TileImprovement,
+            unit: MapUnit,
+            ruleset: Ruleset,
+            currentPlayerCiv: Civilization,
+            maxErasForward: Int,
+        ): ProblemReport? {
+            val report = ProblemReport()
+            var unbuildableBecause = tile.improvementFunctions.getImprovementBuildingProblems(improvement, unit.cache.state).toSet()
+            if (!canReport(unbuildableBecause) && tileWithoutLastTerrain != null) {
+                // Try after pretending to have removed the top terrain layer.
+                unbuildableBecause = tileWithoutLastTerrain.improvementFunctions.getImprovementBuildingProblems(improvement, unit.cache.state).toSet()
+                if (!canReport(unbuildableBecause)) return null
+                report.suggestRemoval = true
+            }
+            if (!canReport(unbuildableBecause)) return null
+
+            with(report) {
+                if (suggestRemoval) {
+                    val removalName = Constants.remove + tile.lastTerrain.name
+                    removalImprovement = ruleset.tileImprovements[removalName]
+                    if (removalImprovement != null) {
+                        // Check for removals that need a tech that's not yet researched
+                        val cannotRemoveReport = buildProblemReport(tile, null, removalImprovement!!, unit, ruleset, currentPlayerCiv, maxErasForward)
+                        if (cannotRemoveReport != null) proposedSolutions.addAll(cannotRemoveReport.proposedSolutions)
+                        proposedSolutions.add("${Constants.remove}[${tile.lastTerrain.name}] first" to removalImprovement!!.makeLink())
+                    }
+                }
+
+                if (ImprovementBuildingProblem.MissingTech in unbuildableBecause) {
+                    val maxEraNumber = if (maxErasForward == Int.MAX_VALUE) Int.MAX_VALUE else currentPlayerCiv.getEraNumber()
+                    for (tech in improvement.requiredTechnologies(ruleset)) {
+                        val techEra = tech?.era(ruleset) ?: continue
+                        if (unit.civ.tech.isResearched(tech.name)) continue
+                        if (techEra.eraNumber > maxEraNumber) return null
+                        proposedSolutions.add("Research [${tech.name}] first" to tech.makeLink())
+                    }
+                }
+                if (ImprovementBuildingProblem.NotJustOutsideBorders in unbuildableBecause)
+                    proposedSolutions.add("Have this tile close to your borders" to null)
+                if (ImprovementBuildingProblem.OutsideBorders in unbuildableBecause)
+                    proposedSolutions.add("Have this tile inside your empire" to null)
+                if (ImprovementBuildingProblem.MissingResources in unbuildableBecause) {
+                    val resources = improvement.getMatchingUniques(UniqueType.ConsumesResources)
+                        .filter { currentPlayerCiv.getResourceAmount(it.params[1]) < it.params[0].toInt() }
+                        .map { "Acquire more [${it.params[1]}]" to ruleset.tileResources[it.params[1]]?.makeLink() }
+                    proposedSolutions.addAll(resources)
+                }
+            }
+            return report
+        }
     }
 
     private var selectedImprovement: TileImprovement? = null
@@ -127,15 +223,7 @@ class ImprovementPickerScreen(
         topTable.add(regularImprovements)
     }
 
-    private fun getTileWithoutLastTerrain(): Tile? {
-        // clone tileInfo without "top" feature if it could be removed
-        // Keep this copy around for speed (in tileWithoutLastTerrain)
-        if (Constants.remove + tile.lastTerrain.name !in ruleset.tileImprovements) return null
-        val newTile = tile.clone(addUnits = false)
-        newTile.setTerrainTransients()
-        newTile.removeTerrainFeature(newTile.lastTerrain.name)
-        return newTile
-    }
+    private fun getTileWithoutLastTerrain(): Tile? = cloneTileWithoutLastTerrain(tile)
 
     private fun Table.addImprovementRow(improvement: TileImprovement, problemReport: ProblemReport) {
         val image = ImageGetter.getImprovementPortrait(improvement.name, 30f)
@@ -305,61 +393,8 @@ class ImprovementPickerScreen(
         return statsTable
     }
 
-    private class ProblemReport {
-        var suggestRemoval = false
-        var removalImprovement: TileImprovement? = null
-        /** `first` is the text, `second` the Civilopedia link */
-        val proposedSolutions = mutableSetOf<Pair<String, String?>>()
-        fun isEmpty() = proposedSolutions.isEmpty()
-        fun isQueueable() = removalImprovement != null && proposedSolutions.size == 1
-    }
-
-    private fun getProblemReport(improvement: TileImprovement) = getProblemReport(tile, tileWithoutLastTerrain, improvement)
-    private fun getProblemReport(tile: Tile, tileWithoutLastTerrain: Tile?, improvement: TileImprovement): ProblemReport? {
-        val report = ProblemReport()
-        var unbuildableBecause = tile.improvementFunctions.getImprovementBuildingProblems(improvement, unit.cache.state).toSet()
-        if (!canReport(unbuildableBecause) && tileWithoutLastTerrain != null) {
-            // Try after pretending to have removed the top terrain layer.
-            unbuildableBecause = tileWithoutLastTerrain.improvementFunctions.getImprovementBuildingProblems(improvement, unit.cache.state).toSet()
-            if (!canReport(unbuildableBecause)) return null
-            report.suggestRemoval = true
-        }
-        if (!canReport(unbuildableBecause)) return null
-
-        with(report) {
-            if (suggestRemoval) {
-                val removalName = Constants.remove + tile.lastTerrain.name
-                removalImprovement = ruleset.tileImprovements[removalName]
-                if (removalImprovement != null) {
-                    // Check for removals that need a tech that's not yet researched
-                    val cannotRemoveReport = getProblemReport(tile, null, removalImprovement!!)
-                    if (cannotRemoveReport != null) proposedSolutions.addAll(cannotRemoveReport.proposedSolutions)
-                    proposedSolutions.add("${Constants.remove}[${tile.lastTerrain.name}] first" to removalImprovement!!.makeLink())
-                }
-            }
-
-            if (ImprovementBuildingProblem.MissingTech in unbuildableBecause) {
-                val maxEraNumber = if (maxErasForward == Int.MAX_VALUE) Int.MAX_VALUE else currentPlayerCiv.getEraNumber()
-                for (tech in improvement.requiredTechnologies(ruleset)) {
-                    val techEra = tech?.era(ruleset) ?: continue
-                    if (unit.civ.tech.isResearched(tech.name)) continue
-                    if (techEra.eraNumber > maxEraNumber) return null
-                    proposedSolutions.add("Research [${tech.name}] first" to tech.makeLink())
-                }
-            }
-            if (ImprovementBuildingProblem.NotJustOutsideBorders in unbuildableBecause)
-                proposedSolutions.add("Have this tile close to your borders" to null)
-            if (ImprovementBuildingProblem.OutsideBorders in unbuildableBecause)
-                proposedSolutions.add("Have this tile inside your empire" to null)
-            if (ImprovementBuildingProblem.MissingResources in unbuildableBecause) {
-                val resources = improvement.getMatchingUniques(UniqueType.ConsumesResources)
-                    .filter { currentPlayerCiv.getResourceAmount(it.params[1]) < it.params[0].toInt() }
-                    .map { "Acquire more [${it.params[1]}]" to ruleset.tileResources[it.params[1]]?.makeLink() }
-                proposedSolutions.addAll(resources)
-            }
-        }
-        return report
-    }
+    private fun getProblemReport(improvement: TileImprovement) =
+        buildProblemReport(tile, tileWithoutLastTerrain, improvement, unit, ruleset, currentPlayerCiv, maxErasForward)
 
     private fun getExplanationActor(improvement: TileImprovement, report: ProblemReport): Actor? {
         fun getPickNowButton(action: ()->Unit) = "Pick now!".toTextButton(SmallButtonStyle()).onClick(action)

--- a/tests/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreenTests.kt
+++ b/tests/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreenTests.kt
@@ -1,0 +1,58 @@
+package com.unciv.ui.screens.pickerscreens
+
+import com.unciv.logic.map.HexCoord
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(BaseTestRunner::class)
+class ImprovementPickerScreenTests {
+
+    private val testGame = TestGame()
+
+    @Before
+    fun setUp() {
+        testGame.makeHexagonalMap(2, baseTerrain = "Grassland")
+    }
+
+    @Test
+    fun plantationOnJungleWithoutBronzeWorkingIsNotRemoveFirstQueueable() {
+        val civ = testGame.addCiv(isPlayer = true)
+        civ.tech.addTechnology("Calendar")
+        val city = testGame.addCity(civ, testGame.getTile(0, 0))
+        val tile = testGame.setTileTerrainAndFeatures(HexCoord(1, 1), "Grassland", "Jungle")
+        tile.setTileResource("Bananas")
+        tile.setOwningCity(city)
+        val worker = testGame.addUnit("Worker", civ, tile)
+        testGame.gameInfo.currentPlayerCiv = civ
+
+        val plantation = testGame.ruleset.tileImprovements["Plantation"]!!
+
+        assertFalse(
+            ImprovementPickerScreen.isRemoveFirstQueueableForTests(tile, worker, plantation)!!
+        )
+    }
+
+    @Test
+    fun plantationOnJungleWithBronzeWorkingIsRemoveFirstQueueable() {
+        val civ = testGame.addCiv(isPlayer = true)
+        civ.tech.addTechnology("Calendar")
+        civ.tech.addTechnology("Bronze Working")
+        val city = testGame.addCity(civ, testGame.getTile(0, 0))
+        val tile = testGame.setTileTerrainAndFeatures(HexCoord(1, 1), "Grassland", "Jungle")
+        tile.setTileResource("Bananas")
+        tile.setOwningCity(city)
+        val worker = testGame.addUnit("Worker", civ, tile)
+        testGame.gameInfo.currentPlayerCiv = civ
+
+        val plantation = testGame.ruleset.tileImprovements["Plantation"]!!
+
+        assertTrue(
+            ImprovementPickerScreen.isRemoveFirstQueueableForTests(tile, worker, plantation)!!
+        )
+    }
+}


### PR DESCRIPTION
Fixes #15512

## Summary

- When the improvement picker suggests "Remove [feature] first", check removal feasibility on the **real tile** (feature still present), not on `tileWithoutLastTerrain` where the feature was already stripped for simulation.
- Without this, missing removal tech (e.g. Bronze Working for Remove Jungle) was never reported, so `isQueueable()` stayed true and "Pick now!" queued illegal removals.

Follow-up to #15445 / #15430: keep the non-null guard there, only fix the tile used for the removal problem report.

## Test plan

- [ ] Calendar researched, Bronze Working **not** researched: worker on jungle + bananas → Plantation shows "Research [Bronze Working] first" and **no** Pick now for remove-then-plant.
- [ ] Bronze Working researched: same tile → "Remove [Jungle] first" with Pick now queues Remove Jungle then Plantation.
- [ ] Forested hill with Mining: Mine still offered with remove-forest-first queue (#15430 regression check).
