### PR TITLE
Apply warmonger penalties to alliance motivation

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -73,7 +73,7 @@ object DiplomacyAutomation {
 
         // Warmongerers don't make good allies
         if (diploManager.hasModifier(DiplomaticModifiers.WarMongerer)) {
-            motivation -= diploManager.getModifier(DiplomaticModifiers.WarMongerer) * civInfo.getPersonality().scaledFocus(PersonalityValue.Diplomacy)
+            motivation += diploManager.getModifier(DiplomaticModifiers.WarMongerer) * civInfo.getPersonality().scaledFocus(PersonalityValue.Diplomacy)
         }
 
         // If the other civ is stronger than we are compelled to be nice to them
@@ -333,7 +333,7 @@ object DiplomacyAutomation {
 
         // Warmongerers don't make good allies
         if (ourDiploManager.hasModifier(DiplomaticModifiers.WarMongerer)) {
-            motivation -= ourDiploManager.getModifier(DiplomaticModifiers.WarMongerer) * civInfo.getPersonality().scaledFocus(PersonalityValue.Diplomacy)
+            motivation += ourDiploManager.getModifier(DiplomaticModifiers.WarMongerer) * civInfo.getPersonality().scaledFocus(PersonalityValue.Diplomacy)
         }
 
         // If they are stronger than us, then we value it a lot more


### PR DESCRIPTION
Warmonger modifiers are negative. Subtracting them can cancel the opinion penalty or even make a warmonger more attractive as an ally.

Add the signed modifier when evaluating friendships and defensive pacts.
