### PR TITLE
Start Golden Ages at the required happiness total

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
@@ -75,7 +75,7 @@ class GoldenAgeManager : IsPartOfGameInfoSerialization {
                     UniqueTriggerActivation.triggerUnique(unique, civInfo)
         }
                 
-        else if (storedHappiness > happinessRequiredForNextGoldenAge()) {
+        else if (storedHappiness >= happinessRequiredForNextGoldenAge()) {
             storedHappiness -= happinessRequiredForNextGoldenAge()
             enterGoldenAge()
             numberOfGoldenAges++


### PR DESCRIPTION
A Golden Age does not start when stored happiness lands exactly on its displayed requirement, for example 505/505 on Standard speed with one city.

Include equality in the threshold check.
