### PR TITLE
Improve desktop font rendering with mipmaps and preserve glyph contrast

### DIFF
--- a/android/src/com/unciv/app/AndroidFont.kt
+++ b/android/src/com/unciv/app/AndroidFont.kt
@@ -104,11 +104,15 @@ class AndroidFont : FontImplementation {
         canvas.drawText(symbolString, 0f, metric.leading + metric.ascent + 1f, paint)
 
         val pixmap = Pixmap(width, height, Pixmap.Format.RGBA8888)
+        // Preserve white RGB in transparent pixels so filtering does not darken text
+        // edges. Keep the colours of visible pixels, including Android's colour emoji.
+        pixmap.blending = Pixmap.Blending.None
         val data = IntArray(width * height)
         bitmap.getPixels(data, 0, width, 0, 0, width, height) // faster than bitmap[x, y]
         for (x in 0 until width) {
             for (y in 0 until height) {
-                pixmap.drawPixel(x, y, Integer.rotateLeft(data[x + (y * width)], 8))
+                val rgba = Integer.rotateLeft(data[x + (y * width)], 8)
+                pixmap.drawPixel(x, y, if ((rgba and 255) == 0) 0xffffff00.toInt() else rgba)
             }
         }
         bitmap.recycle()

--- a/core/src/com/unciv/ui/components/fonts/FontImplementation.kt
+++ b/core/src/com/unciv/ui/components/fonts/FontImplementation.kt
@@ -1,9 +1,16 @@
 package com.unciv.ui.components.fonts
 
 import com.badlogic.gdx.graphics.Pixmap
+import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.graphics.g2d.BitmapFont
 
 interface FontImplementation {
+    /** Opt in to mipmapped font atlases on platforms where they have been enabled. */
+    val useMipMaps: Boolean get() = false
+
+    /** Apply platform-specific sampling settings when a font atlas page is created. */
+    fun configureFontTexture(texture: Texture) {}
+
     fun setFontFamily(fontFamilyData: FontFamilyData, size: Int)
     fun getFontSize(): Int
 

--- a/core/src/com/unciv/ui/components/fonts/FontImplementation.kt
+++ b/core/src/com/unciv/ui/components/fonts/FontImplementation.kt
@@ -5,9 +5,6 @@ import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.graphics.g2d.BitmapFont
 
 interface FontImplementation {
-    /** Opt in to mipmapped font atlases on platforms where they have been enabled. */
-    val useMipMaps: Boolean get() = false
-
     /** Apply platform-specific sampling settings when a font atlas page is created. */
     fun configureFontTexture(texture: Texture) {}
 

--- a/core/src/com/unciv/ui/components/fonts/MipmappedFontTexture.kt
+++ b/core/src/com/unciv/ui/components/fonts/MipmappedFontTexture.kt
@@ -1,0 +1,63 @@
+package com.unciv.ui.components.fonts
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Pixmap
+import com.badlogic.gdx.graphics.Texture
+import com.badlogic.gdx.graphics.TextureData
+import com.badlogic.gdx.graphics.glutils.PixmapTextureData
+
+/** A font atlas page whose mipmaps are refreshed when a batch binds it for drawing.
+ * The packer retains the complete CPU image for context restoration; glyph uploads
+ * update only level zero, so multiple labels can share one mipmap regeneration.
+ */
+internal class MipmappedFontTexture(
+    private val pagePixmap: Pixmap,
+    private val fontImplementation: FontImplementation
+) : Texture(PixmapTextureData(pagePixmap, pagePixmap.format, true, false, true)) {
+    private var mipmapsDirty = false
+    private var disposed = false
+
+    fun uploadGlyph(pixmap: Pixmap, x: Int, y: Int) {
+        // Bypass our draw-time bind hook: adding another glyph must not regenerate
+        // mipmaps left dirty by a previous label. The packer already updated pagePixmap.
+        super.bind()
+        Gdx.gl.glTexSubImage2D(glTarget, 0, x, y, pixmap.width, pixmap.height,
+            pixmap.glFormat, pixmap.glType, pixmap.pixels)
+        mipmapsDirty = true
+    }
+
+    override fun bind() {
+        super.bind()
+        updateMipmaps()
+    }
+
+    override fun bind(unit: Int) {
+        super.bind(unit)
+        updateMipmaps()
+    }
+
+    private fun updateMipmaps() {
+        if (!mipmapsDirty) return
+        Gdx.gl.glGenerateMipmap(glTarget)
+        mipmapsDirty = false
+    }
+
+    override fun load(data: TextureData) {
+        // A full upload (including context restoration) builds mipmaps from the CPU
+        // page. Do not regenerate the old GPU contents when Texture.load calls bind().
+        mipmapsDirty = false
+        super.load(data)
+    }
+
+    override fun reload() {
+        super.reload()
+        fontImplementation.configureFontTexture(this)
+    }
+
+    override fun dispose() {
+        if (disposed) return
+        disposed = true
+        super.dispose()
+        pagePixmap.dispose()
+    }
+}

--- a/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
+++ b/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
@@ -91,7 +91,6 @@ class NativeBitmapFontData(
         val assumeRoundIcon = isFontRulesetIcon && charPixmap.guessIsRoundSurroundedByTransparency()
 
         val rect = packer.pack(charPixmap)
-        charPixmap.dispose()
         glyph.page = packer.pages.size - 1 // Glyph is always packed into the last page for now.
         glyph.srcX = rect.x
         glyph.srcY = rect.y
@@ -102,10 +101,13 @@ class NativeBitmapFontData(
         // If a page was added, create a new texture region for the incrementally added glyph.
         if (regions.size <= glyph.page)
             updateTextureRegions()
+        else if (useMipMaps)
+            (regions[glyph.page].texture as MipmappedFontTexture).uploadGlyph(charPixmap, rect.x, rect.y)
+        charPixmap.dispose()
 
         setGlyphRegion(glyph, regions.get(glyph.page))
         setGlyph(ch.code, glyph)
-        dirty = true
+        if (!useMipMaps) dirty = true
 
         return glyph
     }
@@ -161,8 +163,8 @@ class NativeBitmapFontData(
     }
 
     override fun getGlyphs(run: GlyphLayout.GlyphRun, str: CharSequence, start: Int, end: Int, lastGlyph: BitmapFont.Glyph?) {
-        // Direct subimage uploads update only level zero. For mipmapped fonts, let the
-        // packer upload dirty pages and regenerate their mipmaps after adding glyphs.
+        // Mipmapped pages use our own incremental uploads and regenerate mipmaps at
+        // draw time. The packer only manages their CPU images and glyph placement.
         packer.packToTexture = !useMipMaps
         super.getGlyphs(run, str, start, end, lastGlyph)
         if (dirty) {
@@ -173,13 +175,25 @@ class NativeBitmapFontData(
 
     private fun updateTextureRegions() {
         val previousPageCount = regions.size
-        packer.updateTextureRegions(regions, minFilter, magFilter, useMipMaps)
+        if (useMipMaps) {
+            while (regions.size < packer.pages.size) {
+                val texture = MipmappedFontTexture(packer.pages[regions.size].pixmap, fontImplementation)
+                texture.setFilter(minFilter, magFilter)
+                regions.add(TextureRegion(texture))
+            }
+        } else {
+            packer.updateTextureRegions(regions, minFilter, magFilter, false)
+        }
         for (page in previousPageCount until regions.size)
             fontImplementation.configureFontTexture(regions[page].texture)
     }
 
     override fun dispose() {
-        packer.dispose()
+        // Mipmapped textures own their CPU pages, just like PixmapPacker's textures.
+        // Calling packer.dispose() for those pages would dispose their pixmaps twice,
+        // since the packer itself has no reference to our custom textures.
+        if (useMipMaps) regions.forEach { it.texture.dispose() }
+        else packer.dispose()
     }
 
 }

--- a/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
+++ b/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
@@ -23,7 +23,11 @@ class NativeBitmapFontData(
     private var dirty = false
     private val packer: PixmapPacker
 
-    private val filter = Texture.TextureFilter.Linear
+    private val useMipMaps = fontImplementation.useMipMaps
+    // Trilinear minification smooths both within and between mip levels. Magnification
+    // must use a non-mipmap filter, since mip levels only help when shrinking text.
+    private val minFilter = if (useMipMaps) Texture.TextureFilter.MipMapLinearLinear else Texture.TextureFilter.Linear
+    private val magFilter = Texture.TextureFilter.Linear
 
     private companion object {
         /** How to get the alpha channel in a Pixmap.getPixel return value (Int) - it's the LSB */
@@ -53,13 +57,15 @@ class NativeBitmapFontData(
         // Create a packer.
         val size = 1024
         val packStrategy = PixmapPacker.GuillotineStrategy()
-        packer = PixmapPacker(size, size, Pixmap.Format.RGBA8888, 1, false, packStrategy)
+        // Leave room between glyphs for the wider sampling footprint of mipmaps at UI sizes.
+        val padding = if (useMipMaps) 16 else 1
+        packer = PixmapPacker(size, size, Pixmap.Format.RGBA8888, padding, false, packStrategy)
         packer.transparentColor = Color.WHITE
         packer.transparentColor.a = 0f
 
         // Generate texture regions.
         regions = Array()
-        packer.updateTextureRegions(regions, filter, filter, false)
+        updateTextureRegions()
 
         // Set space glyph.
         val spaceGlyph = getGlyph(' ')
@@ -95,7 +101,7 @@ class NativeBitmapFontData(
 
         // If a page was added, create a new texture region for the incrementally added glyph.
         if (regions.size <= glyph.page)
-            packer.updateTextureRegions(regions, filter, filter, false)
+            updateTextureRegions()
 
         setGlyphRegion(glyph, regions.get(glyph.page))
         setGlyph(ch.code, glyph)
@@ -155,12 +161,21 @@ class NativeBitmapFontData(
     }
 
     override fun getGlyphs(run: GlyphLayout.GlyphRun, str: CharSequence, start: Int, end: Int, lastGlyph: BitmapFont.Glyph?) {
-        packer.packToTexture = true // All glyphs added after this are packed directly to the texture.
+        // Direct subimage uploads update only level zero. For mipmapped fonts, let the
+        // packer upload dirty pages and regenerate their mipmaps after adding glyphs.
+        packer.packToTexture = !useMipMaps
         super.getGlyphs(run, str, start, end, lastGlyph)
         if (dirty) {
             dirty = false
-            packer.updateTextureRegions(regions, filter, filter, false)
+            updateTextureRegions()
         }
+    }
+
+    private fun updateTextureRegions() {
+        val previousPageCount = regions.size
+        packer.updateTextureRegions(regions, minFilter, magFilter, useMipMaps)
+        for (page in previousPageCount until regions.size)
+            fontImplementation.configureFontTexture(regions[page].texture)
     }
 
     override fun dispose() {

--- a/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
+++ b/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
@@ -4,7 +4,6 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.graphics.g2d.BitmapFont
-import com.badlogic.gdx.graphics.g2d.GlyphLayout
 import com.badlogic.gdx.graphics.g2d.PixmapPacker
 import com.badlogic.gdx.graphics.g2d.TextureRegion
 import com.badlogic.gdx.utils.Array
@@ -20,13 +19,11 @@ class NativeBitmapFontData(
 
     val regions: Array<TextureRegion>
 
-    private var dirty = false
     private val packer: PixmapPacker
 
-    private val useMipMaps = fontImplementation.useMipMaps
     // Trilinear minification smooths both within and between mip levels. Magnification
     // must use a non-mipmap filter, since mip levels only help when shrinking text.
-    private val minFilter = if (useMipMaps) Texture.TextureFilter.MipMapLinearLinear else Texture.TextureFilter.Linear
+    private val minFilter = Texture.TextureFilter.MipMapLinearLinear
     private val magFilter = Texture.TextureFilter.Linear
 
     private companion object {
@@ -58,8 +55,11 @@ class NativeBitmapFontData(
         val size = 1024
         val packStrategy = PixmapPacker.GuillotineStrategy()
         // Leave room between glyphs for the wider sampling footprint of mipmaps at UI sizes.
-        val padding = if (useMipMaps) 16 else 1
+        val padding = 16
         packer = PixmapPacker(size, size, Pixmap.Format.RGBA8888, padding, false, packStrategy)
+        // Only use the packer for CPU images and glyph placement. Our textures handle
+        // incremental uploads and defer mipmap regeneration until drawing.
+        packer.packToTexture = false
         packer.transparentColor = Color.WHITE
         packer.transparentColor.a = 0f
 
@@ -101,13 +101,12 @@ class NativeBitmapFontData(
         // If a page was added, create a new texture region for the incrementally added glyph.
         if (regions.size <= glyph.page)
             updateTextureRegions()
-        else if (useMipMaps)
+        else
             (regions[glyph.page].texture as MipmappedFontTexture).uploadGlyph(charPixmap, rect.x, rect.y)
         charPixmap.dispose()
 
         setGlyphRegion(glyph, regions.get(glyph.page))
         setGlyph(ch.code, glyph)
-        if (!useMipMaps) dirty = true
 
         return glyph
     }
@@ -162,38 +161,20 @@ class NativeBitmapFontData(
         return fontImplementation.getCharPixmap(DiacriticSupport.getStringFor(ch))
     }
 
-    override fun getGlyphs(run: GlyphLayout.GlyphRun, str: CharSequence, start: Int, end: Int, lastGlyph: BitmapFont.Glyph?) {
-        // Mipmapped pages use our own incremental uploads and regenerate mipmaps at
-        // draw time. The packer only manages their CPU images and glyph placement.
-        packer.packToTexture = !useMipMaps
-        super.getGlyphs(run, str, start, end, lastGlyph)
-        if (dirty) {
-            dirty = false
-            updateTextureRegions()
-        }
-    }
-
     private fun updateTextureRegions() {
-        val previousPageCount = regions.size
-        if (useMipMaps) {
-            while (regions.size < packer.pages.size) {
-                val texture = MipmappedFontTexture(packer.pages[regions.size].pixmap, fontImplementation)
-                texture.setFilter(minFilter, magFilter)
-                regions.add(TextureRegion(texture))
-            }
-        } else {
-            packer.updateTextureRegions(regions, minFilter, magFilter, false)
+        while (regions.size < packer.pages.size) {
+            val texture = MipmappedFontTexture(packer.pages[regions.size].pixmap, fontImplementation)
+            texture.setFilter(minFilter, magFilter)
+            regions.add(TextureRegion(texture))
+            fontImplementation.configureFontTexture(texture)
         }
-        for (page in previousPageCount until regions.size)
-            fontImplementation.configureFontTexture(regions[page].texture)
     }
 
     override fun dispose() {
         // Mipmapped textures own their CPU pages, just like PixmapPacker's textures.
         // Calling packer.dispose() for those pages would dispose their pixmaps twice,
         // since the packer itself has no reference to our custom textures.
-        if (useMipMaps) regions.forEach { it.texture.dispose() }
-        else packer.dispose()
+        regions.forEach { it.texture.dispose() }
     }
 
 }

--- a/desktop/src/com/unciv/app/desktop/DesktopFont.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopFont.kt
@@ -1,6 +1,8 @@
 package com.unciv.app.desktop
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Pixmap
+import com.badlogic.gdx.graphics.Texture
 import com.unciv.UncivGame
 import com.unciv.ui.components.fonts.FontFamilyData
 import com.unciv.ui.components.fonts.FontImplementation
@@ -13,12 +15,22 @@ import java.awt.GraphicsEnvironment
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.util.Locale
+import org.lwjgl.opengl.GL14
 
 
 class DesktopFont : FontImplementation {
 
+    override val useMipMaps = true
+
+    override fun configureFontTexture(texture: Texture) {
+        // Prefer slightly finer mip levels to sharpen text while retaining trilinear filtering.
+        texture.bind()
+        Gdx.gl.glTexParameterf(texture.glTarget, GL14.GL_TEXTURE_LOD_BIAS, -0.5f)
+    }
+
     private lateinit var font: Font
     private lateinit var metric: FontMetrics
+    private lateinit var fallbackMetric: FontMetrics
 
     override fun setFontFamily(fontFamilyData: FontFamilyData, size: Int) {
 
@@ -36,6 +48,7 @@ class DesktopFont : FontImplementation {
         val bufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR)
         val graphics = bufferedImage.createGraphics()
         this.metric = graphics.getFontMetrics(font)
+        fallbackMetric = graphics.getFontMetrics(Font(Font.DIALOG, Font.PLAIN, size))
         graphics.dispose()
     }
 
@@ -66,7 +79,12 @@ class DesktopFont : FontImplementation {
     override fun getCharPixmap(symbolString: String) = getCharPixmapCommon(symbolString, metric.stringWidth(symbolString))
 
     private fun getCharPixmapCommon(symbolString: String, measuredWidth: Int): Pixmap {
-        var width = measuredWidth
+        // Physical fonts such as Microsoft YaHei may lack typographic spaces used by
+        // the UI (U+2004, U+2009). Their missing-glyph box is neither blank nor the right
+        // width. Borrow the logical font's spacing, without changing visible glyphs.
+        val unsupportedSpace = symbolString.isNotEmpty() &&
+            symbolString.all { Character.isSpaceChar(it) } && font.canDisplayUpTo(symbolString) != -1
+        var width = if (unsupportedSpace) fallbackMetric.stringWidth(symbolString) else measuredWidth
         var height = metric.height
         if (width == 0) {
             // This happens e.g. for the Tab character
@@ -79,13 +97,20 @@ class DesktopFont : FontImplementation {
         g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
         g.font = font
         g.color = Color.WHITE
-        g.drawString(symbolString, 0, metric.leading + metric.ascent)
+        if (!unsupportedSpace)
+            g.drawString(symbolString, 0, metric.leading + metric.ascent)
 
         val pixmap = Pixmap(bi.width, bi.height, Pixmap.Format.RGBA8888)
+        // Mipmaps average RGB as well as alpha. Transparent black around white glyphs
+        // would darken their edges, then alpha blending would attenuate them again.
+        // Keep white RGB even at zero coverage, and copy without blending to preserve it.
+        pixmap.blending = Pixmap.Blending.None
         val data = bi.getRGB(0, 0, bi.width, bi.height, null, 0, bi.width)
         for (i in 0 until bi.width) {
             for (j in 0 until bi.height) {
-                pixmap.setColor(Integer.reverseBytes(data[i + (j * bi.width)]))
+                val pixel = data[i + (j * bi.width)]
+                val rgba = 0xffffff00.toInt() or (pixel ushr 24)
+                pixmap.setColor(rgba)
                 pixmap.drawPixel(i, j)
             }
         }

--- a/desktop/src/com/unciv/app/desktop/DesktopFont.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopFont.kt
@@ -30,7 +30,6 @@ class DesktopFont : FontImplementation {
 
     private lateinit var font: Font
     private lateinit var metric: FontMetrics
-    private lateinit var fallbackMetric: FontMetrics
 
     override fun setFontFamily(fontFamilyData: FontFamilyData, size: Int) {
 
@@ -48,7 +47,6 @@ class DesktopFont : FontImplementation {
         val bufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR)
         val graphics = bufferedImage.createGraphics()
         this.metric = graphics.getFontMetrics(font)
-        fallbackMetric = graphics.getFontMetrics(Font(Font.DIALOG, Font.PLAIN, size))
         graphics.dispose()
     }
 
@@ -79,12 +77,7 @@ class DesktopFont : FontImplementation {
     override fun getCharPixmap(symbolString: String) = getCharPixmapCommon(symbolString, metric.stringWidth(symbolString))
 
     private fun getCharPixmapCommon(symbolString: String, measuredWidth: Int): Pixmap {
-        // Physical fonts such as Microsoft YaHei may lack typographic spaces used by
-        // the UI (U+2004, U+2009). Their missing-glyph box is neither blank nor the right
-        // width. Borrow the logical font's spacing, without changing visible glyphs.
-        val unsupportedSpace = symbolString.isNotEmpty() &&
-            symbolString.all { Character.isSpaceChar(it) } && font.canDisplayUpTo(symbolString) != -1
-        var width = if (unsupportedSpace) fallbackMetric.stringWidth(symbolString) else measuredWidth
+        var width = measuredWidth
         var height = metric.height
         if (width == 0) {
             // This happens e.g. for the Tab character
@@ -97,8 +90,7 @@ class DesktopFont : FontImplementation {
         g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
         g.font = font
         g.color = Color.WHITE
-        if (!unsupportedSpace)
-            g.drawString(symbolString, 0, metric.leading + metric.ascent)
+        g.drawString(symbolString, 0, metric.leading + metric.ascent)
 
         val pixmap = Pixmap(bi.width, bi.height, Pixmap.Format.RGBA8888)
         // Mipmaps average RGB as well as alpha. Transparent black around white glyphs

--- a/desktop/src/com/unciv/app/desktop/DesktopFont.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopFont.kt
@@ -20,8 +20,6 @@ import org.lwjgl.opengl.GL14
 
 class DesktopFont : FontImplementation {
 
-    override val useMipMaps = true
-
     override fun configureFontTexture(texture: Texture) {
         // Prefer slightly finer mip levels to sharpen text while retaining trilinear filtering.
         texture.bind()
@@ -95,15 +93,14 @@ class DesktopFont : FontImplementation {
         val pixmap = Pixmap(bi.width, bi.height, Pixmap.Format.RGBA8888)
         // Mipmaps average RGB as well as alpha. Transparent black around white glyphs
         // would darken their edges, then alpha blending would attenuate them again.
-        // Keep white RGB even at zero coverage, and copy without blending to preserve it.
+        // Keep white RGB at zero coverage, preserving visible colours from colour fonts.
+        // Copy without blending to preserve the RGB of fully transparent pixels.
         pixmap.blending = Pixmap.Blending.None
         val data = bi.getRGB(0, 0, bi.width, bi.height, null, 0, bi.width)
         for (i in 0 until bi.width) {
             for (j in 0 until bi.height) {
-                val pixel = data[i + (j * bi.width)]
-                val rgba = 0xffffff00.toInt() or (pixel ushr 24)
-                pixmap.setColor(rgba)
-                pixmap.drawPixel(i, j)
+                val rgba = Integer.rotateLeft(data[i + (j * bi.width)], 8)
+                pixmap.drawPixel(i, j, if ((rgba and 255) == 0) 0xffffff00.toInt() else rgba)
             }
         }
         g.dispose()

--- a/tests/src/com/unciv/ui/components/fonts/NativeBitmapFontDataTest.kt
+++ b/tests/src/com/unciv/ui/components/fonts/NativeBitmapFontDataTest.kt
@@ -1,0 +1,76 @@
+package com.unciv.ui.components.fonts
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Pixmap
+import com.badlogic.gdx.graphics.Texture.TextureFilter
+import com.badlogic.gdx.graphics.g2d.GlyphLayout
+import com.unciv.testing.GdxTestRunner
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.clearInvocations
+import org.mockito.Mockito.mockingDetails
+
+@RunWith(GdxTestRunner::class)
+class NativeBitmapFontDataTest {
+    private class TestFont(override val useMipMaps: Boolean) : FontImplementation {
+        override fun setFontFamily(fontFamilyData: FontFamilyData, size: Int) {}
+        override fun getFontSize() = 100
+        override fun getCharPixmap(symbolString: String) = Pixmap(50, 100, Pixmap.Format.RGBA8888).apply {
+            setColor(1f, 1f, 1f, 1f)
+            fill()
+        }
+        override fun getSystemFonts() = emptySequence<FontFamilyData>()
+        override fun getMetrics() = FontMetricsCommon(80f, 20f, 100f, 0f)
+    }
+
+    private fun mipmapsUploaded() = mockingDetails(Gdx.gl).invocations.any {
+        it.method.name == "glGenerateMipmap" ||
+            (it.method.name == "glTexImage2D" && (it.arguments[1] as Int) > 0)
+    }
+
+    @Test
+    fun mipmapsIncludeCharactersAddedAfterTextureCreation() {
+        val data = NativeBitmapFontData(TestFont(true))
+        try {
+            val texture = data.regions.first().texture
+            assertTrue(texture.textureData.useMipMaps())
+            assertEquals(TextureFilter.MipMapLinearLinear, texture.minFilter)
+            assertEquals(TextureFilter.Linear, texture.magFilter)
+
+            // The space glyph already created the page texture. Both subsequent additions
+            // must refresh lower levels, even after the incremental packing path is active.
+            for (text in listOf("A", "B")) {
+                clearInvocations(Gdx.gl)
+                data.getGlyphs(GlyphLayout.GlyphRun(), text, 0, text.length, null)
+                assertTrue("Missing mipmap update for $text", mipmapsUploaded())
+            }
+            clearInvocations(Gdx.gl)
+            data.getGlyphs(GlyphLayout.GlyphRun(), "AB", 0, 2, null)
+            assertFalse("Cached glyphs should not regenerate mipmaps", mipmapsUploaded())
+        } finally {
+            data.regions.forEach { it.texture.dispose() }
+            data.dispose()
+        }
+    }
+
+    @Test
+    fun otherPlatformsKeepLinearFilteringWithoutMipmaps() {
+        val data = NativeBitmapFontData(TestFont(false))
+        try {
+            val texture = data.regions.first().texture
+            assertFalse(texture.textureData.useMipMaps())
+            assertEquals(TextureFilter.Linear, texture.minFilter)
+            assertEquals(TextureFilter.Linear, texture.magFilter)
+            clearInvocations(Gdx.gl)
+            data.getGlyphs(GlyphLayout.GlyphRun(), "AB", 0, 2, null)
+            assertFalse(mipmapsUploaded())
+            assertTrue(mockingDetails(Gdx.gl).invocations.any { it.method.name == "glTexSubImage2D" })
+        } finally {
+            data.regions.forEach { it.texture.dispose() }
+            data.dispose()
+        }
+    }
+}

--- a/tests/src/com/unciv/ui/components/fonts/NativeBitmapFontDataTest.kt
+++ b/tests/src/com/unciv/ui/components/fonts/NativeBitmapFontDataTest.kt
@@ -4,6 +4,8 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.Texture.TextureFilter
 import com.badlogic.gdx.graphics.g2d.GlyphLayout
+import com.badlogic.gdx.graphics.g2d.SpriteBatch
+import com.badlogic.gdx.graphics.glutils.ShaderProgram
 import com.unciv.testing.GdxTestRunner
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -12,13 +14,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.clearInvocations
 import org.mockito.Mockito.mockingDetails
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 @RunWith(GdxTestRunner::class)
 class NativeBitmapFontDataTest {
-    private class TestFont(override val useMipMaps: Boolean) : FontImplementation {
+    private class TestFont(override val useMipMaps: Boolean, private val glyphSize: Int = 50) : FontImplementation {
         override fun setFontFamily(fontFamilyData: FontFamilyData, size: Int) {}
         override fun getFontSize() = 100
-        override fun getCharPixmap(symbolString: String) = Pixmap(50, 100, Pixmap.Format.RGBA8888).apply {
+        override fun getCharPixmap(symbolString: String) = Pixmap(glyphSize, glyphSize, Pixmap.Format.RGBA8888).apply {
             setColor(1f, 1f, 1f, 1f)
             fill()
         }
@@ -32,26 +36,86 @@ class NativeBitmapFontDataTest {
     }
 
     @Test
-    fun mipmapsIncludeCharactersAddedAfterTextureCreation() {
+    fun multipleLabelsShareOneMipmapUpdateAtBatchFlush() {
         val data = NativeBitmapFontData(TestFont(true))
+        `when`(Gdx.gl.glGenBuffer()).thenReturn(1)
+        val batch = SpriteBatch(1000, mock(ShaderProgram::class.java))
         try {
             val texture = data.regions.first().texture
             assertTrue(texture.textureData.useMipMaps())
             assertEquals(TextureFilter.MipMapLinearLinear, texture.minFilter)
             assertEquals(TextureFilter.Linear, texture.magFilter)
 
-            // The space glyph already created the page texture. Both subsequent additions
-            // must refresh lower levels, even after the incremental packing path is active.
+            clearInvocations(Gdx.gl)
+            batch.begin()
+            // Simulate two labels laying out new characters and queuing draws. Neither
+            // the layout nor the second subimage upload should regenerate mipmaps.
             for (text in listOf("A", "B")) {
-                clearInvocations(Gdx.gl)
                 data.getGlyphs(GlyphLayout.GlyphRun(), text, 0, text.length, null)
-                assertTrue("Missing mipmap update for $text", mipmapsUploaded())
+                batch.draw(texture, 0f, 0f, 10f, 10f)
+                assertFalse("Premature mipmap update for $text", mipmapsUploaded())
             }
+            assertEquals(2, mockingDetails(Gdx.gl).invocations.count { it.method.name == "glTexSubImage2D" })
+            assertFalse(mockingDetails(Gdx.gl).invocations.any { it.method.name == "glTexImage2D" })
+            batch.end()
+            assertEquals(1, mockingDetails(Gdx.gl).invocations.count { it.method.name == "glGenerateMipmap" })
+            val calls = mockingDetails(Gdx.gl).invocations.map { it.method.name }
+            assertTrue("Mipmaps must be ready before drawing", calls.indexOf("glGenerateMipmap") < calls.indexOf("glDrawElements"))
+
             clearInvocations(Gdx.gl)
             data.getGlyphs(GlyphLayout.GlyphRun(), "AB", 0, 2, null)
+            texture.bind()
             assertFalse("Cached glyphs should not regenerate mipmaps", mipmapsUploaded())
+
+            // A later addition must also become visible on the very next bind.
+            data.getGlyphs(GlyphLayout.GlyphRun(), "C", 0, 1, null)
+            assertFalse(mipmapsUploaded())
+            texture.bind(0)
+            assertEquals(1, mockingDetails(Gdx.gl).invocations.count { it.method.name == "glGenerateMipmap" })
         } finally {
+            batch.dispose()
             data.regions.forEach { it.texture.dispose() }
+            data.dispose()
+        }
+    }
+
+    @Test
+    fun newPageDoesNotFlushPendingMipmapsOnAnotherPage() {
+        val data = NativeBitmapFontData(TestFont(true, 400))
+        try {
+            val firstTexture = data.regions.first().texture
+            data.getGlyphs(GlyphLayout.GlyphRun(), "ABC", 0, 3, null)
+            assertEquals(1, data.regions.size)
+            data.getGlyphs(GlyphLayout.GlyphRun(), "D", 0, 1, null)
+            assertEquals(2, data.regions.size)
+            clearInvocations(Gdx.gl)
+            data.regions[1].texture.bind()
+            assertFalse("New page already has mipmaps", mipmapsUploaded())
+            firstTexture.bind()
+            assertEquals(1, mockingDetails(Gdx.gl).invocations.count { it.method.name == "glGenerateMipmap" })
+        } finally {
+            data.dispose()
+        }
+    }
+
+    @Test
+    fun fullReloadRetainsNewGlyphsWithoutGeneratingStaleMipmaps() {
+        val data = NativeBitmapFontData(TestFont(true))
+        try {
+            data.getGlyphs(GlyphLayout.GlyphRun(), "A", 0, 1, null)
+            val texture = data.regions.first().texture
+            val glyph = data.getGlyph('A')
+            assertEquals(-1, texture.textureData.consumePixmap().getPixel(glyph.srcX, glyph.srcY))
+            clearInvocations(Gdx.gl)
+            texture.load(texture.textureData)
+            assertTrue("Full upload must rebuild mipmaps", mipmapsUploaded())
+            val calls = mockingDetails(Gdx.gl).invocations.map { it.method.name }
+            assertTrue("No generation from stale contents before the full upload",
+                calls.indexOf("glGenerateMipmap") == -1 || calls.indexOf("glTexImage2D") < calls.indexOf("glGenerateMipmap"))
+            clearInvocations(Gdx.gl)
+            texture.bind()
+            assertFalse(mipmapsUploaded())
+        } finally {
             data.dispose()
         }
     }

--- a/tests/src/com/unciv/ui/components/fonts/NativeBitmapFontDataTest.kt
+++ b/tests/src/com/unciv/ui/components/fonts/NativeBitmapFontDataTest.kt
@@ -19,7 +19,7 @@ import org.mockito.Mockito.`when`
 
 @RunWith(GdxTestRunner::class)
 class NativeBitmapFontDataTest {
-    private class TestFont(override val useMipMaps: Boolean, private val glyphSize: Int = 50) : FontImplementation {
+    private class TestFont(private val glyphSize: Int = 50) : FontImplementation {
         override fun setFontFamily(fontFamilyData: FontFamilyData, size: Int) {}
         override fun getFontSize() = 100
         override fun getCharPixmap(symbolString: String) = Pixmap(glyphSize, glyphSize, Pixmap.Format.RGBA8888).apply {
@@ -37,7 +37,7 @@ class NativeBitmapFontDataTest {
 
     @Test
     fun multipleLabelsShareOneMipmapUpdateAtBatchFlush() {
-        val data = NativeBitmapFontData(TestFont(true))
+        val data = NativeBitmapFontData(TestFont())
         `when`(Gdx.gl.glGenBuffer()).thenReturn(1)
         val batch = SpriteBatch(1000, mock(ShaderProgram::class.java))
         try {
@@ -81,7 +81,7 @@ class NativeBitmapFontDataTest {
 
     @Test
     fun newPageDoesNotFlushPendingMipmapsOnAnotherPage() {
-        val data = NativeBitmapFontData(TestFont(true, 400))
+        val data = NativeBitmapFontData(TestFont(400))
         try {
             val firstTexture = data.regions.first().texture
             data.getGlyphs(GlyphLayout.GlyphRun(), "ABC", 0, 3, null)
@@ -100,7 +100,7 @@ class NativeBitmapFontDataTest {
 
     @Test
     fun fullReloadRetainsNewGlyphsWithoutGeneratingStaleMipmaps() {
-        val data = NativeBitmapFontData(TestFont(true))
+        val data = NativeBitmapFontData(TestFont())
         try {
             data.getGlyphs(GlyphLayout.GlyphRun(), "A", 0, 1, null)
             val texture = data.regions.first().texture
@@ -121,17 +121,20 @@ class NativeBitmapFontDataTest {
     }
 
     @Test
-    fun otherPlatformsKeepLinearFilteringWithoutMipmaps() {
-        val data = NativeBitmapFontData(TestFont(false))
+    fun defaultImplementationUsesMipmapsForDirectGlyphLookups() {
+        val data = NativeBitmapFontData(TestFont())
         try {
             val texture = data.regions.first().texture
-            assertFalse(texture.textureData.useMipMaps())
-            assertEquals(TextureFilter.Linear, texture.minFilter)
+            assertTrue(texture.textureData.useMipMaps())
+            assertEquals(TextureFilter.MipMapLinearLinear, texture.minFilter)
             assertEquals(TextureFilter.Linear, texture.magFilter)
             clearInvocations(Gdx.gl)
-            data.getGlyphs(GlyphLayout.GlyphRun(), "AB", 0, 2, null)
+            data.getGlyph('A')
+            data.getGlyph('B')
             assertFalse(mipmapsUploaded())
             assertTrue(mockingDetails(Gdx.gl).invocations.any { it.method.name == "glTexSubImage2D" })
+            texture.bind()
+            assertEquals(1, mockingDetails(Gdx.gl).invocations.count { it.method.name == "glGenerateMipmap" })
         } finally {
             data.regions.forEach { it.texture.dispose() }
             data.dispose()


### PR DESCRIPTION
This PR attempts to improve text rendering quality on desktop platforms and low pixel density displays
- Generate mipmaps for glyphs to help the quality when texture is shrunk by more than 2x.
- Apply a slight mipmap level bias to improve the contrast at edges on desktop

 before:
<img width="1428" height="1164" alt="Screenshot 2026-09-07 102332" src="https://github.com/user-attachments/assets/05ee50d7-4766-4777-86db-421014877960" />

after:
<img width="1465" height="1171" alt="Screenshot 2026-09-07 102220" src="https://github.com/user-attachments/assets/de797914-bbcd-4188-87fe-3e8659828624" />
