### PR TITLE
Add Victory.humanOnly - a victory only the human player can achieve

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/VictoryManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/VictoryManager.kt
@@ -119,6 +119,7 @@ class VictoryManager : IsPartOfGameInfoSerialization {
         val victory = civInfo.gameInfo.ruleset.victories
                 .filter { it.key != Constants.neutralVictoryType && it.key in enabledVictories }
                 .map { it.value }
+                .filter { !it.humanOnly || civInfo.isHuman() }
                 .firstOrNull { getNextMilestone(it) == null }
         if (victory != null) return victory.name
         if (civInfo.hasUnique(UniqueType.TriggersVictory))

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -202,6 +202,10 @@ class Ruleset {
         ?: SubStat.safeValueOf(resourceName)
         ?: tileResources[resourceName]
 
+    /** The victories a player may enable in the new game options - [Victory.humanOnly] ones are left out,
+     *  a ruleset that defines them enables them itself (in the scenario or game it ships). */
+    @Readonly fun selectableVictories(): List<Victory> = victories.values.filter { !it.humanOnly }
+
     private inline fun <reified T : INamed> createHashmap(items: Array<T>): LinkedHashMap<String, T> {
         val hashMap = LinkedHashMap<String, T>(items.size)
         for (item in items) {

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -55,6 +55,9 @@ class Victory : INamed, ICivilopediaText {
     override var name = ""
     val victoryScreenHeader = "Do things to win!"
     val hiddenInVictoryScreen = false
+    /** Only a human player can achieve this victory, and it is not offered in the new game options -
+     *  for a ruleset that defines a goal for the player to reach, which an AI reaching it first would spoil. */
+    val humanOnly = false
     // Things to do to win
     // Needs to be ordered, as the milestones are supposed to be obtained in a specific order
     val milestones = ArrayList<String>()

--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -345,7 +345,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
                 val gameInfo = GameSetupInfo.fromSettings("Chieftain")
                 if (gameInfo.gameParameters.victoryTypes.isEmpty()) {
                     val ruleSet = RulesetCache.getComplexRuleset(gameInfo.gameParameters)
-                    gameInfo.gameParameters.victoryTypes.addAll(ruleSet.victories.keys)
+                    gameInfo.gameParameters.victoryTypes.addAll(ruleSet.selectableVictories().map { it.name })
                 }
                 newGame = GameStarter.startNewGame(gameInfo)
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -527,7 +527,7 @@ class GameOptionsTable(
 
         // Create a checkbox for each VictoryType existing
         val victoryConditionsTable = Table().apply { defaults().pad(5f) }
-        for ((i, victoryType) in ruleset.victories.values.withIndex()) {
+        for ((i, victoryType) in ruleset.selectableVictories().withIndex()) {
             val victoryCheckbox = victoryType.name.toCheckBox(gameParameters.victoryTypes.contains(victoryType.name)) {
                 // If the checkbox is checked, adds the victoryTypes else remove it
                 if (it) {
@@ -569,7 +569,7 @@ class GameOptionsTable(
         // Remove victory types which are not in the new ruleset, then default to all if none remain
         gameParameters.victoryTypes.removeAll { it !in ruleset.victories.keys }
         if (gameParameters.victoryTypes.isEmpty())
-            gameParameters.victoryTypes.addAll(ruleset.victories.keys)
+            gameParameters.victoryTypes.addAll(ruleset.selectableVictories().map { it.name })
 
         // Mod choices will change the number of available civs
         val maxMajorCivs = numberOfMajorCivs()

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -70,7 +70,7 @@ class NewGameScreen(
         gameSetupInfo.gameParameters.victoryTypes.removeAll { it !in ruleset.victories.keys }
 
         if (gameSetupInfo.gameParameters.victoryTypes.isEmpty())
-            gameSetupInfo.gameParameters.victoryTypes.addAll(ruleset.victories.keys)
+            gameSetupInfo.gameParameters.victoryTypes.addAll(ruleset.selectableVictories().map { it.name })
 
         rightSideButton.enable()  // now because PlayerPickerTable init might disable it again
         playerPickerTable = PlayerPickerTable(

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -364,6 +364,7 @@ Each victory have the following structure:
 | victoryString          | String          | none     | Shown in the footer of the victory screen when you won the game with this victory          |
 | defeatString           | String          | none     | Shown in the footer of the victory screen when someone else won the game with this victory |
 | hiddenInVictoryScreen  | Boolean         | false    | Whether progress of this victory is hidden in the victory screen                           |
+| humanOnly              | Boolean         | false    | Only a human player can achieve this victory, and it is not offered as a new game option   |
 | requiredSpaceshipParts | List of Strings | empty    | What spaceship parts must be added to the capital for the corresponding milestone          |
 | Milestones             | List of Strings | Required | List of milestones that must be accomplished to win, [see below](#milestones)              |
 | civilopediaText        | List            | Optional | See [civilopediaText chapter](5-Miscellaneous-JSON-files.md#civilopedia-text)              |

--- a/docs/Modders/schemas/VictoryTypes.schema.json
+++ b/docs/Modders/schemas/VictoryTypes.schema.json
@@ -34,6 +34,12 @@
         "description": "Whether progress of this victory is hidden in the victory screen",
         "default": false
       },
+      "humanOnly": {
+        "title": "Human Only",
+        "type": "boolean",
+        "description": "Only a human player can achieve this victory, and it is not offered as a new game option",
+        "default": false
+      },
       "requiredSpaceshipParts": {
         "title": "Requires Spaceship Parts",
         "type": "array",

--- a/tests/src/com/unciv/models/ruleset/HumanOnlyVictoryTests.kt
+++ b/tests/src/com/unciv/models/ruleset/HumanOnlyVictoryTests.kt
@@ -1,0 +1,54 @@
+package com.unciv.models.ruleset
+
+import com.unciv.json.json
+import com.unciv.testing.BaseTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** [Victory.humanOnly] - a victory only a human player can achieve, and that is not a new game option */
+@RunWith(BaseTestRunner::class)
+class HumanOnlyVictoryTests {
+
+    private fun gameWithVictory(humanOnly: Boolean): TestGame {
+        val testGame = TestGame()
+        testGame.makeHexagonalMap(2)
+        val victory = json().fromJson(Victory::class.java,
+            """{ "name": "Reach the goal", "humanOnly": $humanOnly, "milestones": ["Build [Monument]"] }""")
+        testGame.ruleset.victories[victory.name] = victory
+        testGame.gameInfo.gameParameters.victoryTypes = arrayListOf(victory.name)
+        return testGame
+    }
+
+    @Test
+    fun `an AI civ does not achieve a humanOnly victory`() {
+        val testGame = gameWithVictory(humanOnly = true)
+        val aiCiv = testGame.addCiv()
+        val humanCiv = testGame.addCiv(isPlayer = true)
+        testGame.addCity(aiCiv, testGame.getTile(0, 0)).cityConstructions.addBuilding("Monument")
+        testGame.addCity(humanCiv, testGame.getTile(2, 0)).cityConstructions.addBuilding("Monument")
+
+        Assert.assertNull(aiCiv.victoryManager.getVictoryTypeAchieved())
+        Assert.assertEquals("Reach the goal", humanCiv.victoryManager.getVictoryTypeAchieved())
+    }
+
+    @Test
+    fun `an AI civ still achieves a normal victory`() {
+        val testGame = gameWithVictory(humanOnly = false)
+        val aiCiv = testGame.addCiv()
+        testGame.addCity(aiCiv, testGame.getTile(0, 0)).cityConstructions.addBuilding("Monument")
+
+        Assert.assertEquals("Reach the goal", aiCiv.victoryManager.getVictoryTypeAchieved())
+    }
+
+    @Test
+    fun `humanOnly victories are not offered in the new game options`() {
+        val selectable = gameWithVictory(humanOnly = true).ruleset.selectableVictories().map { it.name }
+        Assert.assertFalse("Reach the goal" in selectable)
+        Assert.assertTrue("The ruleset's own victories are still selectable", selectable.isNotEmpty())
+
+        val normal = gameWithVictory(humanOnly = false).ruleset.selectableVictories().map { it.name }
+        Assert.assertTrue("Reach the goal" in normal)
+    }
+}


### PR DESCRIPTION

### The problem

A ruleset can use a victory to express "this is the goal the player is meant to reach": a
tutorial-like ruleset, a challenge with a fixed objective, a scenario shipped by a mod. Two things
get in the way today.

1. **An AI can reach the goal first.** `VictoryManager.getVictoryTypeAchieved()` checks every
   enabled victory for every major civilization, so an AI that happens to complete the same
   milestones ends the game before the player gets there. With a goal like "build a Granary and
   adopt a policy", a competent AI does that on its own within a dozen turns, and the player is
   shown a defeat screen for a victory that was written for them. There is no way for the ruleset
   to say the goal belongs to the player.
2. **The goal shows up as a new game option.** The victory checkboxes in the new game options are
   built from `ruleset.victories`, so the objective appears next to Domination and Science as
   something to tick or untick - and the three "default to everything" fallbacks
   (`NewGameScreen`, `GameOptionsTable`, Quickstart) enable it silently in any free game using
   that ruleset.

### The change

An optional boolean `humanOnly` on `VictoryTypes.json` entries, `false` by default, so no existing
ruleset changes behaviour.

* `VictoryManager.getVictoryTypeAchieved()` skips a `humanOnly` victory for a non-human
  civilization. One `filter` in an existing chain; everything else about the victory (milestones,
  progress in the victory screen, `getNextMilestone`) is untouched, so the AI is not made blind to
  it - it simply cannot win with it.
* `Ruleset.selectableVictories()` returns the victories a player may enable, i.e. all of them
  except the `humanOnly` ones. The victory checkboxes are built from it, and so are the three
  places that fall back to "all victories" when the selection is empty. A ruleset that defines a
  `humanOnly` victory enables it explicitly in the game or scenario it ships.

`selectableVictories()` is used rather than filtering at each call site so that the rule lives in
one place; the raw `ruleset.victories` map is still what validation and the victory screen use.

### What it does not change

Victory conditions, the victory screen, and the AI's victory-oriented behaviour. An AI still
pursues its usual goals; it just does not win *this* victory. And a `humanOnly` victory that the
player never enables behaves exactly as before.

### Documentation

* Victory attribute table in `docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md`.
* `docs/Modders/schemas/VictoryTypes.schema.json` - required, since the schema is
  `"additionalProperties": false` and would otherwise reject every ruleset using the flag.

### Verification

`./gradlew desktop:dist` and `./gradlew tests:test` pass (801 tests, 0 failures).

New tests in `tests/src/com/unciv/models/ruleset/HumanOnlyVictoryTests.kt`: an AI civ and a human
civ completing the same milestone (only the human wins), the same victory without the flag (the AI
wins), and `selectableVictories()` hiding the flagged victory while still listing the ruleset's own.
