### PR TITLE
Fixed a bug in comparing unitTable.selectedCity (view) to foreignCityView.getCity() (raw)

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/citybutton/CityButton.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/citybutton/CityButton.kt
@@ -198,7 +198,7 @@ class CityButton(val foreignCityView: ForeignCityView, private val tileGroup: Ti
         onRightClick(action = ::enterCityOrInfoPopup)
 
         // when deselected, move city button to its original position
-        if (unitTable.selectedCity != foreignCityView.getCity() && unitTable.selectedUnit?.getTile() != foreignCityView.getCenterTile() && unitTable.selectedSpy == null)
+        if (unitTable.selectedCity != foreignCityView && unitTable.selectedUnit?.getTile() != foreignCityView.getCenterTile() && unitTable.selectedSpy == null)
             moveButtonUp()
     }
 


### PR DESCRIPTION
Easy check 

- Load a normal single-player game with a city you own.
-  Clear any unit/spy selection, then left-click the city’s name banner once. Confirm the bottom-left panel shows the city’s strength and bombard strength.
-  Wait one second for the banner to finish sliding down.
- Press Ctrl+Y—the default “toggle tile yields” shortcut. This refreshes the world screen without changing the selected city.
- Wait another second.

  Predicted buggy behavior: the banner slides back up, although the bottom-left panel still shows that city selected. Clicking its banner again lowers it instead of opening CityScreen.

  After the fix: the banner stays down through the refresh, and the next click opens CityScreen. 