### PR TITLE
Add victory milestone "Have at least [amount] [countable]"

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1659,6 +1659,7 @@ Add all [comment] in capital =
 Destroy all players = 
 Capture all capitals = 
 Complete [amount] Policy branches = 
+Have at least [amount] [countable] = 
 Have more [countable1] than each player's [countable2] = 
 You have won a [victoryType] Victory! = 
 [civilization] has won a [victoryType] Victory! = 

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -31,6 +31,8 @@ enum class MilestoneType(val text: String) {
     WinDiplomaticVote("Win diplomatic vote"),
     ScoreAfterTimeOut("Have highest score after max turns"),
     MoreCountableThanEachPlayer("Have more [countable] than each player's [countable]"),
+    /** Reach an absolute amount of a countable - unlike [MoreCountableThanEachPlayer] this does not depend on the other players */
+    HaveCountable("Have at least [amount] [countable]"),
 }
 
 class Victory : INamed, ICivilopediaText {
@@ -137,6 +139,15 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
     fun getMoreCountableThanOtherCivRelevant(civ: Civilization, otherCiv: Civilization): Boolean =
         civ != otherCiv && otherCiv.isMajorCiv() && otherCiv.isAlive()
 
+    /** [MilestoneType.HaveCountable]: the amount the countable must reach */
+    @Readonly
+    fun getCountableToDo(): Int = params[0].toIntOrNull() ?: 0
+
+    /** [MilestoneType.HaveCountable]: the amount the civilization has right now */
+    @Readonly
+    fun getCountableDone(civInfo: Civilization): Int =
+        Countables.getCountableAmount(params[1], GameContext(civInfo)) ?: 0
+
     @Readonly
     fun hasBeenCompletedBy(civInfo: Civilization): Boolean {
         return when (type!!) {
@@ -151,6 +162,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                 originalMajorCapitalsOwned(civInfo) == civsWithPotentialCapitalsToOwn(civInfo.gameInfo).size
             MilestoneType.CompletePolicyBranches ->
                 civInfo.policies.completedBranches.size >= params[0].toInt()
+            MilestoneType.HaveCountable -> getCountableDone(civInfo) >= getCountableToDo()
             MilestoneType.MoreCountableThanEachPlayer -> {
                 val relevantCivs = civInfo.gameInfo.civilizations.filter { getMoreCountableThanOtherCivRelevant(civInfo, it) }
                 relevantCivs.isNotEmpty() && relevantCivs.all { getMoreCountableThanOtherCivPercent(civInfo, it) > 100f }
@@ -195,6 +207,13 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                     if (completed) amountToDo
                     else civInfo.getCompletedPolicyBranchesCount().tr()
                 "{$uniqueDescription} (${amountDone}/${amountToDo})"
+            }
+            MilestoneType.HaveCountable -> {
+                val amountToDo = getCountableToDo()
+                val amountDone =
+                    if (completed) amountToDo
+                    else getCountableDone(civInfo).coerceAtMost(amountToDo)
+                "{$uniqueDescription} (${amountDone.tr()}/${amountToDo.tr()})"
             }
             MilestoneType.CaptureAllCapitals -> {
                 val amountToDo = civsWithPotentialCapitalsToOwn(civInfo.gameInfo).size
@@ -267,7 +286,8 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             // No extra buttons necessary
             null,
             MilestoneType.BuiltBuilding, MilestoneType.BuildingBuiltGlobally,
-            MilestoneType.ScoreAfterTimeOut, MilestoneType.WinDiplomaticVote -> {}
+            MilestoneType.ScoreAfterTimeOut, MilestoneType.WinDiplomaticVote,
+            MilestoneType.HaveCountable -> {}
 
             MilestoneType.AddedSSPartsInCapital -> {
                 val completedSpaceshipParts = civInfo.victoryManager.currentsSpaceshipParts
@@ -364,6 +384,26 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
         return buttons
     }
 
+    /** Attempt to interpret the focus a countable-based milestone suggests, from the Countable type */
+    private fun getFocusFromCountable(countableText: String, ruleset: Ruleset): Victory.Focus =
+        when (Countables.getMatching(countableText, ruleset)) {
+            Countables.Stats -> when (Stat.safeValueOf(countableText)) {
+                Stat.Production -> Victory.Focus.Production
+                Stat.Food -> Victory.Focus.Production
+                Stat.Gold -> Victory.Focus.Gold
+                Stat.Science -> Victory.Focus.Science
+                Stat.Culture -> Victory.Focus.Culture
+                Stat.Happiness -> Victory.Focus.Gold
+                Stat.Faith -> Victory.Focus.Faith
+                else -> Victory.Focus.Production
+            }
+            Countables.Cities, Countables.FilteredCities, Countables.FilteredBuildings, Countables.OwnedTiles -> Victory.Focus.Production
+            Countables.Units, Countables.FilteredUnits -> Victory.Focus.Military
+            Countables.PolicyBranches, Countables.FilteredPolicies -> Victory.Focus.Culture
+            Countables.TileResources, Countables.TileFilterTiles -> Victory.Focus.Production
+            else -> Victory.Focus.Score
+        }
+
     fun getFocus(civInfo: Civilization): Victory.Focus {
         val ruleset = civInfo.gameInfo.ruleset
         return when (type!!) {
@@ -392,26 +432,8 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             }
             MilestoneType.DestroyAllPlayers, MilestoneType.CaptureAllCapitals -> Victory.Focus.Military
             MilestoneType.CompletePolicyBranches -> Victory.Focus.Culture
-            MilestoneType.MoreCountableThanEachPlayer -> {
-                // Attempt to interpret the focus from the Countable type
-                when (Countables.getMatching(params[0], ruleset)) {
-                    Countables.Stats -> when (Stat.safeValueOf(params[0])) {
-                        Stat.Production -> Victory.Focus.Production
-                        Stat.Food -> Victory.Focus.Production
-                        Stat.Gold -> Victory.Focus.Gold
-                        Stat.Science -> Victory.Focus.Science
-                        Stat.Culture -> Victory.Focus.Culture
-                        Stat.Happiness -> Victory.Focus.Gold
-                        Stat.Faith -> Victory.Focus.Faith
-                        else -> Victory.Focus.Production
-                    }
-                    Countables.Cities, Countables.FilteredCities, Countables.FilteredBuildings, Countables.OwnedTiles -> Victory.Focus.Production
-                    Countables.Units, Countables.FilteredUnits -> Victory.Focus.Military
-                    Countables.PolicyBranches, Countables.FilteredPolicies -> Victory.Focus.Culture
-                    Countables.TileResources, Countables.TileFilterTiles -> Victory.Focus.Production
-                    else -> Victory.Focus.Score
-                }
-            }
+            MilestoneType.MoreCountableThanEachPlayer -> getFocusFromCountable(params[0], ruleset)
+            MilestoneType.HaveCountable -> getFocusFromCountable(params[1], ruleset)
             MilestoneType.WinDiplomaticVote -> Victory.Focus.CityStates
             MilestoneType.ScoreAfterTimeOut -> Victory.Focus.Score
             MilestoneType.WorldReligion -> Victory.Focus.Faith

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -10,6 +10,7 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.tile.TerrainType
+import com.unciv.models.ruleset.unique.Countables
 import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.Unique
@@ -544,6 +545,12 @@ internal class BaseRulesetValidator(
                     && milestone.params[0] !in ruleset.buildings)
                     lines.add(
                         "Victory type ${victoryType.name} has milestone \"${milestone.uniqueDescription}\" that references an unknown building ${milestone.params[0]}!",
+                        RulesetErrorSeverity.Error,
+                    )
+                if (milestone.type == MilestoneType.HaveCountable
+                    && (milestone.params[0].toIntOrNull() == null || Countables.getMatching(milestone.params[1], ruleset) == null))
+                    lines.add(
+                        "Victory type ${victoryType.name} has milestone \"${milestone.uniqueDescription}\" with an invalid amount or an unknown countable!",
                         RulesetErrorSeverity.Error,
                     )
             }

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenIllustrations.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenIllustrations.kt
@@ -261,6 +261,10 @@ class VictoryScreenIllustrations(
                     total += game.gameParameters.maxTurns
                     game.turns.coerceAtMost(game.gameParameters.maxTurns)
                 }
+                MilestoneType.HaveCountable -> {
+                    total += milestone.getCountableToDo()
+                    milestone.getCountableDone(civ).coerceAtMost(milestone.getCountableToDo())
+                }
                 else -> {
                     total += 2
                     if (completed) 2 else 0

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -383,6 +383,7 @@ Currently the following milestones are supported:
 | Win diplomatic vote                | At any point in the game win a diplomatic vote (UN). You may lose afterwards and still retain this milestone |
 | Become the world religion          | Have your religion be the majority religion in a majority of cities of all major civs                        |
 | Have highest score after max turns | Basically time victory. Enables the 'max turn' slider and calculates score when that amount is reached       |
+| Have at least [amount] [countable] | Have at least [amount] of the given `countable`. Unlike the milestone below, this does not depend on the other players, so a ruleset can require several concrete things - a building, a policy, worked tiles - to be achieved in any order. |
 | Have more [countable] than each player's [countable] | Have your given `countable` be more than every other Civilization's `countable` to achieve this victory. This is useful to simulate a victory similar to the Cultural Victory in Brave New World. |
 
 ## Civilopedia text

--- a/docs/Modders/schemas/VictoryTypes.schema.json
+++ b/docs/Modders/schemas/VictoryTypes.schema.json
@@ -67,6 +67,7 @@
             "Win diplomatic vote",
             "Become the world religion",
             "Have highest score after max turns",
+            "Have at least [amount] [countable]",
             "Have more [countable] than each player's [countable]"
           ]
         },

--- a/tests/src/com/unciv/models/ruleset/VictoryMilestoneTests.kt
+++ b/tests/src/com/unciv/models/ruleset/VictoryMilestoneTests.kt
@@ -1,0 +1,74 @@
+package com.unciv.models.ruleset
+
+import com.unciv.json.json
+import com.unciv.models.ruleset.validation.RulesetValidator
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** [MilestoneType.HaveCountable] - "Have at least [amount] [countable]" */
+@RunWith(BaseTestRunner::class)
+class HaveCountableMilestoneTests {
+
+    private fun victoryWithMilestones(vararg milestones: String): Victory {
+        val milestoneList = milestones.joinToString(", ") { "\"$it\"" }
+        return json().fromJson(Victory::class.java, """{ "name": "Test", "milestones": [ $milestoneList ] }""")
+    }
+
+    @Test
+    fun `milestones of a countable victory can be completed in any order`() {
+        val testGame = TestGame()
+        testGame.makeHexagonalMap(2)
+        val victory = victoryWithMilestones(
+            "Have at least [1] [Owned [Farm] Tiles]",
+            "Build [Granary]",
+            "Have at least [1] [Adopted [Tradition] Policies]"
+        )
+        testGame.ruleset.victories[victory.name] = victory
+        testGame.gameInfo.gameParameters.victoryTypes = arrayListOf(victory.name)
+        val civ = testGame.addCiv()
+        val city = testGame.addCity(civ, testGame.getTile(0, 0))
+        val farmMilestone = victory.milestoneObjects[0]
+        val policyMilestone = victory.milestoneObjects[2]
+
+        Assert.assertFalse(farmMilestone.hasBeenCompletedBy(civ))
+
+        // Out of the order they are declared in: the policy first, then the building, then the farm
+        civ.policies.freePolicies = 1
+        civ.policies.adopt(testGame.ruleset.policies["Tradition"]!!, branchCompletion = false)
+        Assert.assertTrue(policyMilestone.hasBeenCompletedBy(civ))
+        city.cityConstructions.addBuilding("Granary")
+        Assert.assertNull("Not won yet - the farm is missing", civ.victoryManager.getVictoryTypeAchieved())
+
+        val farmTile = testGame.getTile(1, 0)
+        testGame.addTileToCity(city, farmTile)
+        farmTile.setImprovement("Farm")
+        Assert.assertTrue(farmMilestone.hasBeenCompletedBy(civ))
+        Assert.assertEquals("Test", civ.victoryManager.getVictoryTypeAchieved())
+    }
+
+    @Test
+    fun `countable milestone shows its progress`() {
+        val testGame = TestGame()
+        testGame.makeHexagonalMap(2)
+        val victory = victoryWithMilestones("Have at least [3] [Cities]")
+        val civ = testGame.addCiv()
+        val milestone = victory.milestoneObjects[0]
+
+        Assert.assertEquals("{Have at least [3] [Cities]} (0/3)", milestone.getVictoryScreenButtonHeaderText(false, civ))
+        testGame.addCity(civ, testGame.getTile(0, 0))
+        Assert.assertEquals("{Have at least [3] [Cities]} (1/3)", milestone.getVictoryScreenButtonHeaderText(false, civ))
+        Assert.assertFalse(milestone.hasBeenCompletedBy(civ))
+    }
+
+    @Test
+    fun `an invalid amount or countable is a ruleset error`() {
+        val testGame = TestGame()
+        val victory = victoryWithMilestones("Have at least [lots] [No Such Countable]")
+        testGame.ruleset.victories[victory.name] = victory
+        val errors = RulesetValidator.create(testGame.ruleset).getErrorList()
+        Assert.assertTrue(errors.any { "Have at least [lots] [No Such Countable]" in it.text })
+    }
+}


### PR DESCRIPTION

### What is missing

Victories are built from milestones, and the countable-based one that exists,
`Have more [countable] than each player's [countable]`, is *relative*: it can only express
"more than the other players". There is no milestone for an absolute amount of a countable.

That leaves a whole class of victory conditions inexpressible. A ruleset that wants its victory
to be "own a Farm, build a Granary and adopt a policy" has to hope a matching milestone type
happens to exist; only `Build [building]` and `Complete [amount] Policy branches` do. Anything
counted - worked tiles, owned tiles, units, cities, population, a resource, an amount of a stat -
cannot be required at all, even though the countable machinery already knows how to evaluate all
of them.

### The change

A new milestone type, `Have at least [amount] [countable]`, completed when the civilization's
amount of the countable reaches the given number.

Because milestones are evaluated independently, a victory made of several of these is fulfilled
in any order, which is what makes it useful for "achieve these N things" goals. The victory screen
shows each one's progress on its header line, e.g.
`Have at least [3] [Owned [Farm] Tiles] (2/3)`, and `VictoryScreenIllustrations` counts its
partial progress towards the overall percentage instead of the flat "2 points if done" fallback.

Details worth reviewing:

* `Milestone.getCountableToDo()` / `getCountableDone(civInfo)` are the two accessors, so the
  victory screen and the illustrations use the same numbers as the completion check.
* The milestone gets no extra per-step buttons - the header line already carries the progress -
  so it joins the "no extra buttons necessary" branch.
* `getFocus` needs to say what the victory is *about*. The mapping from a countable to a
  `Victory.Focus` already existed inline inside the `MoreCountableThanEachPlayer` branch; it is
  extracted as `getFocusFromCountable(countableText, ruleset)` and used by both. The existing
  milestone's behaviour is unchanged - same `when`, same order, same fallbacks.
* `BaseRulesetValidator` reports an error when the amount is not an integer or the countable is
  unknown, so a mod author gets a message instead of a milestone that can never be completed.

### What it does not change

No existing milestone type, no new unique, no new conditional. Rulesets that do not use the new
milestone are unaffected.

### Documentation and translation

* Milestone table in `docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md`.
* `docs/Modders/schemas/VictoryTypes.schema.json` milestone examples.
* One line in `android/assets/jsons/translations/template.properties`, next to the other milestone
  texts (milestone texts are manual there; countable texts are not, those come from
  `TranslationFileWriter`).

### Verification

`./gradlew desktop:dist` and `./gradlew tests:test` pass (801 tests, 0 failures).

New tests in `tests/src/com/unciv/models/ruleset/VictoryMilestoneTests.kt`:

* a three-milestone victory (`Owned [Farm] Tiles`, `Build [Granary]`,
  `Adopted [Tradition] Policies`) completed in a different order than declared, asserting the
  victory only triggers once the last one is done;
* the progress text `(0/3)` then `(1/3)` for `Have at least [3] [Cities]`;
* a ruleset error for `Have at least [lots] [No Such Countable]`.
