### PR TITLE
Translate and complete Vietnamese properties file

### DIFF
--- a/android/assets/jsons/translations/Vietnamese.properties
+++ b/android/assets/jsons/translations/Vietnamese.properties
@@ -918,8 +918,7 @@ Gameplay = Lối chơi
 Check for idle units = Kiểm tra các Đơn vị nhàn rỗi
 'Next unit' button cycles idle units = Hiện nút 'Đơn vị tiếp theo' để chuyển sang các đơn vị nhàn rỗi khác
 Auto Unit Cycle = Chu kỳ đơn vị tự động
- # Requires translation!
-Cycle idle units by distance = 
+Cycle idle units by distance = Chuyển qua các đơn vị nhàn rỗi theo khoảng cách
 Show Small Skip/Cycle Unit Button = Hiện ra nút Bỏ qua lượt/Đơn vị tiếp theo nhỏ hơn
 Move units with a single tap = Di chuyển đơn vị với một chạm
 Move units with a long tap = Di chuyển đơn vị với việc nhấn giữ
@@ -1473,14 +1472,10 @@ Add or move to the top in all cities = Thêm hoặc di chuyển lên đầu tron
 Remove from the queue in all cities = Xóa khỏi hàng đợi ở tất cả các thành phố.
 Disable = Vô hiệu hóa
 Enable = Kích hoạt
- # Requires translation!
-Disable in this city = 
- # Requires translation!
-Enable in this city = 
- # Requires translation!
-Disable in all cities = 
- # Requires translation!
-Enable in all cities = 
+Disable in this city = Vô hiệu hóa ở thành phố này
+Enable in this city = Kích hoạt ở thành phố này
+Disable in all cities = Vô hiệu hóa ở mọi thành phố
+Enable in all cities = Kích hoạt ở mọi thành phố
 
 # Specialized Popups - Ask for text or numbers, file picker
 
@@ -2979,8 +2974,7 @@ Completed Policy branches = Những Chính sách đã hoàn thành
 [cityFilter] Cities = Thành phố [cityFilter] 
 Carried [mapUnitFilter] units = Mang theo đơn vị [mapUnitFilter] 
 [buildingFilter] Buildings by [civFilter] Civilizations = Công trình [buildingFilter] được xây bởi các nền Văn minh [civFilter] 
- # Requires translation!
-[populationFilter] in [cityFilter] Cities = 
+[populationFilter] in [cityFilter] Cities = [populationFilter] ở các Thành phố [cityFilter]
 [cityFilter] Cities of [civFilter] Civilizations = Thành phố [cityFilter] của nền Văn minh [civFilter] 
 Adopted [policyFilter] Policies = Chấp nhận Chính sách [policyFilter] 
 Adopted [policyFilter] Policies by [civFilter] Civilizations = Những nền Văn minh [civFilter] đã tiếp nhận Chính sách [policyFilter] 
@@ -7518,7 +7512,7 @@ Carolean = Quân đội Carolean
 Mehal Sefari = Cận vệ Hoàng gia
 
 
-Hussar = Khinh Kỵ binh
+Hussar = Kỵ binh nhẹ
 
 
 Great War Infantry = Bộ Binh (Thế chiến)
@@ -7926,10 +7920,8 @@ On the World screen, select an unit that can be upgraded, then right-click or lo
 In the Units overview, the same upgrade menu is available by clicking the unit icon in the "Upgrade" column. When an unit is upgradeable, the icon is lit if conditions are met (enough gold and/or resources), otherwise it is dimmed. = Ở mục tổng quan đơn vị, danh sách các nâng cấp có thể được xem qua việc nhấn vào cột "Nâng cấp". Mỗi khi có đơn vị nâng cấp được thì biếu tưởng sẽ sáng lên. 
 Additional controls for the construction queue = Các loại điều khiển thêm cho phần hàng đợi công trình 
 Right-click or long press a construction item to open a popup menu with additional controls, allowing to manage production of the same item in all cities, by issuing the commands from the same City Screen. = Nhấn chuột phải hoặc giữ chuột một món đồ để mở danh sách với các mục điều khiển, cho phép người chơi được quản lý việc sản xuất cùng một món đồ trong mọi thành phố. 
