### PR TITLE
Copy free building sets when cloning

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -99,7 +99,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         toReturn.currentConstructionIsUserSet = currentConstructionIsUserSet
         toReturn.constructionQueue.addAll(constructionQueue)
         toReturn.productionOverflow = productionOverflow
-        toReturn.freeBuildingsProvidedFromThisCity.putAll(freeBuildingsProvidedFromThisCity)
+        toReturn.freeBuildingsProvidedFromThisCity.putAll(freeBuildingsProvidedFromThisCity.mapValues { it.value.toHashSet() })
         return toReturn
     }
 

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -51,9 +51,9 @@ class CivConstructions : IsPartOfGameInfoSerialization {
     fun clone(): CivConstructions {
         val toReturn = CivConstructions()
         toReturn.civInfo = civInfo
-        toReturn.freeBuildings.putAll(freeBuildings)
-        toReturn.freeStatBuildingsProvided.putAll(freeStatBuildingsProvided)
-        toReturn.freeSpecificBuildingsProvided.putAll(freeSpecificBuildingsProvided)
+        toReturn.freeBuildings.putAll(freeBuildings.mapValues { it.value.toHashSet() })
+        toReturn.freeStatBuildingsProvided.putAll(freeStatBuildingsProvided.mapValues { it.value.toHashSet() })
+        toReturn.freeSpecificBuildingsProvided.putAll(freeSpecificBuildingsProvided.mapValues { it.value.toHashSet() })
         toReturn.boughtItemsWithIncreasingPrice.add(boughtItemsWithIncreasingPrice)  // add copies
         toReturn.builtItemsWithIncreasingCost.add(builtItemsWithIncreasingCost)
         return toReturn


### PR DESCRIPTION
The free building maps still share their sets after cloning. Grants in a discarded turn can mark cities as already served in the original game and cause later grants to be skipped.

Copy the nested sets when cloning the construction managers.
