### PR TITLE
Fix movement history perspective

### DIFF
--- a/core/src/com/unciv/logic/map/MapVisualization.kt
+++ b/core/src/com/unciv/logic/map/MapVisualization.kt
@@ -3,12 +3,13 @@ package com.unciv.logic.map
 import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.mapunit.MapUnit
+import yairm210.purity.annotations.Readonly
 
 /** Helper class for making decisions about more abstract information that may be displayed on the world map (or fair to use in AI), but which does not have any direct influence on save state, rules, or behaviour. */
 class MapVisualization(val gameInfo: GameInfo, val viewingCiv: Civilization) {
 
     /** @return Whether a unit's past movements should be visible to the player. */
-    fun isUnitPastVisible(unit: MapUnit): Boolean {
+    @Readonly fun isUnitPastVisible(unit: MapUnit): Boolean {
         if (unit.civ == viewingCiv)
             return true
         val checkPositions = sequenceOf(unit.movementMemories.asSequence().map { it.position }, sequenceOf(unit.getTile().position)).flatten()
@@ -18,6 +19,6 @@ class MapVisualization(val gameInfo: GameInfo, val viewingCiv: Civilization) {
     }
 
     /** @return Whether an attack by a unit to a target should be visible to the player. */
-    fun isAttackVisible(attacker: Civilization, source: HexCoord, target: HexCoord) = (attacker == viewingCiv || gameInfo.tileMap[source] in viewingCiv.viewableTiles || gameInfo.tileMap[target] in viewingCiv.viewableTiles)
+    @Readonly fun isAttackVisible(attacker: Civilization, source: HexCoord, target: HexCoord) = (attacker == viewingCiv || gameInfo.tileMap[source] in viewingCiv.viewableTiles || gameInfo.tileMap[target] in viewingCiv.viewableTiles)
     // Attacks by the player civ should always be visible, and attacks by foreign civs should be visible if either the tile they targeted or the attacker's tile are visible. E.G. Civ V shows bombers coming out of the Fog of War.
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -15,7 +15,6 @@ import com.unciv.logic.civilization.PlayerType
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.event.EventBus
 import com.unciv.logic.map.HexCoord
-import com.unciv.logic.map.MapVisualization
 import com.unciv.logic.multiplayer.MultiplayerGameUpdated
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.MultiplayerAuthException
@@ -131,7 +130,6 @@ class WorldScreen(
     val mapHolder = WorldMapHolder(this, gameInfo.tileMap)
 
     internal var waitingForAutosave = false
-    private val mapVisualization = MapVisualization(gameInfo, viewingCiv)
 
     // Floating Widgets going counter-clockwise
     internal val topBar = WorldScreenTopBar(this)
@@ -410,14 +408,9 @@ class WorldScreen(
 
         mapHolder.resetArrows()
         if (UncivGame.Current.settings.showUnitMovements) {
-            val allUnits = gameInfo.civilizations.asSequence().flatMap { it.units.getCivUnits() }
-            val allAttacks = allUnits.map { unit -> unit.attacksSinceTurnStart.asSequence().map { attacked -> Triple(unit.civ, unit.getTile().position, attacked.toHexCoord()) } }.flatten() +
-                gameInfo.civilizations.asSequence().flatMap { civInfo -> civInfo.attacksSinceTurnStart.asSequence().map { Triple(civInfo, it.source, it.target) } }
             mapHolder.updateMovementOverlay(
-                allUnits.filter(mapVisualization::isUnitPastVisible).map { selectedGameView.getForeignMapUnitView(it) },
+                getGameViewConsideringForOfWar(),
                 selectedGameView.civView.getUnits().asSequence(),
-                allAttacks.filter { (attacker, source, target) -> mapVisualization.isAttackVisible(attacker, source, target) }
-                        .map { (_, source, target) -> source to target }
             )
         }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.Batch
-import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
@@ -22,7 +21,7 @@ import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Spy
 import com.unciv.models.UncivSound
 import com.unciv.view.CivView
-import com.unciv.view.ForeignMapUnitView
+import com.unciv.view.GameView
 import com.unciv.view.MapUnitView
 import com.unciv.view.TileView
 import com.unciv.ui.audio.SoundPlayer
@@ -609,14 +608,13 @@ class WorldMapHolder(
     /**
      * Add arrows to show all past and planned movements and attacks, if the options setting to do so is enabled.
      *
-     * @param pastVisibleUnits Sequence of units for which the last turn's movement history can be displayed.
+     * @param gameView Effective fog-of-war perspective for history visibility and arrow endpoints.
      * @param targetVisibleUnits Sequence of units for which the active movement target can be displayed.
-     * @param visibleAttacks Sequence of pairs of [Vector2] positions of the sources and the targets of all attacks that can be displayed.
      * */
-    internal fun updateMovementOverlay(pastVisibleUnits: Sequence<ForeignMapUnitView>, targetVisibleUnits: Sequence<MapUnitView>, visibleAttacks: Sequence<Pair<HexCoord, HexCoord>>) {
-        val tileMapView = worldScreen.selectedGameView.tileMapView
+    internal fun updateMovementOverlay(gameView: GameView, targetVisibleUnits: Sequence<MapUnitView>) {
+        val tileMapView = gameView.tileMapView
         val selectedUnit = worldScreen.bottomUnitTable.selectedUnit
-        for (unitView in pastVisibleUnits) {
+        for (unitView in gameView.getUnitsWithVisibleMovementHistory()) {
             val movementMemories = unitView.getMovementMemories()
             if (movementMemories.isEmpty()) continue
             if (selectedUnit != null && selectedUnit != unitView) continue // When selecting a unit, show only arrows of that unit
@@ -640,7 +638,7 @@ class WorldMapHolder(
             val fromTileView = tileMapView.getTile(unitView.getTile().position()) ?: continue
             addArrow(fromTileView, toTileView, MiscArrowTypes.UnitMoving)
         }
-        for ((from, to) in visibleAttacks) {
+        for ((from, to) in gameView.getVisibleAttacks()) {
             if (selectedUnit != null
                 && selectedUnit.getTile().position() != from
                 && selectedUnit.getTile().position() != to) continue

--- a/core/src/com/unciv/view/GameView.kt
+++ b/core/src/com/unciv/view/GameView.kt
@@ -25,6 +25,10 @@ class GameView(gameInfo: GameInfo, override val viewer: Civilization, spectatorM
     @Readonly fun getForeignCivView(civ: Civilization): ForeignCivView = ForeignCivView(civ, viewer, spectatorMode, this)
 
     // Data retrieval
+    @Readonly fun getTile(tile: Tile): TileView = tileMapView.getTile(tile)
+    /** Resolves the same tile from this game's viewing perspective, e.g. after a spectator toggles fog of war. */
+    @Readonly fun getTile(tileView: TileView): TileView = tileMapView.getTile(tileView.unwrap())
+
     /** Units whose past movements may be displayed from this view's perspective. */
     @Readonly fun getUnitsWithVisibleMovementHistory(): Sequence<ForeignMapUnitView> =
         wrapped.civilizations.asSequence()
@@ -48,6 +52,4 @@ class GameView(gameInfo: GameInfo, override val viewer: Civilization, spectatorM
         }
         return unitAttacks + civilizationAttacks
     }
-    /** Resolves the same tile from this game's viewing perspective, e.g. after a spectator toggles fog of war. */
-    @Readonly fun getTile(tileView: TileView): TileView = tileMapView.getTile(tileView.unwrap())
 }

--- a/core/src/com/unciv/view/GameView.kt
+++ b/core/src/com/unciv/view/GameView.kt
@@ -3,6 +3,8 @@ package com.unciv.view
 import com.unciv.logic.GameInfo
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.map.HexCoord
+import com.unciv.logic.map.MapVisualization
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import yairm210.purity.annotations.Readonly
@@ -11,6 +13,7 @@ import yairm210.purity.annotations.Readonly
 class GameView(gameInfo: GameInfo, override val viewer: Civilization, spectatorMode: Boolean = false) : View<GameInfo>(gameInfo, viewer, spectatorMode) {
     val civView: CivView = CivView(viewer, viewer, spectatorMode, this)
     val tileMapView: TileMapView = TileMapView(gameInfo.tileMap, viewer, spectatorMode, this)
+    private val mapVisualization = MapVisualization(gameInfo, viewer)
 
     // Navigation
     // These can be cached in the future if we see a need, for now - simplicity
@@ -23,4 +26,28 @@ class GameView(gameInfo: GameInfo, override val viewer: Civilization, spectatorM
 
     // Data retrieval
     @Readonly fun getTile(tile: Tile): TileView = tileMapView.getTile(tile)
+
+    /** Units whose past movements may be displayed from this view's perspective. */
+    @Readonly fun getUnitsWithVisibleMovementHistory(): Sequence<ForeignMapUnitView> =
+        wrapped.civilizations.asSequence()
+            .flatMap { it.units.getCivUnits() }
+            .filter(mapVisualization::isUnitPastVisible)
+            .map { getForeignMapUnitView(it) }
+
+    /** Visible attacks, including records retained after the attacking unit has disappeared. */
+    @Readonly fun getVisibleAttacks(): Sequence<Pair<HexCoord, HexCoord>> {
+        val unitAttacks = wrapped.civilizations.asSequence().flatMap { civ ->
+            civ.units.getCivUnits().flatMap { unit ->
+                unit.attacksSinceTurnStart.asSequence()
+                    .filter { mapVisualization.isAttackVisible(civ, unit.getTile().position, it) }
+                    .map { unit.getTile().position to it }
+            }
+        }
+        val civilizationAttacks = wrapped.civilizations.asSequence().flatMap { civ ->
+            civ.attacksSinceTurnStart.asSequence()
+                .filter { mapVisualization.isAttackVisible(civ, it.source, it.target) }
+                .map { it.source to it.target }
+        }
+        return unitAttacks + civilizationAttacks
+    }
 }

--- a/tests/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapMovementOverlayTest.kt
+++ b/tests/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapMovementOverlayTest.kt
@@ -1,0 +1,149 @@
+package com.unciv.ui.screens.worldscreen.worldmap
+
+import com.unciv.Constants
+import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.map.HexCoord
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.TestGame
+import com.unciv.ui.components.MapArrowType
+import com.unciv.ui.components.MiscArrowTypes
+import com.unciv.ui.components.UnitMovementMemoryType
+import com.unciv.ui.screens.worldscreen.WorldScreen
+import com.unciv.ui.screens.worldscreen.unit.UnitTable
+import com.unciv.view.GameView
+import com.unciv.view.MapUnitView
+import com.unciv.view.TileView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Answers
+import org.mockito.Mockito.doCallRealMethod
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@RunWith(BaseTestRunner::class)
+class WorldMapMovementOverlayTest {
+    private lateinit var game: TestGame
+    private lateinit var selectedCiv: Civilization
+    private lateinit var enemy: Civilization
+    private lateinit var restrictedView: GameView
+    private lateinit var spectatorView: GameView
+
+    private data class Arrow(val from: HexCoord, val to: HexCoord, val type: MapArrowType)
+
+    @Before
+    fun setUp() {
+        game = TestGame()
+        game.makeHexagonalMap(4)
+        selectedCiv = game.addCiv(isPlayer = true)
+        enemy = game.addCiv()
+        val spectator = game.addCiv(game.ruleset.nations[Constants.spectator]!!, isPlayer = true)
+        spectator.viewableTiles = game.tileMap.values.toSet()
+        spectator.viewableInvisibleUnitsTiles = spectator.viewableTiles
+        restrictedView = GameView(game.gameInfo, selectedCiv, spectatorMode = true)
+        spectatorView = GameView(game.gameInfo, spectator, spectatorMode = true)
+    }
+
+    @Test
+    fun foreignHistoryIsHiddenOnExploredTilesOutsideCurrentVision() {
+        val unit = unitWithHistory(enemy, HexCoord(-1, 0), HexCoord.Zero)
+        unit.attacksSinceTurnStart.add(HexCoord(1, 0))
+        for (tile in game.tileMap.values) tile.setExplored(selectedCiv, true)
+        selectedCiv.viewableTiles = emptySet()
+
+        assertTrue(drawOverlay(restrictedView).isEmpty())
+
+        selectedCiv.viewableTiles = game.tileMap.values.toSet()
+        assertEquals(setOf(
+            Arrow(HexCoord(-1, 0), HexCoord.Zero, UnitMovementMemoryType.UnitMoved),
+            Arrow(HexCoord.Zero, HexCoord(1, 0), MiscArrowTypes.UnitHasAttacked)
+        ), drawOverlay(restrictedView).toSet())
+    }
+
+    @Test
+    fun spectatorArrowsIncludeEndpointsUnexploredBySelectedCivilization() {
+        val unit = unitWithHistory(enemy, HexCoord(-1, 0), HexCoord.Zero)
+        unit.attacksSinceTurnStart.add(HexCoord(1, 0))
+        enemy.attacksSinceTurnStart.add(Civilization.HistoricalAttackMemory(null, HexCoord(2, 0), HexCoord(2, 1)))
+        assertFalse(game.getTile(HexCoord.Zero).isExplored(selectedCiv))
+        assertTrue(drawOverlay(restrictedView).isEmpty())
+
+        assertEquals(setOf(
+            Arrow(HexCoord(-1, 0), HexCoord.Zero, UnitMovementMemoryType.UnitMoved),
+            Arrow(HexCoord.Zero, HexCoord(1, 0), MiscArrowTypes.UnitHasAttacked),
+            Arrow(HexCoord(2, 0), HexCoord(2, 1), MiscArrowTypes.UnitHasAttacked)
+        ), drawOverlay(spectatorView).toSet())
+    }
+
+    @Test
+    fun selectedUnitStillFiltersHistoryWhenMapPerspectiveChanges() {
+        val selectedUnit = unitWithHistory(selectedCiv, HexCoord(-1, 0), HexCoord.Zero)
+        selectedUnit.attacksSinceTurnStart.add(HexCoord(0, 1))
+        val otherUnit = unitWithHistory(enemy, HexCoord(2, 0), HexCoord(3, 0))
+        otherUnit.attacksSinceTurnStart.add(HexCoord(3, 1))
+        otherUnit.attacksSinceTurnStart.add(HexCoord.Zero)
+
+        assertEquals(setOf(
+            Arrow(HexCoord(-1, 0), HexCoord.Zero, UnitMovementMemoryType.UnitMoved),
+            Arrow(HexCoord.Zero, HexCoord(0, 1), MiscArrowTypes.UnitHasAttacked),
+            Arrow(HexCoord(3, 0), HexCoord.Zero, MiscArrowTypes.UnitHasAttacked)
+        ), drawOverlay(spectatorView, restrictedView.getMapUnitView(selectedUnit)).toSet())
+    }
+
+    @Test
+    fun spectatorPerspectiveKeepsPlannedRoutesForSelectedCivilization() {
+        val selectedUnit = game.addUnit("Warrior", selectedCiv, game.getTile(0, 0))
+        selectedUnit.action = "moveTo 1,0"
+        val otherOwnUnit = game.addUnit("Warrior", selectedCiv, game.getTile(-3, 0))
+        otherOwnUnit.action = "moveTo -2,0"
+        val enemyUnit = game.addUnit("Warrior", enemy, game.getTile(3, 0))
+        enemyUnit.action = "moveTo 3,1"
+
+        assertEquals(setOf(
+            Arrow(HexCoord.Zero, HexCoord(1, 0), MiscArrowTypes.UnitMoving),
+            Arrow(HexCoord(-3, 0), HexCoord(-2, 0), MiscArrowTypes.UnitMoving)
+        ), drawOverlay(spectatorView, restrictedView.getMapUnitView(selectedUnit)).toSet())
+    }
+
+    private fun unitWithHistory(civ: Civilization, from: HexCoord, to: HexCoord): MapUnit {
+        val unit = game.addUnit("Warrior", civ, game.getTile(to))
+        unit.movementMemories = arrayListOf(MapUnit.UnitMovementMemory(from, UnitMovementMemoryType.UnitMoved))
+        return unit
+    }
+
+    /** Run the real overlay method, intercepting drawing so the test needs no graphics context. */
+    private fun drawOverlay(gameView: GameView, selectedUnit: MapUnitView? = null): List<Arrow> {
+        val unitTable = mock(UnitTable::class.java)
+        `when`(unitTable.selectedUnit).thenReturn(selectedUnit)
+        val screen = mock(WorldScreen::class.java) { invocation ->
+            if (invocation.method.name.startsWith("getBottomUnitTable")) unitTable
+            else Answers.RETURNS_DEFAULTS.answer(invocation)
+        }
+        `when`(screen.selectedGameView).thenReturn(restrictedView)
+        val arrows = ArrayList<Arrow>()
+        val holder = mock(WorldMapHolder::class.java) { invocation ->
+            if (invocation.method.name == "addArrow") {
+                val from = invocation.getArgument<TileView>(0).position()
+                val to = invocation.getArgument<TileView>(1).position()
+                // Zero-length segments recorded when a unit has not moved have no visible arrow.
+                if (from != to) arrows.add(Arrow(from, to, invocation.getArgument(2)))
+                null
+            } else Answers.RETURNS_DEFAULTS.answer(invocation)
+        }
+        WorldMapHolder::class.java.getDeclaredField("worldScreen").apply {
+            isAccessible = true
+            set(holder, screen)
+        }
+        val plannedUnits = restrictedView.civView.getUnits().asSequence()
+        val updateMovementOverlay = WorldMapHolder::class.java.methods.single {
+            it.name.startsWith("updateMovementOverlay") && it.parameterCount == 2
+        }
+        updateMovementOverlay.invoke(doCallRealMethod().`when`(holder), gameView, plannedUnits)
+        updateMovementOverlay.invoke(holder, gameView, plannedUnits)
+        return arrows
+    }
+}

--- a/tests/src/com/unciv/view/GameViewMovementHistoryTest.kt
+++ b/tests/src/com/unciv/view/GameViewMovementHistoryTest.kt
@@ -1,0 +1,131 @@
+package com.unciv.view
+
+import com.unciv.Constants
+import com.unciv.logic.civilization.Civilization.HistoricalAttackMemory
+import com.unciv.logic.map.mapunit.MapUnit.UnitMovementMemory
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.TestGame
+import com.unciv.ui.components.UnitMovementMemoryType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(BaseTestRunner::class)
+class GameViewMovementHistoryTest {
+    private val testGame = TestGame().apply { makeHexagonalMap(2) }
+    private val player = testGame.addCiv(testGame.ruleset.nations["Germany"]!!, isPlayer = true)
+    private val enemy = testGame.addCiv(testGame.ruleset.nations["Egypt"]!!)
+    private val spectator = testGame.addCiv(testGame.ruleset.nations[Constants.spectator]!!).apply {
+        viewableTiles = testGame.tileMap.values.toSet()
+        viewableInvisibleUnitsTiles = viewableTiles
+    }
+    private val playerView = GameView(testGame.gameInfo, player, spectatorMode = true)
+    private val spectatorView = GameView(testGame.gameInfo, spectator, spectatorMode = true)
+
+    @Test
+    fun `foreign movement history requires every remembered and current tile to be visible`() {
+        val origin = testGame.getTile(0, 0)
+        val previous = testGame.getTile(0, 1)
+        val current = testGame.getTile(1, 1)
+        val unit = testGame.addUnit("Warrior", enemy, current)
+        unit.movementMemories = arrayListOf(
+            UnitMovementMemory(origin.position, UnitMovementMemoryType.UnitMoved),
+            UnitMovementMemory(previous.position, UnitMovementMemoryType.UnitMoved)
+        )
+        val pathTiles = setOf(origin, previous, current)
+        for (tile in pathTiles) tile.setExplored(player, true)
+
+        for (foggedTile in pathTiles) {
+            player.viewableTiles = pathTiles - foggedTile
+            assertTrue("History must stay hidden when ${foggedTile.position} is fogged",
+                playerView.getUnitsWithVisibleMovementHistory().none())
+            assertSame(unit, spectatorView.getUnitsWithVisibleMovementHistory().single().getUnit())
+        }
+
+        player.viewableTiles = pathTiles
+        val visibleUnit = playerView.getUnitsWithVisibleMovementHistory().single()
+        assertSame(unit, visibleUnit.getUnit())
+        assertSame(playerView, visibleUnit.gameView)
+        assertTrue(visibleUnit.spectatorMode)
+    }
+
+    @Test
+    fun `invisible foreign movement history requires detection on the current tile`() {
+        val origin = testGame.getTile(0, 0)
+        val current = testGame.getTile(1, 0)
+        val unit = testGame.addDefaultMeleeUnitWithUniques(enemy, current, UniqueType.Invisible.text)
+        unit.movementMemories = arrayListOf(
+            UnitMovementMemory(origin.position, UnitMovementMemoryType.UnitMoved)
+        )
+        player.viewableTiles = setOf(origin, current)
+
+        assertTrue(playerView.getUnitsWithVisibleMovementHistory().none())
+        assertSame(unit, spectatorView.getUnitsWithVisibleMovementHistory().single().getUnit())
+
+        player.viewableInvisibleUnitsTiles = setOf(origin)
+        assertTrue(playerView.getUnitsWithVisibleMovementHistory().none())
+
+        player.viewableInvisibleUnitsTiles = setOf(current)
+        assertSame(unit, playerView.getUnitsWithVisibleMovementHistory().single().getUnit())
+    }
+
+    @Test
+    fun `own movement history stays visible after its old tiles leave sight`() {
+        val origin = testGame.getTile(0, 0)
+        val current = testGame.getTile(1, 0)
+        val unit = testGame.addUnit("Warrior", player, current)
+        unit.movementMemories = arrayListOf(
+            UnitMovementMemory(origin.position, UnitMovementMemoryType.UnitMoved)
+        )
+        player.viewableTiles = setOf(current)
+
+        assertSame(unit, playerView.getUnitsWithVisibleMovementHistory().single().getUnit())
+    }
+
+    @Test
+    fun `foreign live and stored attacks are visible when either endpoint is in sight`() {
+        val unitSource = testGame.getTile(0, 0)
+        val unitTarget = testGame.getTile(1, 0)
+        val storedSource = testGame.getTile(0, 1)
+        val storedTarget = testGame.getTile(1, 1)
+        val unit = testGame.addUnit("Warrior", enemy, unitSource)
+        unit.attacksSinceTurnStart.add(unitTarget.position)
+        enemy.attacksSinceTurnStart.add(HistoricalAttackMemory(null, storedSource.position, storedTarget.position))
+        val liveAttack = unitSource.position to unitTarget.position
+        val storedAttack = storedSource.position to storedTarget.position
+        for (tile in listOf(unitSource, unitTarget, storedSource, storedTarget)) tile.setExplored(player, true)
+
+        player.viewableTiles = emptySet()
+        assertTrue(playerView.getVisibleAttacks().none())
+        assertEquals(setOf(liveAttack, storedAttack), spectatorView.getVisibleAttacks().toSet())
+
+        for (visibleTile in listOf(unitSource, unitTarget)) {
+            player.viewableTiles = setOf(visibleTile)
+            assertEquals(listOf(liveAttack), playerView.getVisibleAttacks().toList())
+        }
+        for (visibleTile in listOf(storedSource, storedTarget)) {
+            player.viewableTiles = setOf(visibleTile)
+            assertEquals(listOf(storedAttack), playerView.getVisibleAttacks().toList())
+        }
+    }
+
+    @Test
+    fun `own live and stored attacks stay visible when neither endpoint is in sight`() {
+        val unitSource = testGame.getTile(0, 0)
+        val unitTarget = testGame.getTile(1, 0)
+        val storedSource = testGame.getTile(0, 1)
+        val storedTarget = testGame.getTile(1, 1)
+        val unit = testGame.addUnit("Warrior", player, unitSource)
+        unit.attacksSinceTurnStart.add(unitTarget.position)
+        player.attacksSinceTurnStart.add(HistoricalAttackMemory("Archer", storedSource.position, storedTarget.position))
+        player.viewableTiles = emptySet()
+
+        assertEquals(
+            setOf(unitSource.position to unitTarget.position, storedSource.position to storedTarget.position),
+            playerView.getVisibleAttacks().toSet()
+        )
+    }
+}


### PR DESCRIPTION
Related to https://github.com/yairm210/Unciv/issues/15280

Fix movement and attack arrows to follow the active spectator fog-of-war perspective. History filtering and arrow placement now use the same GameView, preventing hidden enemy activity from appearing through fog and restoring missing arrows when fog is disabled.

[Reproduction save](https://github.com/user-attachments/files/31869682/unciv-c3-repro.json) (generated by GPT): 

  1. Click the C3: Berlin notification, then single-click Berlin’s city hex, avoiding its name banner. Confirm Berlin appears in the bottom-left panel.
  2. Click C3: Arrow test area. The bug: a movement arrow appears across fogged tiles even though the Egyptian Warrior is hidden.
  3. Toggle Fog of War off. A nearby Destroyer appears, but its movement arrow is missing.

Also, I had GPT make some tests. Let me know if these tests look terrible and I'll remove them, I'm not familiar with Kotlin (or videogame) testing approaches. 