### PR TITLE
Fix overflow in trade evaluation

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -121,15 +121,15 @@ class TradeEvaluation {
 
         val sumOfTheirOffers = trade.theirOffers.asSequence()
             .filter { it.type != TradeOfferType.Treaty }
-            .sumOf { evaluateBuyCostWithInflation(it, evaluator, tradePartner, trade) }
+            .sumOf { evaluateBuyCostWithInflation(it, evaluator, tradePartner, trade).toLong() }
 
-        var sumOfOurOffers = trade.ourOffers.sumOf { evaluateSellCostWithInflation(it, evaluator, tradePartner, trade) }
+        var sumOfOurOffers = trade.ourOffers.sumOf { evaluateSellCostWithInflation(it, evaluator, tradePartner, trade).toLong() }
 
         val relationshipLevel = evaluator.getDiplomacyManager(tradePartner)!!.relationshipIgnoreAfraid()
         // If we're making a peace treaty, don't try to up the bargain for people you don't like.
         // Leads to spartan behaviour where you demand more, the more you hate the enemy...unhelpful
         if (trade.ourOffers.none { it.name == Constants.peaceTreaty || it.name == Constants.researchAgreement}) {
-            if (relationshipLevel == RelationshipLevel.Enemy) sumOfOurOffers = (sumOfOurOffers * 1.5).toInt()
+            if (relationshipLevel == RelationshipLevel.Enemy) sumOfOurOffers = (sumOfOurOffers * 1.5).toLong()
             else if (relationshipLevel == RelationshipLevel.Unforgivable) sumOfOurOffers *= 2
         }
         if (trade.ourOffers.firstOrNull { it.name == Constants.defensivePact } != null) {
@@ -140,7 +140,8 @@ class TradeEvaluation {
             }
         }
         val diplomaticGifts: Int = if (includeDiplomaticGifts) evaluator.getDiplomacyManager(tradePartner)!!.getGoldGifts() else 0
-        return sumOfTheirOffers - sumOfOurOffers + diplomaticGifts
+        return (sumOfTheirOffers - sumOfOurOffers + diplomaticGifts)
+            .coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong()).toInt()
     }
 
     @Readonly

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -119,6 +119,9 @@ class TradeEvaluation {
             return Int.MIN_VALUE
         }
 
+        // Some offers use Int.MAX_VALUE to prevent acceptance. Summing or multiplying
+        // these costs can overflow and make a rejected trade look favorable.
+        // Use Long for the calculation and clamp the final result to the Int range.
         val sumOfTheirOffers = trade.theirOffers.asSequence()
             .filter { it.type != TradeOfferType.Treaty }
             .sumOf { evaluateBuyCostWithInflation(it, evaluator, tradePartner, trade).toLong() }


### PR DESCRIPTION
Asking an AI for a spaceship resource and 2 gold can make it accept the trade for nothing because the resource's `Int.MAX_VALUE` valuation overflows when the offers are added.

Use `Long` for the totals and clamp the final result before converting back to `Int`.

Verified the trade is refused and the existing gold gifting tests pass.
