### PR TITLE
Fix possible crash when scrolling to the selected construction queue entry

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -765,13 +765,23 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         }
     }
 
+    /** The queue widgets can be out of sync with the construction queue when this is called:
+     *  [selectQueueEntry] triggers the *asynchronous* [CityScreen.updateAsync] and then scrolls to the
+     *  selected entry, so the cells read here are still the ones of the previous layout - and they are
+     *  not even guaranteed to exist, as this table is only populated by [updateConstructionQueue].
+     *  Therefore: check the bounds instead of indexing blindly, a missing button simply means no scrolling. */
     private fun getSelectedQueueButton(): Actor? {
         if (selectedQueueEntry == 0) {
-            return constructionsQueueTable.cells[0].actor
+            val cells = constructionsQueueTable.cells
+            if (cells.size == 0) return null
+            return cells[0].actor
         }
         if (selectedQueueEntry > 0 && selectedQueueEntry < cityView.constructions.constructionQueue.size) {
             // *2 because it's always the entry and a separator
-            return queueExpander.innerTable.cells[selectedQueueEntry * 2 - 2].actor
+            val cells = queueExpander.innerTable.cells
+            val index = selectedQueueEntry * 2 - 2
+            if (index >= cells.size) return null
+            return cells[index].actor
         }
         return null
     }


### PR DESCRIPTION

### The problem

`CityConstructionsTable.getSelectedQueueButton()` indexes the queue widgets directly:

```kotlin
if (selectedQueueEntry == 0) return constructionsQueueTable.cells[0].actor
...
return queueExpander.innerTable.cells[selectedQueueEntry * 2 - 2].actor
```

Both lookups throw `IndexOutOfBoundsException` when the cell is not there, and the method's only
caller, `ensureQueueEntryVisible()`, is called at moments when the cells are not guaranteed to
match the current construction queue:

* `selectQueueEntry()` calls `cityScreen.updateAsync()` and then `ensureQueueEntryVisible()` right
  away. `updateAsync` is asynchronous - it recalculates stats in a coroutine and only then posts
  `updateSync` (which rebuilds the queue table) back to the GL thread. So the cells read by
  `getSelectedQueueButton` are the ones of the *previous* layout, for a `selectedQueueEntry` that
  was computed from the *new* queue. This is the path taken when an entry is removed from the queue
  (`getRemoveFromQueueButton` -> `selectQueueEntry(index.coerceAtMost(lastIndex))`).
* `constructionsQueueTable` and `queueExpander.innerTable` are only ever populated by
  `updateConstructionQueue()`. Anything that reaches this table without a preceding
  `CityConstructionsTable.update()` - for instance an alternative city UI that reuses the queue
  buttons - finds them empty, and `cells[0]` throws.

The failure mode is bad out of proportion to what the method does: instead of "no scrolling", the
game crashes while the player is editing the construction queue. I hit it as an
`IndexOutOfBoundsException` on removing a construction from a queue of two entries.

### The change

Bound both lookups and return `null` when there is nothing to scroll to. That is already the
method's contract - it returns `Actor?` and its third branch returns `null` - and
`ensureQueueEntryVisible()` already handles `null` with `?.let`. No behaviour changes when the
widgets are in sync, which is the normal case.

The comment above the method records why the cells may be stale, so the next reader does not
"simplify" the bounds check away.

### What it does not change

Nothing about the asynchronous update itself. Making `selectQueueEntry` scroll only after the
rebuild would be the deeper fix, but it changes the ordering of an already delicate path
(the comment in `getMovePriorityButton` shows this ordering was tuned deliberately), so this PR
stays with the local, safe change.

### Verification

`./gradlew desktop:dist` and `./gradlew tests:test` pass on this branch (798 tests, 0 failures).
No test added: reproducing the race needs a live `CityScreen` with a coroutine dispatcher, which
the test harness does not build.
