### PR TITLE
Keep inquisitor conversion targets in owned cities

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/ReligiousUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/ReligiousUnitAutomation.kt
@@ -131,7 +131,8 @@ object ReligiousUnitAutomation {
 
         val holyCity = unit.civ.religionManager.getHolyCity()
         // Our own holy city was taken over!
-        if (holyCity != null && holyCity.religion.getMajorityReligion() != unit.civ.religionManager.religion!!)
+        if (holyCity != null && holyCity.civ == unit.civ
+            && holyCity.religion.getMajorityReligion() != unit.civ.religionManager.religion!!)
             return holyCity
 
         val blockedHolyCity = unit.civ.cities.firstOrNull { it.religion.isBlockedHolyCity && it.religion.religionThisIsTheHolyCityOf == unit.religion }
@@ -139,7 +140,7 @@ object ReligiousUnitAutomation {
             return blockedHolyCity
 
         // Find cities 
-        val relevantCities = unit.civ.gameInfo.getCities()
+        val relevantCities = unit.civ.cities.asSequence()
             .filter { it.getCenterTile().isExplored(unit.civ) } // Cities we know about
             // Someone else is controlling this city
             .filter { 


### PR DESCRIPTION
Inquisitors can pick cities owned by another civilization even though Remove Heresy only works in owned cities.

Restrict the conversion search and holy city shortcut to our cities.
