### PR TITLE
Add countable "Known [civFilter] Civilizations"

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -302,6 +302,22 @@ enum class Countables(
                 .map { text.fillPlaceholders(it) }.toSet()
     },
 
+    KnownCivs("Known [civFilter] Civilizations", shortDocumentation = "The number of other civilizations the relevant Civilization has met") {
+        override val documentationStrings = listOf("Counts only civilizations that are still alive, and never the civilization itself")
+        override fun eval(parameterText: String, gameContext: GameContext): Int? {
+            val filter = parameterText.getPlaceholderParameters()[0]
+            val civInfo = gameContext.civInfo ?: return null
+            return civInfo.gameInfo.civilizations.count {
+                it != civInfo && it.isAlive() && civInfo.knows(it) && it.matchesFilter(filter, gameContext)
+            }
+        }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.CivFilter.getTranslatedErrorSeverity(parameterText, ruleset)
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
+            UniqueParameterType.CivFilter.getKnownValuesForAutocomplete(ruleset)
+                .map { text.fillPlaceholders(it) }.toSet()
+    },
+
     RemainingCivs("Remaining [civFilter] Civilizations") {
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -307,9 +307,7 @@ enum class Countables(
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]
             val civInfo = gameContext.civInfo ?: return null
-            return civInfo.gameInfo.civilizations.count {
-                it != civInfo && it.isAlive() && civInfo.knows(it) && it.matchesFilter(filter, gameContext)
-            }
+            return civInfo.getKnownCivs().count { it.matchesFilter(filter, gameContext) }
         }
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
             UniqueParameterType.CivFilter.getTranslatedErrorSeverity(parameterText, ruleset)

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -409,6 +409,9 @@ Allowed values:
     - Example: `Only available <when number of [Researched [Agriculture] Technologies] is more than [0]>`
     - Counts researched matching technologies for the relevant Civilization
     - Repeatable technologies, like Future Tech, are only counted once
+-   `Known [civFilter] Civilizations` - The number of other civilizations the relevant Civilization has met
+    - Example: `Only available <when number of [Known [City-States] Civilizations] is more than [0]>`
+    - Counts only civilizations that are still alive, and never the civilization itself
 -   `Remaining [civFilter] Civilizations`
     - Example: `Only available <when number of [Remaining [City-States] Civilizations] is more than [0]>`
 -   `Worked [tileFilter] Tiles in this city`

--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -283,6 +283,30 @@ class CountableTests {
     }
 
     @Test
+    fun testKnownCivsCountable() {
+        // A big map with distant cities: civilizations must not meet by seeing each other
+        game = TestGame()
+        game.makeHexagonalMap(12)
+        val ourCiv = game.addCiv()
+        val otherMajorCiv = game.addCiv()
+        val cityState = game.addCiv(cityStateType = game.ruleset.cityStateTypes.keys.first())
+        game.addCity(ourCiv, game.tileMap[0,0])
+        game.addCity(otherMajorCiv, game.tileMap[10,0])
+        game.addCity(cityState, game.tileMap[-10,0])
+        val context = GameContext(ourCiv)
+        fun known(filter: String) = Countables.getCountableAmount("Known [$filter] Civilizations", context)
+
+        assertEquals("Nobody met yet", 0, known("Major"))
+        ourCiv.diplomacyFunctions.makeCivilizationsMeet(cityState)
+        assertEquals("A City-State is not a major civ", 0, known("Major"))
+        assertEquals(1, known("City-State"))
+        ourCiv.diplomacyFunctions.makeCivilizationsMeet(otherMajorCiv)
+        assertEquals(1, known("Major"))
+        // "all" includes neither ourselves nor civilizations we have not met
+        assertEquals(2, known("all"))
+    }
+
+    @Test
     fun testOwnedTilesCountable() {
         setupModdedGame()
         UniqueTriggerActivation.triggerUnique(Unique("Turn this tile into a [Coast] tile"), civ, tile = game.tileMap[-3,0])


### PR DESCRIPTION

### What is missing

Countables can already tell a ruleset how many civilizations are *left* in the game
(`Remaining [civFilter] Civilizations`), but not how many the relevant civilization has actually
*met*. Diplomatic contact is invisible to rulesets: there is no way to write a unique, a
conditional or a victory milestone that depends on "you have met another civilization" - or on
"you have met at least three City-States" - even though meeting someone is one of the first things
that happens in a game and is already tracked per civilization (`Civilization.knows`).

### The change

A new countable, `Known [civFilter] Civilizations`: the number of civilizations the relevant
civilization has met, that are still alive and match the filter. The civilization itself is never
counted, so `Known [all] Civilizations` is `0` at the start of a game and `2` once you have met a
major civ and a City-State.

It is written directly next to `RemainingCivs`, on which it is modelled, and shares its filter
handling: `UniqueParameterType.CivFilter` for both `getErrorSeverity` and
`getKnownValuesForAutocomplete`.

One deliberate difference from `RemainingCivs`: this countable is *per civilization*, not per game,
so it reads `gameContext.civInfo` and returns `null` when there is none - the same convention the
other per-civ countables follow, which makes it unusable (and reported as such) in a context where
no civilization is known.

Example uses:

```
Only available <when number of [Known [Major] Civilizations] is more than [0]>
"milestones": ["Have at least [1] [Known [Major] Civilizations]"]
```

### What it does not change

Nothing existing. It is a new enum entry; no unique, conditional or milestone changes behaviour.

### Documentation and translation

`docs/Modders/Unique-parameters.md`, in the auto-generated countables block, in the exact format
`UniqueDocsWriter` produces (header from `text` + `shortDocumentation`, example built from the
parameter's `docExample`, then the `documentationStrings`).

No `template.properties` change: `TranslationFileWriter` writes countable texts into the language
files itself, under "Lines from Countables".

### Verification

`./gradlew desktop:dist` and `./gradlew tests:test` pass (799 tests, 0 failures), including the
existing `testCountableConventions`, `testAllCountableParametersAreUniqueParameterTypes` and
`testAllCountableAutocompleteValuesMatch` meta-tests.

New test `testKnownCivsCountable` in `CountableTests`: three civilizations on a map large enough
that their cities do not see each other, met one at a time, checking `Major`, `City-State` and
`all` after each contact.
