### PR TITLE
chore: Change PlatformSaverLoader architecture

### DIFF
--- a/android/src/com/unciv/app/AndroidSaverLoader.kt
+++ b/android/src/com/unciv/app/AndroidSaverLoader.kt
@@ -3,12 +3,15 @@ package com.unciv.app
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.provider.DocumentsContract
 import android.provider.OpenableColumns
 import com.unciv.logic.files.PlatformSaverLoader
 import com.unciv.utils.Log
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import androidx.core.net.toUri
 
 
 class AndroidSaverLoader(private val activity: Activity) : PlatformSaverLoader {
@@ -24,50 +27,42 @@ class AndroidSaverLoader(private val activity: Activity) : PlatformSaverLoader {
         val onCancel: () -> Unit = { onError(PlatformSaverLoader.Cancelled()) }
     }
 
-    override fun saveGame(
-        data: String,
+    override fun requestSaveLocation(
         suggestedLocation: String,
-        onSaved: (location: String) -> Unit,
+        mimeType: String,
+        onLocationChosen: (stream: OutputStream, location: String) -> Unit,
         onError: (ex: Exception) -> Unit
     ) {
-
         // When we loaded, we returned a "content://" URI as file location.
-        val suggestedUri = Uri.parse(suggestedLocation)
+        val suggestedUri = suggestedLocation.toUri()
         val fileName = getFilename(suggestedUri, suggestedLocation)
 
         val onFileChosen = { uri: Uri ->
-            var stream: OutputStream? = null
             try {
-                stream = contentResolver.openOutputStream(uri, "rwt")
-                stream!!.writer().use { it.write(data) }
-                onSaved(uri.toString())
+                val stream = contentResolver.openOutputStream(uri, "rwt")
+                    ?: throw IOException("openOutputStream returned null for $uri")
+                onLocationChosen(stream, uri.toString())
             } catch (ex: Exception) {
                 onError(ex)
-            } finally {
-                stream?.close()
             }
         }
 
         requests[requestCode] = Request(onFileChosen, onError)
-        openSaveFileChooser(fileName, suggestedUri, requestCode)
+        openSaveFileChooser(fileName, suggestedUri, mimeType, requestCode)
         requestCode += 1
     }
 
-    override fun loadGame(
-        onLoaded: (data: String, location: String) -> Unit,
+    override fun requestLoadLocation(
+        onLocationChosen: (stream: InputStream, location: String) -> Unit,
         onError: (ex: Exception) -> Unit
     ) {
-
-        val onFileChosen = {uri: Uri ->
-            var stream: InputStream? = null
+        val onFileChosen = { uri: Uri ->
             try {
-                stream = contentResolver.openInputStream(uri)
-                val text = stream!!.reader().use { it.readText() }
-                onLoaded(text, uri.toString())
+                val stream = contentResolver.openInputStream(uri)
+                    ?: throw IOException("openInputStream returned null for $uri")
+                onLocationChosen(stream, uri.toString())
             } catch (ex: Exception) {
                 onError(ex)
-            } finally {
-                stream?.close()
             }
         }
 
@@ -84,11 +79,11 @@ class AndroidSaverLoader(private val activity: Activity) : PlatformSaverLoader {
         request.onFileChosen(uri)
     }
 
-    private fun openSaveFileChooser(fileName: String, uri: Uri, requestCode: Int) {
+    private fun openSaveFileChooser(fileName: String, uri: Uri, mimeType: String, requestCode: Int) {
         val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
-        intent.type = "application/json"
+        intent.type = mimeType
         intent.putExtra(Intent.EXTRA_TITLE, fileName)
-        if (uri.scheme == "content")
+        if (uri.scheme == "content" && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, uri)
         activity.startActivityForResult(intent, requestCode)
     }
@@ -102,21 +97,19 @@ class AndroidSaverLoader(private val activity: Activity) : PlatformSaverLoader {
     }
 
     private fun getFilename(uri: Uri, suggestedLocation: String): String {
-
         if (uri.scheme != "content")
             return suggestedLocation
 
         try {
             contentResolver.query(uri, null, null, null, null).use {
-                if (it?.moveToFirst() == true)
-                    return it.getString(it.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+                return if (it?.moveToFirst() == true)
+                    it.getString(it.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
                 else
-                    return ""
+                    ""
             }
         } catch(ex: Exception) {
-            Log.error("Failed to get filename from Uri", ex)
+            Log.error("Failed to get filename from Uri \"$uri\"", ex)
             return suggestedLocation.split("2F").last() // I have no idea why but the content path ends with this before the filename
         }
-
     }
 }

--- a/core/src/com/unciv/logic/files/PlatformSaverLoader.kt
+++ b/core/src/com/unciv/logic/files/PlatformSaverLoader.kt
@@ -1,40 +1,107 @@
 package com.unciv.logic.files
 
+import java.io.InputStream
+import java.io.OutputStream
+
 /**
- * Contract for platform-specific helper classes to handle saving and loading games to and from
- * arbitrary external locations.
+ * Contract for platform-specific helper classes to provide streams to arbitrary external
+ * locations, chosen interactively by the user.
  *
- * Implementation note: If a game is loaded with [loadGame] and the same game is saved with [saveGame],
- * the suggestedLocation in [saveGame] will be the location returned by [loadGame].
+ * Implementation note: If a location is obtained via [requestLoadLocation] and the same file is
+ * later saved with [requestSaveLocation]/[saveGame], the suggestedLocation passed should be the
+ * location returned then.
  */
 interface PlatformSaverLoader {
 
-    fun saveGame(
-        data: String,                               // Data to save
-        suggestedLocation: String,                  // Proposed location
-        onSaved: (location: String) -> Unit = {},   // On-save-complete callback
-        onError: (ex: Exception) -> Unit = {}       // On-save-error callback
+    /** Ask the platform for a place to write to.
+     *  @param mimeType Advertised to the platform's file picker (e.g. to suggest a default
+     *      extension/icon on Android). Not all platforms use this; pass the real type of what
+     *      you're about to write regardless, since callers always know it upfront.
+     *  @param onLocationChosen Receives an open, writable stream and the resulting location.
+     *      The caller owns the stream from this point — writing to it, handling I/O failures, and
+     *      closing it are all the caller's responsibility, not the implementation's.
+     *  @param onError Called only for failures *obtaining* a location (permission denied,
+     *      provider returned null, or user cancellation as [Cancelled]). Never called after
+     *      [onLocationChosen] has already fired.
+     */
+    fun requestSaveLocation(
+        suggestedLocation: String,
+        mimeType: String,
+        onLocationChosen: (stream: OutputStream, location: String) -> Unit,
+        onError: (ex: Exception) -> Unit = {}
     )
 
-    fun loadGame(
-        onLoaded: (data: String, location: String) -> Unit,  // On-load-complete callback
-        onError: (Exception) -> Unit = {}                    // On-load-error callback
+    /** Ask the platform for a place to read from.
+     *  @param onLocationChosen Receives an open, readable stream and the resulting location.
+     *      The caller owns the stream from this point onward, same as in [requestSaveLocation].
+     *  @param onError Called only for failures obtaining a location, see [requestSaveLocation].
+     */
+    fun requestLoadLocation(
+        onLocationChosen: (stream: InputStream, location: String) -> Unit,
+        onError: (ex: Exception) -> Unit = {}
     )
+
+    /** Convenience wrapper around [requestSaveLocation] for saving a game already encoded as String.
+     *  See [requestSaveLocation] for the save-location/exception-handling contract.
+     *  [isZipped] only affects the advertised mimeType. */
+    fun saveGame(
+        data: String,
+        isZipped: Boolean = false,
+        suggestedLocation: String,
+        onSaved: (location: String) -> Unit = {},
+        onError: (ex: Exception) -> Unit = {}
+    ) {
+        requestSaveLocation(
+            suggestedLocation,
+            if (isZipped) ZIP_SAVE_MIME_TYPE else PLAIN_SAVE_MIME_TYPE,
+            onLocationChosen = { stream, location ->
+                try {
+                    stream.writer().use { it.write(data) }
+                    onSaved(location)
+                } catch (ex: Exception) {
+                    onError(ex)
+                }
+            },
+            onError = onError
+        )
+    }
+
+    /** Convenience wrapper around [requestLoadLocation] for loading a String.
+     *  See [requestLoadLocation] for the load-location/exception-handling contract. */
+    fun loadGame(
+        onLoaded: (data: String, location: String) -> Unit,
+        onError: (Exception) -> Unit = {}
+    ) {
+        requestLoadLocation(
+            onLocationChosen = { stream, location ->
+                try {
+                    val data = stream.reader().use { it.readText() }
+                    onLoaded(data, location)
+                } catch (ex: Exception) {
+                    onError(ex)
+                }
+            },
+            onError = onError
+        )
+    }
 
     /** Invisible Exception can be used with onError callbacks to indicate the User cancelled the operation and needs no message */
     class Cancelled : Exception()
 
     companion object {
+        const val PLAIN_SAVE_MIME_TYPE = "application/json"
+        const val ZIP_SAVE_MIME_TYPE = "application/gzip"
+
         val None = object : PlatformSaverLoader {
-            override fun saveGame(
-                data: String,
+            override fun requestSaveLocation(
                 suggestedLocation: String,
-                onSaved: (location: String) -> Unit,
-                onError: (ex: Exception) -> Unit
+                mimeType: String,
+                onLocationChosen: (OutputStream, String) -> Unit,
+                onError: (Exception) -> Unit
             ) {}
 
-            override fun loadGame(
-                onLoaded: (data: String, location: String) -> Unit,
+            override fun requestLoadLocation(
+                onLocationChosen: (InputStream, String) -> Unit,
                 onError: (Exception) -> Unit
             ) {}
         }

--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -224,7 +224,7 @@ class UncivFiles(
         try {
             val data = gameInfoToString(game)
             debug("Initiating UI to save GameInfo %s to custom location %s", game.gameId, saveLocation)
-            saverLoader.saveGame(data, saveLocation,
+            saverLoader.saveGame(data, saveZipped, saveLocation,
                 { location ->
                     game.customSaveLocation = location
                     Concurrency.runOnGLThread { onSaved() }
@@ -430,7 +430,7 @@ class UncivFiles(
             val fixedData = gameData.trim().replace("\r", "").replace("\n", "")
             val unzippedJson = try {
                 FileConversions.unzip(fixedData)
-            } catch (ex: Exception) {
+            } catch (_: Exception) {
                 fixedData
             }
             val gameInfo = try {

--- a/desktop/src/com/unciv/app/desktop/DesktopSaverLoader.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopSaverLoader.kt
@@ -13,46 +13,27 @@ import javax.swing.JFrame
 
 class DesktopSaverLoader : PlatformSaverLoader {
 
-    override fun saveGame(
-        data: String,
+    override fun requestSaveLocation(
         suggestedLocation: String,
-        onSaved: (location: String) -> Unit,
+        mimeType: String,   // unused: JFileChooser has no MIME-type concept
+        onLocationChosen: (stream: OutputStream, location: String) -> Unit,
         onError: (ex: Exception) -> Unit
     ) {
-        val onFileChosen = { stream: OutputStream, location: String ->
-            try {
-                stream.writer().use { it.write(data) }
-                onSaved(location)
-            } catch (ex: Exception) {
-                onError(ex)
-            }
-        }
-
-        pickFile(onFileChosen, onError, JFileChooser::showSaveDialog, File::outputStream, suggestedLocation)
-
+        pickFile(onLocationChosen, onError, JFileChooser::showSaveDialog, File::outputStream, suggestedLocation)
     }
 
-    override fun loadGame(
-        onLoaded: (data: String, location: String) -> Unit,
+    override fun requestLoadLocation(
+        onLocationChosen: (stream: InputStream, location: String) -> Unit,
         onError: (ex: Exception) -> Unit
     ) {
-        val onFileChosen = { stream: InputStream, location: String ->
-            try {
-                val data = stream.reader().use { it.readText() }
-                onLoaded(data, location)
-            } catch (ex: Exception) {
-                onError(ex)
-            }
-        }
-
-        pickFile(onFileChosen, onError, JFileChooser::showOpenDialog, File::inputStream)
+        pickFile(onLocationChosen, onError, JFileChooser::showOpenDialog, File::inputStream)
     }
 
     private fun <T> pickFile(onSuccess: (T, String) -> Unit,
-                             onError: (Exception) -> Unit,
-                             chooseAction: (JFileChooser, Component) -> Int,
-                             createValue: (File) -> T,
-                             suggestedLocation: String? = null) {
+        onError: (Exception) -> Unit,
+        chooseAction: (JFileChooser, Component) -> Int,
+        createValue: (File) -> T,
+        suggestedLocation: String? = null) {
         EventQueue.invokeLater {
             try {
                 val fileChooser = JFileChooser().apply fileChooser@{

--- a/desktop/src/com/unciv/app/desktop/LinuxX11SaverLoader.kt
+++ b/desktop/src/com/unciv/app/desktop/LinuxX11SaverLoader.kt
@@ -7,18 +7,15 @@ import com.unciv.logic.files.PlatformSaverLoader
 import com.unciv.utils.Concurrency
 import java.awt.GraphicsEnvironment
 import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
 
 
-/**
- *  A dedicated PlatformSaverLoader for X11-based Linux boxes, as using the Java AWT/Swing file chooser dialog will kill the App after closing that dialog
- *
- *  Tested as required from Mint 20.1 up to Mint 21.2, seems independent of Java runtime (mostly tested with adoptium temurin 11 and 17 versions).
- */
 class LinuxX11SaverLoader : PlatformSaverLoader {
-    override fun saveGame(
-        data: String,
+    override fun requestSaveLocation(
         suggestedLocation: String,
-        onSaved: (location: String) -> Unit,
+        mimeType: String,   // unused: Gdx FileChooser has no MIME-type concept
+        onLocationChosen: (stream: OutputStream, location: String) -> Unit,
         onError: (ex: Exception) -> Unit
     ) {
         Concurrency.runOnGLThread {
@@ -26,14 +23,13 @@ class LinuxX11SaverLoader : PlatformSaverLoader {
                 if (suggestedLocation.startsWith(File.separator)) Gdx.files.absolute(suggestedLocation)
                 else if (Gdx.files.external(suggestedLocation).parent().exists()) Gdx.files.external(suggestedLocation)
                 else UncivGame.Current.files.getLocalFile(suggestedLocation)
-            
+
             FileChooser.createSaveDialog(stage, "Save game", startLocation) { success, file ->
                 if (!success)
                     onError(PlatformSaverLoader.Cancelled())
                 else
                     try {
-                        file.writeString(data, false, Charsets.UTF_8.name())
-                        onSaved(file.path())
+                        onLocationChosen(file.write(false), file.path())
                     } catch (ex: Exception) {
                         onError(ex)
                     }
@@ -41,8 +37,8 @@ class LinuxX11SaverLoader : PlatformSaverLoader {
         }
     }
 
-    override fun loadGame(
-        onLoaded: (data: String, location: String) -> Unit,
+    override fun requestLoadLocation(
+        onLocationChosen: (stream: InputStream, location: String) -> Unit,
         onError: (Exception) -> Unit
     ) {
         Concurrency.runOnGLThread {
@@ -51,8 +47,7 @@ class LinuxX11SaverLoader : PlatformSaverLoader {
                     onError(PlatformSaverLoader.Cancelled())
                 else
                     try {
-                        val data = file.readString(Charsets.UTF_8.name())
-                        onLoaded(data, file.path())
+                        onLocationChosen(file.read(), file.path())
                     } catch (ex: Exception) {
                         onError(ex)
                     }


### PR DESCRIPTION
…to allow SAF-compliant saving/loading any file type

The current architecture has bugged me for years, as it mixes concerns (UI and IO), and cannot be reused for any other usecase requiring a user-chosen file outside what the Unciv app is allowed to access directly.
I'm sure I ditched a few ideas already because of this limitation. Now I got another, and it seems it's time.

Also cleans up a few warnings, advertises known mime type to the provider, and fixes a double-close.

File history: #8773, #9490, #10358

Functionally tested:

-  [x] Android (LOS19)
-  [x] Linux Mint (X11)
-  [ ] Windows
