### PR TITLE
Fix terrain changes from gifted improvements

### DIFF
--- a/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
@@ -381,7 +381,7 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
                     improveTileButton.onClick {
                         viewingCiv.addGold(-200)
                         improvableTile.stopWorkingOnImprovement()
-                        improvableTile.setImprovement(tileImprovement)
+                        improvableTile.setImprovement(tileImprovement, otherCiv)
                         otherCiv.cache.updateCivResources()
                         diplomacyScreen.rightSideTable.clear()
                         diplomacyScreen.rightSideTable.add(ScrollPane(getCityStateDiplomacyTable(otherCiv)))

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -202,6 +202,16 @@ class TileImprovementConstructionTests {
     }
 
     @Test
+    fun buildingImprovementWithCivAppliesTerrainChange() {
+        val tile = tileMap[1,1]
+        val improvement = testGame.createTileImprovement("Turn this tile into a [Coast] tile")
+
+        tile.setImprovement(improvement, civInfo)
+
+        Assert.assertEquals("Coast", tile.baseTerrain)
+    }
+
+    @Test
     fun citadelTakesOverAdjacentTiles() {
         val tile = tileMap[1,1]
         Assert.assertFalse(tile.neighbors.all { it.owningCity == city })


### PR DESCRIPTION
Fixes #13977

City-state improvement gifts must pass the receiving civilization to setImprovement so improvement-triggered effects run. This makes improvements with `Turn this tile into a [terrain] tile` update the underlying terrain when gifted.

Includes a focused regression test.