### PR TITLE
Copy temporary uniques when cloning civilizations

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -343,7 +343,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         toReturn.cityStateResource = cityStateResource
         toReturn.cityStateUniqueUnit = cityStateUniqueUnit
         toReturn.flagsCountdown.putAll(flagsCountdown)
-        toReturn.temporaryUniques.addAll(temporaryUniques)
+        temporaryUniques.mapTo(toReturn.temporaryUniques) { it.clone() }
         toReturn.hasEverOwnedOriginalCapital = hasEverOwnedOriginalCapital
         toReturn.passableImpassables.addAll(passableImpassables)
         toReturn.numMinorCivsAttacked = numMinorCivsAttacked

--- a/core/src/com/unciv/models/ruleset/unique/TemporaryUnique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/TemporaryUnique.kt
@@ -22,6 +22,13 @@ class TemporaryUnique() : IsPartOfGameInfoSerialization {
     val uniqueObject: Unique by lazy { Unique(unique, sourceObjectType, sourceObjectName) }
 
     var turnsLeft: Int = 0
+
+    fun clone() = TemporaryUnique().also {
+        it.unique = unique
+        it.sourceObjectType = sourceObjectType
+        it.sourceObjectName = sourceObjectName
+        it.turnsLeft = turnsLeft
+    }
 }
 
 


### PR DESCRIPTION
Cloning a civilization shares its temporary unique objects. Advancing the clone also reduces their duration in the original game, which can consume bonuses or make them permanent after a failed multiplayer upload.

Copy each temporary unique when cloning the civilization. Existing timed unique tests and both clone reproducers pass.
