### PR TITLE
Patch regions to change the region to match the civ placed there

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -11,6 +11,8 @@ import com.unciv.logic.map.HexMath
 import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.mapgenerator.MapGenerator
 import com.unciv.logic.map.tile.Tile
+import com.unciv.logic.map.tile.TileNormalizer
+import com.unciv.models.ruleset.tile.TerrainType
 import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.Ruleset
@@ -407,9 +409,86 @@ class GameStarter private constructor(
         }
 
         val startingLocations = getStartingLocations(allCivs, landTilesInBigEnoughGroup, startScores)
+        patchUnsatisfiedStartBiases(startingLocations)
 
         // no starting units for Barbarians and Spectators
         determineStartingUnitsAndLocations(gameInfo, startingLocations, ruleSet)
+    }
+
+    /**
+     * Last-resort guarantee: after placement, force a neighbor of each civ's start tile to satisfy
+     * any start bias that still isn't met (e.g. no Tundra existed anywhere reachable on this map).
+     * This intentionally accepts a locally mismatched tile (e.g. a lone Tundra tile deep in a
+     * temperate region) in exchange for the bias actually being followed.
+     */
+    private fun patchUnsatisfiedStartBiases(startingLocations: Map<Civilization, Tile>) {
+        if (gameSetupInfo.gameParameters.noStartBias) return
+        for ((civ, tile) in startingLocations) {
+            if (civ.isBarbarian || civ.isSpectator()) continue
+            val startBiases = civ.nation.getStartBias(ruleset, civ.getGameContextForStartBias())
+            for (startBias in startBiases) {
+                if (isStartBiasSatisfiedBy(tile, startBias)) continue
+                patchNeighborForStartBias(tile, startBias)
+            }
+        }
+    }
+
+    private fun patchNeighborForStartBias(startTile: Tile, startBias: String) {
+        // Can't reliably force a specific natural wonder or coastline into existence here -
+        // these already have dedicated (if imperfect) handling elsewhere.
+        if (startBias in tileMap.naturalWonders) return
+        if (startBias.equalsPlaceholderText("Avoid []")) {
+            patchAreaToAvoid(startTile, startBias.getPlaceholderParameters()[0])
+            return
+        }
+        val targetTerrain = ruleset.terrains[startBias] ?: return
+        if (targetTerrain.isCoast || targetTerrain.type == TerrainType.Water) return
+
+        val positionOrder = compareBy<Tile>({ it.position.x }, { it.position.y })
+        @Suppress("DEPRECATION")
+        val ring1 = startTile.getTilesInDistance(1).filter { it != startTile && it.isLand && !it.isImpassible() }.sortedWith(positionOrder).toList()
+        @Suppress("DEPRECATION")
+        val ring2 = startTile.getTilesInDistance(2).filter { it !in ring1 && it != startTile && it.isLand && !it.isImpassible() }.sortedWith(positionOrder).toList()
+        // Ring 1 first (preserved, not re-sorted together with ring 2), so the immediate-adjacency
+        // bias check is guaranteed to have a converted candidate as long as one exists at all.
+        val orderedCandidates = (ring1 + ring2).filterNot { it.matchesTerrainFilter(startBias, null) }
+        if (orderedCandidates.isEmpty()) return
+
+        // Mirror the ruleset's own "region counts as this type" percentage instead of a guessed number.
+        val requiredPercent = targetTerrain.getMatchingUniques(UniqueType.RegionRequirePercentSingleType)
+            .firstOrNull()?.params?.get(0)?.toIntOrNull() ?: 30
+        val areaSize = ring1.size + ring2.size
+        val alreadyMatching = areaSize - orderedCandidates.size
+        val target = (requiredPercent * areaSize) / 100
+        val toConvert = (target - alreadyMatching).coerceAtLeast(1)
+
+        for (candidate in orderedCandidates.take(toConvert)) {
+            if (targetTerrain.type == TerrainType.TerrainFeature) {
+                val compatibleBaseTerrainName = targetTerrain.occursOn.firstOrNull { ruleset.terrains.containsKey(it) } ?: continue
+                candidate.setBaseTerrain(ruleset.terrains[compatibleBaseTerrainName]!!)
+                candidate.addTerrainFeature(startBias)
+            } else {
+                candidate.setBaseTerrain(targetTerrain)
+            }
+            TileNormalizer.normalizeToRuleset(candidate, ruleset)
+        }
+    }
+
+    private fun patchAreaToAvoid(startTile: Tile, terrainToAvoid: String) {
+        val avoidedTerrain = ruleset.terrains[terrainToAvoid] ?: return
+        @Suppress("DEPRECATION")
+        val offenders = startTile.getTilesInDistance(2).filter { it.matchesTerrainFilter(terrainToAvoid, null) }
+        for (offender in offenders) {
+            if (avoidedTerrain.type == TerrainType.TerrainFeature) {
+                offender.removeTerrainFeature(terrainToAvoid)
+            } else {
+                val replacement = ruleset.terrains.values.firstOrNull {
+                    it.type == TerrainType.Land && !it.impassable && it.name != terrainToAvoid
+                } ?: continue
+                offender.setBaseTerrain(replacement)
+            }
+            TileNormalizer.normalizeToRuleset(offender, ruleset)
+        }
     }
 
     private fun removeAncientRuinsNearStartingLocation(startingLocation: Tile) {
@@ -551,14 +630,58 @@ class GameStarter private constructor(
     ): HashMap<Civilization, Tile> {
 
         val civsOrderedByAvailableLocations = getCivsOrderedByAvailableLocations(civs)
+        val totalBiasCount = civsOrderedByAvailableLocations.sumOf {
+            it.nation.getStartBias(ruleset, it.getGameContextForStartBias()).size
+        }
 
+        // The largest spacing that successfully places everyone doesn't necessarily respect the most
+        // start biases - tightly-clustered biased terrain (e.g. Tundra near the poles) can get pruned
+        // by the edge-distance requirement at high spacing. So try every spacing down to 0 and keep
+        // whichever successful placement satisfies the most start biases, favoring larger spacing on ties.
+        var bestStartingLocations: HashMap<Civilization, Tile>? = null
+        var bestSatisfiedBiasCount = -1
         for (minimumDistanceBetweenStartingLocations in tileMap.tileMatrix.size / 6 downTo 0) {
             val freeTiles = getFreeTiles(landTilesInBigEnoughGroup, minimumDistanceBetweenStartingLocations)
 
             val startingLocations = getStartingLocationsForCivs(civsOrderedByAvailableLocations, freeTiles, startScores, minimumDistanceBetweenStartingLocations)
-            if (startingLocations != null) return startingLocations
+                ?: continue
+            if (totalBiasCount == 0) return startingLocations // nothing to optimize for
+
+            val satisfiedBiasCount = countSatisfiedBiases(startingLocations)
+            if (satisfiedBiasCount > bestSatisfiedBiasCount) {
+                bestSatisfiedBiasCount = satisfiedBiasCount
+                bestStartingLocations = startingLocations
+            }
+            if (satisfiedBiasCount == totalBiasCount) break
         }
-        throw Exception("Didn't manage to get starting tiles even with distance of 1?")
+        return bestStartingLocations ?: throw Exception("Didn't manage to get starting tiles even with distance of 1?")
+    }
+
+    @Readonly
+    private fun countSatisfiedBiases(startingLocations: Map<Civilization, Tile>): Int {
+        var count = 0
+        for ((civ, tile) in startingLocations) {
+            val startBiases = civ.nation.getStartBias(ruleset, civ.getGameContextForStartBias())
+            for (startBias in startBiases) {
+                if (isStartBiasSatisfiedBy(tile, startBias)) count++
+            }
+        }
+        return count
+    }
+
+    @Readonly
+    private fun isStartBiasSatisfiedBy(tile: Tile, startBias: String): Boolean {
+        if (startBias.equalsPlaceholderText("Avoid []")) {
+            val tileToAvoid = startBias.getPlaceholderParameters()[0]
+            @Suppress("DEPRECATION")
+            return !tile.getTilesInDistance(1).any { it.matchesTerrainFilter(tileToAvoid, null) }
+        }
+        if (startBias in tileMap.naturalWonders) {
+            @Suppress("DEPRECATION")
+            return tile.getTilesInDistance(1).any { it.isNaturalWonder() && it.naturalWonder == startBias }
+        }
+        @Suppress("DEPRECATION")
+        return tile.getTilesInDistance(1).any { it.matchesTerrainFilter(startBias, null) }
     }
 
     @Readonly
@@ -650,7 +773,7 @@ class GameStarter private constructor(
 
         var preferredTiles = freeTiles.toList()
         for (startBias in startBiases) {
-            preferredTiles = when {
+            val filtered = when {
                 startBias.equalsPlaceholderText("Avoid []") -> {
                     val tileToAvoid = startBias.getPlaceholderParameters()[0]
                     preferredTiles.filter { tile ->
@@ -668,6 +791,9 @@ class GameStarter private constructor(
                     }
                 }
             }
+            // If this bias can't be satisfied alongside the previous ones, drop it rather than
+            // discarding all previously-matched biases by falling through to a fully random tile.
+            if (filtered.isNotEmpty()) preferredTiles = filtered
         }
         return preferredTiles.randomOrNull(rng) ?: freeTiles.random(rng)
     }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.isActive
 import kotlin.math.E
 import kotlin.math.abs
 import kotlin.math.exp
+import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sign
@@ -171,12 +172,14 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             return map
         }
 
+        val startBiasBoosts = getStartBiasGenerationBoosts(gameParameters, gameInfo)
+
         if (consoleTimings) debug("\nMapGenerator run with parameters %s", mapParameters)
         runAndMeasure("MapLandmassGenerator") {
             MapLandmassGenerator(map, ruleset, randomness).generateLand()
         }
         runAndMeasure("applyHumidityAndTemperature") {
-            applyHumidityAndTemperature(map)
+            applyHumidityAndTemperature(map, startBiasBoosts)
         }
         runAndMeasure("raiseMountainsAndHills") {
             MapElevationGenerator(map, ruleset, terrainConditions, randomness).raiseMountainsAndHills()
@@ -185,7 +188,7 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             spawnLakesAndCoasts(map)
         }
         runAndMeasure("spawnVegetation") {
-            spawnVegetation(map)
+            spawnVegetation(map, startBiasBoosts)
         }
         runAndMeasure("spawnRareFeatures") {
             spawnRareFeatures(map)
@@ -505,18 +508,72 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
 
 
     /**
+     * Whether generation should be nudged so enough terrain exists on the map to satisfy the
+     * game's civs' start biases - otherwise start bias placement and [MapRegions] region-matching
+     * have nothing to work with regardless of priority order, no matter how rare that terrain is.
+     *
+     * Determined from each biased terrain's own [UniqueType.TileGenerationConditions] data rather
+     * than hardcoded terrain names, so this also works for mods that rename or rebalance terrains.
+     */
+    private class StartBiasGenerationBoosts(
+        /** How cold the coldest biased terrain's warmest possible occurrence still is, 0..1 -
+         *  e.g. Tundra (never occurs above -0.4 temperature) yields 0.4. 0 means nothing biased needs cold. */
+        val coldRequired: Float,
+        /** How hot the hottest biased terrain's coolest possible occurrence still is, 0..1 - symmetric to [coldRequired]. */
+        val heatRequired: Float,
+        val needsVegetation: Boolean
+    ) {
+        // Scale the push proportionally to how extreme the requirement actually is, instead of a
+        // flat bump - a terrain that's only mildly cold-locked shouldn't distort the map as much
+        // as one that (in some mod) is locked to near-arctic temperatures only.
+        val temperatureIntensityBoost = (max(coldRequired, heatRequired) * 0.4f).coerceIn(0f, 1f)
+        val vegetationRichnessBoost = if (needsVegetation) 0.15f else 0f
+
+        companion object {
+            val none = StartBiasGenerationBoosts(0f, 0f, false)
+        }
+    }
+
+    private fun getStartBiasGenerationBoosts(gameParameters: GameParameters, gameInfo: GameInfo?): StartBiasGenerationBoosts {
+        if (gameParameters.noStartBias || gameInfo == null)
+            return StartBiasGenerationBoosts.none
+        val majorCivNations = gameInfo.civilizations
+            .filter { ruleset.nations[it.civName]?.isMajorCiv == true }
+            .mapNotNull { ruleset.nations[it.civName] }
+        if (majorCivNations.isEmpty()) // map editor or menu background
+            return StartBiasGenerationBoosts.none
+
+        val requiredBiases = majorCivNations.flatMapTo(mutableSetOf()) {
+            it.getStartBias(ruleset, GameContext(gameInfo = gameInfo))
+        }
+        val biasedTerrainRows = requiredBiases.associateWith { bias -> terrainConditions.filter { it.name == bias && it.isConstrained } }
+            .filterValues { it.isNotEmpty() }
+
+        // A terrain like Desert can occur across almost the entire temperature range as long as
+        // humidity is low, so it contributes ~0 to either requirement here - low humidity isn't
+        // handled by a global skew, since that helps one biased terrain at the direct expense of
+        // every other terrain sharing the same map (see GameStarter's per-civ terraform patch for
+        // how low-humidity biases get guaranteed instead).
+        val coldRequired = biasedTerrainRows.values.maxOfOrNull { rows -> (-rows.maxOf { it.tempTo }).coerceIn(0f, 1f) } ?: 0f
+        val heatRequired = biasedTerrainRows.values.maxOfOrNull { rows -> rows.minOf { it.tempFrom }.coerceIn(0f, 1f) } ?: 0f
+        val needsVegetation = requiredBiases.any { bias -> terrainConditions.any { it.name == bias && it.hasVegitation } }
+
+        return StartBiasGenerationBoosts(coldRequired, heatRequired, needsVegetation)
+    }
+
+    /**
      * [MapParameters.tilesPerBiomeArea] to set biomes size
      * [MapParameters.temperatureintensity] to favor very high and very low temperatures
      * [MapParameters.temperatureShift] to shift temperature towards cold (negative) or hot (positive)
      */
-    private fun applyHumidityAndTemperature(tileMap: TileMap) {
+    private fun applyHumidityAndTemperature(tileMap: TileMap, startBiasBoosts: StartBiasGenerationBoosts = StartBiasGenerationBoosts.none) {
         val humiditySeed = randomness.RNG.nextInt().toDouble()
         val temperatureSeed = randomness.RNG.nextInt().toDouble()
 
         tileMap.setTransients(ruleset)
 
         val scale = tileMap.mapParameters.tilesPerBiomeArea.toDouble()
-        val temperatureintensity = tileMap.mapParameters.temperatureintensity
+        val temperatureintensity = (tileMap.mapParameters.temperatureintensity + startBiasBoosts.temperatureIntensityBoost).coerceAtMost(1f)
         val temperatureShift = tileMap.mapParameters.temperatureShift
         val humidityShift = if (temperatureShift > 0) -temperatureShift / 2 else 0f
 
@@ -605,13 +662,13 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
     /**
      * [MapParameters.vegetationRichness] is the threshold for vegetation spawn
      */
-    private fun spawnVegetation(tileMap: TileMap) {
+    private fun spawnVegetation(tileMap: TileMap, startBiasBoosts: StartBiasGenerationBoosts = StartBiasGenerationBoosts.none) {
         val vegetationSeed = randomness.RNG.nextInt().toDouble()
         val vegetationTerrains = terrainFeaturePicker.filter { it.hasVegitation && !it.rareFeature }
             .ifEmpty {terrainFeaturePicker.filter { Constants.vegetation.contains(it.name)}}
         val candidateTerrains = vegetationTerrains.flatMap{ it.terrain.occursOn }
         // some map types are more forested than others
-        val vegetationRichness = tileMap.mapParameters.vegetationRichness + when (tileMap.mapParameters.type) {
+        val vegetationRichness = tileMap.mapParameters.vegetationRichness + startBiasBoosts.vegetationRichnessBoost + when (tileMap.mapParameters.type) {
             MapType.boreal -> +0.10
             else -> 0.0
         }

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.map.mapgenerator.mapregions.MapRegions.BiasTypes.Positive
 import com.unciv.logic.map.mapgenerator.resourceplacement.LuxuryResourcePlacementLogic
 import com.unciv.logic.map.mapgenerator.resourceplacement.StrategicBonusResourcePlacementLogic
 import com.unciv.logic.map.tile.Tile
+import com.unciv.logic.map.tile.TileNormalizer
 import com.unciv.models.metadata.GameParameters
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.Terrain
@@ -434,12 +435,81 @@ class MapRegions (val ruleset: Ruleset) {
     private fun assignCivToRegion(civ: Civilization, region: Region) {
         val tile = region.tileMap[region.startPosition!!]
         region.tileMap.addStartingLocation(civ.civID, tile)
+        patchRegionForStartBias(civ, region, tile)
 
         // Place impacts to keep city states etc at appropriate distance
         tileData.placeImpact(ImpactType.MinorCiv,tile, 6)
         tileData.placeImpact(ImpactType.Luxury,  tile, 3)
         tileData.placeImpact(ImpactType.Strategic,tile, 0)
         tileData.placeImpact(ImpactType.Bonus,   tile, 3)
+    }
+
+    /**
+     * Guarantees [civ]'s start bias is actually satisfiable by force-converting tiles across its
+     * whole assigned [region] - not just the start tile's immediate neighborhood - up to the same
+     * percentage the ruleset itself uses to classify a region as that terrain's type (falling back
+     * to 30% if the terrain doesn't define one). Accepts a locally mismatched region in exchange for
+     * the bias actually being followed. Tiles closest to the start position are converted first, so
+     * the immediate-adjacency bias check (see GameStarter.isStartBiasSatisfiedBy) still passes.
+     */
+    private fun patchRegionForStartBias(civ: Civilization, region: Region, startTile: Tile) {
+        val startBiases = ruleset.nations[civ.civName]!!.getStartBias(ruleset, civ.getGameContextForStartBias())
+        for (bias in startBiases) {
+            if (bias in region.tileMap.naturalWonders) continue // can't force a specific natural wonder into existence here
+            if (bias.equalsPlaceholderText("Avoid []")) {
+                patchRegionToAvoid(region, bias.getPlaceholderParameters()[0])
+                continue
+            }
+            patchRegionForPositiveBias(region, startTile, bias)
+        }
+    }
+
+    private fun patchRegionForPositiveBias(region: Region, startTile: Tile, bias: String) {
+        val targetTerrain = ruleset.terrains[bias] ?: return
+        if (targetTerrain.isCoast || targetTerrain.type == TerrainType.Water) return // don't carve water into a landmass region
+
+        val requiredPercent = targetTerrain.getMatchingUniques(UniqueType.RegionRequirePercentSingleType)
+            .firstOrNull()?.params?.get(0)?.toIntOrNull() ?: 30
+        val target = (requiredPercent * region.tiles.size) / 100
+        val alreadyMatching = region.getTerrainAmount(bias)
+        if (alreadyMatching >= target) return
+        val toConvert = target - alreadyMatching
+
+        val candidates = region.tiles
+            .filter { it != startTile && it.isLand && !it.isImpassible() && !it.matchesTerrainFilter(bias, null) }
+            .sortedWith(compareBy({ startTile.aerialDistanceTo(it) }, { it.position.x }, { it.position.y }))
+
+        for (candidate in candidates.take(toConvert)) {
+            val oldBaseTerrain = candidate.baseTerrain
+            if (targetTerrain.type == TerrainType.TerrainFeature) {
+                val compatibleBaseTerrainName = targetTerrain.occursOn.firstOrNull { ruleset.terrains.containsKey(it) } ?: continue
+                candidate.setBaseTerrain(ruleset.terrains[compatibleBaseTerrainName]!!)
+                candidate.addTerrainFeature(bias)
+                region.terrainCounts[compatibleBaseTerrainName] = (region.terrainCounts[compatibleBaseTerrainName] ?: 0) + 1
+            } else {
+                candidate.setBaseTerrain(targetTerrain)
+            }
+            TileNormalizer.normalizeToRuleset(candidate, ruleset)
+            region.terrainCounts[oldBaseTerrain] = ((region.terrainCounts[oldBaseTerrain] ?: 1) - 1).coerceAtLeast(0)
+            region.terrainCounts[bias] = (region.terrainCounts[bias] ?: 0) + 1
+        }
+    }
+
+    private fun patchRegionToAvoid(region: Region, terrainToAvoid: String) {
+        val avoidedTerrain = ruleset.terrains[terrainToAvoid] ?: return
+        val offenders = region.tiles.filter { it.matchesTerrainFilter(terrainToAvoid, null) }
+        for (offender in offenders) {
+            if (avoidedTerrain.type == TerrainType.TerrainFeature) {
+                offender.removeTerrainFeature(terrainToAvoid)
+            } else {
+                val replacement = ruleset.terrains.values.firstOrNull {
+                    it.type == TerrainType.Land && !it.impassable && it.name != terrainToAvoid
+                } ?: continue
+                offender.setBaseTerrain(replacement)
+            }
+            TileNormalizer.normalizeToRuleset(offender, ruleset)
+        }
+        region.terrainCounts[terrainToAvoid] = 0
     }
 
 

--- a/tests/src/com/unciv/logic/GameStarterStartBiasTests.kt
+++ b/tests/src/com/unciv/logic/GameStarterStartBiasTests.kt
@@ -1,0 +1,108 @@
+package com.unciv.logic
+
+import com.badlogic.gdx.Gdx
+import com.unciv.UncivGame
+import com.unciv.logic.civilization.PlayerType
+import com.unciv.logic.files.UncivFiles
+import com.unciv.logic.map.MapParameters
+import com.unciv.logic.map.MapSize
+import com.unciv.models.metadata.GameParameters
+import com.unciv.models.metadata.GameSettings
+import com.unciv.models.metadata.GameSetupInfo
+import com.unciv.models.metadata.Player
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.translations.equalsPlaceholderText
+import com.unciv.models.translations.getPlaceholderParameters
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.RedirectOutput
+import com.unciv.testing.RedirectPolicy
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Not a pass/fail regression test - a measurement tool.
+ * Runs many real games through [GameStarter] and reports what fraction of civs actually
+ * land on a tile satisfying their nation's start bias, so a change to the placement
+ * algorithm can be evaluated before/after by re-running this and comparing the printed rate.
+ */
+@RunWith(BaseTestRunner::class)
+class GameStarterStartBiasTests {
+
+    // One nation per simple bias type actually used in the base ruleset, so each run
+    // exercises a different kind of bias (single-terrain, avoid, and coast/adjacency-based).
+    private val civNames = listOf(
+        "Russia",   // Tundra
+        "Arabia",   // Desert
+        "India",    // Grassland
+        "Iroquois", // Forest
+        "Aztecs",   // Jungle
+        "Inca",     // Hill
+        "Mongolia", // Plains
+        "Greece",   // Coast
+    )
+
+    private val runs = 200
+
+    @Before
+    fun loadRulesets() {
+        if (RulesetCache.isEmpty())
+            RulesetCache.loadRulesets(noMods = true)
+        UncivGame.Current = UncivGame()
+        UncivGame.Current.files = UncivFiles(Gdx.files)
+        UncivGame.Current.settings = GameSettings()
+    }
+
+    private fun tileSatisfiesBias(tile: com.unciv.logic.map.tile.Tile, bias: String): Boolean {
+        if (bias.equalsPlaceholderText("Avoid []")) {
+            val toAvoid = bias.getPlaceholderParameters()[0]
+            return !tile.getTilesInDistance(1).any { it.matchesTerrainFilter(toAvoid, null) }
+        }
+        return tile.getTilesInDistance(1).any { it.matchesTerrainFilter(bias, null) }
+    }
+
+    @Test
+    @RedirectOutput(RedirectPolicy.Show)
+    fun `measure start bias follow rate over 200 games`() {
+        var followedBiases = 0
+        var totalBiases = 0
+        val perNationFollowed = HashMap<String, Int>()
+        val perNationTotal = HashMap<String, Int>()
+
+        repeat(runs) {
+            val gameParameters = GameParameters().apply {
+                players = ArrayList(civNames.mapIndexed { index, name ->
+                    Player(name, if (index == 0) PlayerType.Human else PlayerType.AI)
+                })
+                numberOfCityStates = 0
+                noBarbarians = true
+            }
+            val mapParameters = MapParameters().apply {
+                mapSize = MapSize.Small
+                seed = System.nanoTime()
+            }
+            val setup = GameSetupInfo(gameParameters, mapParameters)
+            val game = GameStarter.startNewGame(setup)
+
+            for (civ in game.civilizations.filter { it.isMajorCiv() }) {
+                val tile = civ.units.getCivUnits().firstOrNull()?.getTile() ?: continue
+                for (bias in civ.nation.startBias) {
+                    totalBiases++
+                    perNationTotal.merge(civ.civName, 1, Int::plus)
+                    if (tileSatisfiesBias(tile, bias)) {
+                        followedBiases++
+                        perNationFollowed.merge(civ.civName, 1, Int::plus)
+                    }
+                }
+            }
+        }
+
+        val percentage = 100.0 * followedBiases / totalBiases
+        println("Start bias follow rate: $followedBiases/$totalBiases (${"%.1f".format(percentage)}%)")
+        for (name in civNames) {
+            val f = perNationFollowed[name] ?: 0
+            val t = perNationTotal[name] ?: 0
+            println("  $name: $f/$t (${"%.1f".format(100.0 * f / t)}%)")
+        }
+    }
+}


### PR DESCRIPTION
I'm not sure this is a good idea, I don't know if I want it in, but this is the only solution I've found that solves the problem.

The Problem: Start biases are only match actual starting locations 70% of the time. This is mainly due to A. restrictions on placement (can't be too near edge) + specific terrains only being placed near the edges (snow/tundra) and B. some terrains requiring specific temperature + humidity conditions - especially desert which requires a lot of heat and very little humidity

Trying to play around with the global heat/humidity did not give great results
This solution placed civs and then goes around the placed civs that do not match the region, and patches the region to match the bias