### PR TITLE
Restore full health for German encampment recruits

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -1084,7 +1084,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             goldGained += unique.params[0].toInt()
             val recruitedUnit = civ.gameInfo.barbarians.spawnBarbarian(tile, civ)
                 ?: continue
-            recruitedUnit.health = 50
+            recruitedUnit.health = 100
             recruitedUnit.currentMovement = 0f
             civ.addNotification(
                 "An enemy [${recruitedUnit.name}] has joined us!",

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -143,6 +143,23 @@ class UnitMovementTests(private val pathfindingAlgorithm: PathfindingAlgorithm) 
     }
 
     @Test
+    fun germanEncampmentRecruitmentUsesFullHealth() {
+        val germany = testGame.addCiv(
+            "When conquering an encampment, earn [25] Gold and recruit a Barbarian unit <with [100]% chance>"
+        )
+        testGame.addBarbarianCiv()
+        testGame.gameInfo.barbarians.setTransients(testGame.gameInfo)
+        val campTile = testGame.getTile(0, 0)
+        testGame.gameInfo.barbarians.createNewCamp(campTile)
+        val unit = testGame.addUnit("Warrior", germany, campTile.neighbors.first())
+
+        unit.movement.moveToTile(campTile)
+
+        val recruitedUnit = germany.units.getCivUnits().single { it != unit }
+        assertEquals(100, recruitedUnit.health)
+    }
+
+    @Test
     fun canNOTEnterCoastUntilProperTechIsResearched() {
         civInfo.tech.unitsCanEmbark = false
         tile.baseTerrain = Constants.coast


### PR DESCRIPTION
Fixes #7376

Units recruited through Germany's encampment unique should join at full health. The current path explicitly reduced them to 50 HP. This changes it to full health and adds a deterministic regression test through the movement and encampment-clearing flow.