### PR TITLE
Preserve building sale limit in cloned cities

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -188,6 +188,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         toReturn.resourceStockpiles = resourceStockpiles.clone()
         toReturn.isBeingRazed = isBeingRazed
         toReturn.attackedThisTurn = attackedThisTurn
+        toReturn.hasSoldBuildingThisTurn = hasSoldBuildingThisTurn
         toReturn.foundingCiv = foundingCiv
         toReturn.previousOwner = previousOwner
         toReturn.turnAcquired = turnAcquired

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -27,6 +27,8 @@ class TurnManager(val civInfo: Civilization) {
     fun startTurn(progressBar: NextTurnProgress? = null):Unit = timeThis("TurnManager.startTurn") {
         if (civInfo.isSpectator()) return
 
+        for (city in civInfo.cities) city.hasSoldBuildingThisTurn = false
+
         civInfo.threatManager.clear()
 
         if (civInfo.cities.isNotEmpty() && civInfo.gameInfo.ruleset.technologies.isNotEmpty())


### PR DESCRIPTION
Undo checkpoints and clone-based autosaves lose `hasSoldBuildingThisTurn`, allowing another building sale in the same turn.

Preserve the flag when cloning a city and reset it before processing turn-start effects.