- # Requires translation!
-The "Disable" option (in a single city or all cities) moves an item to a separated "Disabled" tab, to prevent its automatic queueing by the "Auto-assign city production" option or to remove irrelevant objects from the production planning. To move a disabled item back to its initial place, re-enter its popup menu, and choose "Enable". = 
- # Requires translation!
-Disabled items are set for the current game only and are carried over when founding a new city. = 
+The "Disable" option (in a single city or all cities) moves an item to a separated "Disabled" tab, to prevent its automatic queueing by the "Auto-assign city production" option or to remove irrelevant objects from the production planning. To move a disabled item back to its initial place, re-enter its popup menu, and choose "Enable". = Tùy chọn "Vô hiệu hóa" (áp dụng cho một thành phố hoặc mọi thành phố) sẽ chuyển một món đồ sang thẻ "Vô hiệu hóa" riêng, nhằm ngăn nó bị tự động đưa vào hàng đợi bởi tùy chọn "Tự động chỉ định sản xuất cho thành phố", hoặc để loại bỏ những món đồ không cần thiết khỏi việc lên kế hoạch sản xuất. Để đưa một món đồ đã vô hiệu hóa trở lại vị trí ban đầu, hãy mở lại danh sách điều khiển của nó và chọn "Kích hoạt".
+Disabled items are set for the current game only and are carried over when founding a new city. = Các món đồ đã bị vô hiệu hóa chỉ áp dụng cho trận chơi hiện tại, và sẽ được giữ nguyên khi thành lập một thành phố mới.
 Show Great Person Points breakdown = Xem thống kê điểm Vĩ nhân
 In the right sidepanel, click a Great People row to display the details of Great Person Points (GPP) accumulated each turn by the current city, for this type of Great People. = Ở khu vực bên phải, nhấn vào hàng người Vĩ đại để hiển thị điểm Vĩ nhân nhận được từng lượt bởi thành phố hiện tại, cho riêng loại Vĩ Nhân này. 
 Click any of the Great People icons to display all GPP accumulated each turn by the current city, for all types of Great People. = Nhấn vào bất kì biểu tượng Vĩ Nhân nào để hiển thị điểm Vĩ nhân kiếm được qua từng lượt của thành phố hiện tại, cho mọi loại người Vĩ đại. 
@@ -7969,5 +7961,4 @@ Forest and Jungle Visibility\nIn Unciv, forests and jungles are visible 1 tile o
 City razing\nIn Civilization V, the player can never raze any of the cities he/she founded. Not applicable to Unciv. = San bằng thành phố\nTại Civ V thì người chơi không thể phá huỷ thành phố mà mình dựng lên. Nhưng Unciv thì ngược lại. 
 
 Founding Cities\nThe Settler is a unit that can found a new city. You can build a Settler unit in a city with at least 2 population, and then move them to a good location to found a new city. This will usually be your main way of acquiring more cities. = Khi thành lập thành phố\nNgười định cư là đơn vị sử dụng để tạo ra thành phố. Bạn có thể tạo đơn vị này tại thành phố với hai người dân, và đưa họ đến nơi bạn muốn tạo ra một thành phố mới. Điều này sẽ là phương thức chính của bạn để có thêm thành phố. 
-Food conversion to Production\nDuring the construction of a Settler, the city will not grow. Instead, the 1st, 2nd, 4th, and from there on every 4th, excess Food (Growth) is converted into Production, with the rest of the excess Food being lost. = Việc thay đổi từ điểm Lương thực sang điểm Sản xuất\nKhi bạn bắt đầu tạo ra Người định cư thì thành phố sẽ không tăng trưởng. Thay vào đó, điểm Lương thực thừa sẽ chuyển đổi sang điểm Sản xuất, vầ toàn bộ điểm Lương thực dư thừa sẽ mất đi. 
-
+Food conversion to Production\nDuring the construction of a Settler, the city will not grow. Instead, the 1st, 2nd, 4th, and from there on every 4th, excess Food (Growth) is converted into Production, with the rest of the excess Food being lost. = Việc thay đổi từ điểm Lương thực sang điểm Sản xuất\nKhi bạn bắt đầu tạo ra Người định cư thì thành phố sẽ không tăng trưởng. Thay vào đó, điểm Lương thực thừa sẽ chuyển đổi sang điểm Sản xuất, vầ toàn bộ điểm Lương thực dư thừa sẽ mất đi.


### PR DESCRIPTION
Localization
Added Vietnamese translations for idle-unit distance cycling, construction queue controls, population and city countables, and construction-queue tutorial text.
Updated the Vietnamese translation for “Hussar” to use clearer, more accurate wording.
Normalized whitespace in the food-conversion tutorial text without changing its content.