### PR TITLE
Fixes a tile info update bug when changing perspective

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/TileInfoTable.kt
@@ -30,10 +30,12 @@ class TileInfoTable(private val worldScreen: WorldScreen) : Table(BaseScreen.ski
         )
     }
 
-    internal fun updateTileTable(tileView: TileView?) {
+    internal fun updateTileTable(selectedTileView: TileView?) {
         clearChildren()
         pad(5f)
 
+        // A retained selection may still carry the previous spectator or civilization perspective.
+        val tileView = selectedTileView?.let { civView.gameView.getTile(it) }
         if (tileView != null && (DebugUtils.VISIBLE_MAP || civView.hasExplored(tileView))) {
             add(getStatsTable(tileView)).left().row()
             add(MarkupRenderer.render(TileDescription.toMarkup(tileView, civView), padding = 0f, iconDisplay = IconDisplay.None) {

--- a/core/src/com/unciv/view/GameView.kt
+++ b/core/src/com/unciv/view/GameView.kt
@@ -23,4 +23,7 @@ class GameView(gameInfo: GameInfo, override val viewer: Civilization, spectatorM
 
     // Data retrieval
     @Readonly fun getTile(tile: Tile): TileView = tileMapView.getTile(tile)
+
+    /** Resolves the same tile from this game's viewing perspective, e.g. after a spectator toggles fog of war. */
+    @Readonly fun getTile(tileView: TileView): TileView = tileMapView.getTile(tileView.unwrap())
 }


### PR DESCRIPTION

In https://github.com/yairm210/Unciv/pull/15508, I had this change, but reverted it (frankly, because I forgot why i did it lol). I think I ought to have kept it in. See the attached save file 
[save_file.json](https://github.com/user-attachments/files/31868595/unciv-c2-repro-validated.json) for a demo. 

 1 Click the German Warrior on the island at the center. The bottom-left panel should say C2 Viewpoint.
 2 Click the hill-and-mine island four hexes directly above it. An Egyptian Warrior is there, hidden by Germany’s fog.
 3 Click Fog of War once to reveal the map, without selecting another tile.
 4 Check the bottom-right tile description, then click that same island again.

  The Egyptian Warrior becomes visible in the tile info box on the bottom right at step 3, but “Warrior - Egypt” appears in the description only after step 4. 

`val tileView = selectedTileView?.let { civView.gameView.getTile(it) }` is needed to recast the view of the tile with respect to the current civ's perspective. 
