### PR TITLE
Apply city filters to spy effectiveness

### DIFF
--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -466,8 +466,12 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
             }
         }
         var totalEfficiency = 1.0
-        totalEfficiency *= (100.0 + friendlyUniques.sumOf { it.params[0].toInt() }) / 100
-        totalEfficiency *= (100.0 + enemyUniques.sumOf { it.params[0].toInt() }) / 100
+        totalEfficiency *= (100.0 + friendlyUniques
+            .filter { city == null || city.matchesFilter(it.params[1], civInfo) }
+            .sumOf { it.params[0].toInt() }) / 100
+        totalEfficiency *= (100.0 + enemyUniques
+            .filter { city != null && city.matchesFilter(it.params[1]) }
+            .sumOf { it.params[0].toInt() }) / 100
         return totalEfficiency.coerceAtLeast(0.0)
     }
 


### PR DESCRIPTION
Spy effectiveness uniques currently ignore their city filter, so a capital-only modifier also applies in other cities.

Apply each filter before summing the modifiers, using the spy's civilization for friendly effects and the city's civilization for enemy effects.
