### PR TITLE
Preserve multiplayer timers when copying game settings

### DIFF
--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -104,6 +104,9 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
         parameters.isOnlineMultiplayer = isOnlineMultiplayer
         parameters.multiplayerServerUrl = multiplayerServerUrl
         parameters.anyoneCanSpectate = anyoneCanSpectate
+        parameters.minutesUntilSkipTurn = minutesUntilSkipTurn
+        parameters.minutesUntilForceResign = minutesUntilForceResign
+        parameters.minutesRecoveredPerTurn = minutesRecoveredPerTurn
         parameters.baseRuleset = baseRuleset
         parameters.mods = LinkedHashSet(mods)
         parameters.maxTurns = maxTurns


### PR DESCRIPTION
GameParameters.clone() leaves the three multiplayer timers at their defaults.

Copy their configured values so reused game settings keep the chosen skip-turn, forced-resignation and time-recovery limits.
