### PR TITLE
Adds auto map size

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -282,9 +282,10 @@ class GameStarter private constructor(
             }
             val desiredNumberOfPlayers = (min.coerceAtLeast(nonAICount)..max.coerceAtLeast(nonAICount)).random(rng)
 
-            if (desiredNumberOfPlayers > newGameParameters.players.size) {
-                extraRandomAIPlayers = desiredNumberOfPlayers - newGameParameters.players.size
-            } else if (desiredNumberOfPlayers < newGameParameters.players.size) {
+            val numberOfNonSpectatorPlayers = newGameParameters.players.filter { it.chosenCiv != Constants.spectator }.size
+            if (desiredNumberOfPlayers > numberOfNonSpectatorPlayers) {
+                extraRandomAIPlayers = desiredNumberOfPlayers - numberOfNonSpectatorPlayers
+            } else if (desiredNumberOfPlayers < numberOfNonSpectatorPlayers) {
                 val extraPlayers = newGameParameters.players.size - desiredNumberOfPlayers
                 selectedAIToSkip = newGameParameters.players
                     .filter { it.playerType === PlayerType.AI }

--- a/core/src/com/unciv/logic/map/MapSize.kt
+++ b/core/src/com/unciv/logic/map/MapSize.kt
@@ -8,7 +8,8 @@ import yairm210.purity.annotations.Readonly
  *  Encapsulates the "map size" concept, without also choosing a shape.
  *
  *  Predefined sizes are kept in the [Predefined] enum, instances derived from these have the same [name] and copied dimensions.
- *  Custom sizes always have [custom] as [name], even if created with the exact same dimensions as a [Predefined].
+ *  Custom sizes always have [custom] as [name], even if created with the exact same dimensions as a [Predefined]. 
+ *  Auto sizes  similarly have [auto] as [name], their sizes are changed dynamically when the map is generated.
  *
  *  @property name
  *  @property radius
@@ -34,18 +35,15 @@ class MapSize private constructor(
 
     constructor(size: Predefined) : this(size.name, size.radius, size.width, size.height)
 
-    constructor(name: String) : this(
-        if (name == auto) auto else Predefined.safeValueOf(name).name,
-        (if (name == auto) Predefined.Medium else Predefined.safeValueOf(name)).radius,
-        (if (name == auto) Predefined.Medium else Predefined.safeValueOf(name)).width,
-        (if (name == auto) Predefined.Medium else Predefined.safeValueOf(name)).height
-    )
+    constructor(name: String) : this(if (name == auto) Auto else MapSize(Predefined.safeValueOf(name)))
 
     constructor(radius: Int) : this(custom, radius, 0, 0) {
         setNewRadius(radius)
     }
 
     constructor(width: Int, height: Int) : this(custom, HexMath.getEquivalentHexagonalRadius(width, height), width, height)
+
+    constructor(other: MapSize) : this(other.name, other.radius, other.width, other.height)
 
     /** Predefined Map Sizes, their name can appear in json only as copy in MapSize */
     enum class Predefined(
@@ -82,7 +80,7 @@ class MapSize private constructor(
          * Do not mistake for [MapGeneratedMainType.custom]. */
         const val custom = "Custom"
         const val auto = "Auto"
-        val Auto get() = MapSize(auto) // Defaulting to Medium dimensions
+        val Auto get() = MapSize(auto, Predefined.Medium.radius, Predefined.Medium.width, Predefined.Medium.height)
         val Tiny get() = MapSize(Predefined.Tiny)
         val Small get() = MapSize(Predefined.Small)
         val Medium get() = MapSize(Predefined.Medium)

--- a/core/src/com/unciv/logic/map/MapSize.kt
+++ b/core/src/com/unciv/logic/map/MapSize.kt
@@ -34,7 +34,12 @@ class MapSize private constructor(
 
     constructor(size: Predefined) : this(size.name, size.radius, size.width, size.height)
 
-    constructor(name: String) : this(Predefined.safeValueOf(name))
+    constructor(name: String) : this(
+        if (name == auto) auto else Predefined.safeValueOf(name).name,
+        (if (name == auto) Predefined.Medium else Predefined.safeValueOf(name)).radius,
+        (if (name == auto) Predefined.Medium else Predefined.safeValueOf(name)).width,
+        (if (name == auto) Predefined.Medium else Predefined.safeValueOf(name)).height
+    )
 
     constructor(radius: Int) : this(custom, radius, 0, 0) {
         setNewRadius(radius)
@@ -76,19 +81,21 @@ class MapSize private constructor(
          * used in [name] to indicate user-defined dimensions.
          * Do not mistake for [MapGeneratedMainType.custom]. */
         const val custom = "Custom"
+        const val auto = "Auto"
+        val Auto get() = MapSize(auto) // Defaulting to Medium dimensions
         val Tiny get() = MapSize(Predefined.Tiny)
         val Small get() = MapSize(Predefined.Small)
         val Medium get() = MapSize(Predefined.Medium)
         val Large get() = MapSize(Predefined.Large)
         val Huge get() = MapSize(Predefined.Huge)
-        fun names() = Predefined.entries.map { it.name }
+        fun names() = Predefined.entries.map { it.name } + listOf(auto)
     }
 
     fun clone() = MapSize(name, radius, width, height)
 
     @Readonly
     fun getPredefinedOrNextSmaller(): Predefined {
-        if (name != custom) return Predefined.safeValueOf(name)
+        if (name != custom && name != auto) return Predefined.safeValueOf(name)
         for (predef in Predefined.entries.reversed()) {
             if (radius >= predef.radius) return predef
         }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -243,8 +243,8 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
     private fun resolveAutoMapSize(mapParameters: MapParameters, gameParameters: GameParameters, gameInfo: GameInfo?): MapSize {
         if (gameInfo == null) return mapParameters.mapSize
 
-        val numberOfMajorCivs = gameInfo.civilizations.filter { it.nation.name != Constants.spectator && it.nation.name != Constants.barbarians && !it.isCityState }.size
-        val numberOfMinorCivs = gameInfo.civilizations.filter { it.isCityState }.size
+        val numberOfMajorCivs = gameInfo.civilizations.count { it.isMajorCiv() }
+        val numberOfMinorCivs = gameInfo.civilizations.count { it.isCityState }
         // This is mostly just vibes, tries to make the average minimum distance between major civs equal to 13
         val majorCivContribution = 7.6 * numberOfMajorCivs.toFloat().pow(2) + 
             522 * numberOfMajorCivs - 360 + 120 * sin( 2.48 * numberOfMajorCivs.toFloat())

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -250,11 +250,12 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             522 * numberOfMajorCivs - 360 + 120 * sin( 2.48 * numberOfMajorCivs.toFloat())
         val targetNumberOfTiles = (majorCivContribution + numberOfMinorCivs * 60)
 
+        // Calculates mapsize from tile number, simple algebra reversing area formulas
         val aspectRatio = 1.55 // This is around the default aspect ratios
-        mapParameters.mapSize.radius = (sqrt(0.33 * targetNumberOfTiles - 0.083) - 0.5).toInt()
-        mapParameters.mapSize.height = sqrt(0.66 * targetNumberOfTiles).toInt()
-        mapParameters.mapSize.width = (sqrt(0.66 * targetNumberOfTiles) * aspectRatio).toInt()
- 
+        mapParameters.mapSize.radius = (sqrt(1.0/3 * targetNumberOfTiles - 1.0/12) - 1.0/2).toInt()
+        mapParameters.mapSize.height = sqrt(2.0/3 * targetNumberOfTiles).toInt()
+        mapParameters.mapSize.width = (sqrt(2.0/3 * targetNumberOfTiles) * aspectRatio).toInt()
+
         return mapParameters.mapSize
     }
     private fun flipTopBottom(vector: HexCoord): HexCoord = HexCoord.of(-vector.y, -vector.x)

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -5,6 +5,7 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.map.*
+import com.unciv.logic.map.MapSize.Companion.auto
 import com.unciv.logic.map.mapgenerator.mapregions.MapRegions
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Counter
@@ -28,6 +29,7 @@ import kotlin.math.exp
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sign
+import kotlin.math.sin
 import kotlin.math.sqrt
 import kotlin.math.ulp
 import kotlin.sequences.filter
@@ -146,7 +148,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             .ifEmpty { sequenceOf(TerrainOccursRange(this)) }
 
     fun generateMap(mapParameters: MapParameters, gameParameters: GameParameters = GameParameters(), gameInfo: GameInfo? = null): TileMap {
-        val mapSize = mapParameters.mapSize
+        val mapSize = if (mapParameters.mapSize.name != auto) mapParameters.mapSize else resolveAutoMapSize(mapParameters, gameParameters, gameInfo)
         val mapType = mapParameters.type
 
         if (mapParameters.seed == 0L)
@@ -238,7 +240,23 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
 
         return map
     }
-    
+    private fun resolveAutoMapSize(mapParameters: MapParameters, gameParameters: GameParameters, gameInfo: GameInfo?): MapSize {
+        if (gameInfo == null) return mapParameters.mapSize
+
+        val numberOfMajorCivs = gameInfo.civilizations.filter { it.nation.name != Constants.spectator && it.nation.name != Constants.barbarians && !it.isCityState }.size
+        val numberOfMinorCivs = gameInfo.civilizations.filter { it.isCityState }.size
+        // This is mostly just vibes, tries to make the average minimum distance between major civs equal to 13
+        val majorCivContribution = 7.6 * numberOfMajorCivs.toFloat().pow(2) + 
+            522 * numberOfMajorCivs - 360 + 120 * sin( 2.48 * numberOfMajorCivs.toFloat())
+        val targetNumberOfTiles = (majorCivContribution + numberOfMinorCivs * 60)
+
+        val aspectRatio = 1.55 // This is around the default aspect ratios
+        mapParameters.mapSize.radius = (sqrt(0.33 * targetNumberOfTiles - 0.083) - 0.5).toInt()
+        mapParameters.mapSize.height = sqrt(0.66 * targetNumberOfTiles).toInt()
+        mapParameters.mapSize.width = (sqrt(0.66 * targetNumberOfTiles) * aspectRatio).toInt()
+ 
+        return mapParameters.mapSize
+    }
     private fun flipTopBottom(vector: HexCoord): HexCoord = HexCoord.of(-vector.y, -vector.x)
     private fun flipLeftRight(vector: HexCoord): HexCoord = HexCoord.of(vector.y, vector.x)
 


### PR DESCRIPTION
Takes into account the number of civs and city states and automatically chooses map dimensions. 
Also fixes a bug where the random number of civs feature was counting spectators

The formula used for the contribution by number of civs was arrived at using linear regression on a dataset of pangaea maps with custom map sizes and default advanced settings, and where the minimum distance between civs averaged 13. One limitation of the approach is that other map types might have more or less space. In practice however it seems to work well enough on most map types.

Dataset:
2 players
600
3 players
1350
4 players
1734
5 players
2400
6 players
3174
7 players
3456
8 players
4374
9 players
5046
10 players
5766
11 player
6534
12 players
7350
20 players
13000
34 players
25500