### PR TITLE
Spawn Great Generals at the required point total

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
@@ -68,7 +68,7 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
                 pointsForNextGreatGeneralCounter[unit] = 200
             }
             val requiredPoints = pointsForNextGreatGeneralCounter[unit]
-            if (value > requiredPoints) {
+            if (value >= requiredPoints) {
                 greatGeneralPointsCounter[unit] -= requiredPoints
                 pointsForNextGreatGeneralCounter[unit] += 50
                 return unit


### PR DESCRIPTION
Great Generals currently require more points than the displayed threshold. At exactly 200 points, the first General is not awarded.

Include equality in the threshold check.
