### PR TITLE
Add map generator settings clipboard actions

### DIFF
--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorGenerateTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorGenerateTab.kt
@@ -182,24 +182,46 @@ class MapEditorGenerateTab(
             copyParametersButton.onClick {
                 Gdx.app.clipboard.contents = json().toJson(parent.editorScreen.newMapParameters)
             }
-            pasteParametersButton.onClick {
-                try {
-                    val clipboardContents = Gdx.app.clipboard.contents.trim()
-                    json().readFields(
-                        parent.editorScreen.newMapParameters,
-                        JsonReader().parse(clipboardContents)
-                    )
-                    mapParametersTable.update()
-                } catch (exception: Exception) {
-                    Log.error("Could not load map generation settings", exception)
-                    ToastPopup("Could not load map!", parent.editorScreen)
-                }
-            }
+            pasteParametersButton.onClick { pasteParameters() }
+            attachResourceSettingSync()
+        }
+
+        /** Attaches the resource painting sync to the current resource select box -
+         *  [MapParametersTable.update] replaces it, so this needs repeating after each rebuild */
+        private fun attachResourceSettingSync() {
             mapParametersTable.resourceSelectBox.onChange {
                 parent.editorScreen.run {
                     // normally the 'new map' parameters are independent, this needs to be an exception so strategic resource painting will use it
                     tileMap.mapParameters.mapResources = newMapParameters.mapResources
                 }
+            }
+        }
+
+        /** Rebuilds all controls bound to [MapEditorScreen.newMapParameters] after its contents were replaced */
+        private fun updateParameterControls() {
+            mapParametersTable.update()
+            attachResourceSettingSync()
+            // readFields also replaced the mod set instance the Mods tab is bound to
+            parent.editorScreen.tabs.mods.updateControls()
+        }
+
+        private fun pasteParameters() {
+            val editorScreen = parent.editorScreen
+            // Back up the settings so a malformed payload can't leave partially applied values behind
+            val previousParameters = json().toJson(editorScreen.newMapParameters)
+            try {
+                json().readFields(
+                    editorScreen.newMapParameters,
+                    JsonReader().parse(Gdx.app.clipboard.contents.trim())
+                )
+                updateParameterControls()
+                // Resource painting reads this setting from the active map's parameters
+                editorScreen.tileMap.mapParameters.mapResources = editorScreen.newMapParameters.mapResources
+            } catch (exception: Exception) {
+                json().readFields(editorScreen.newMapParameters, JsonReader().parse(previousParameters))
+                updateParameterControls()
+                Log.error("Could not load map generation settings", exception)
+                ToastPopup("Could not load map!", editorScreen)
             }
         }
     }

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorGenerateTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorGenerateTab.kt
@@ -4,7 +4,9 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.ButtonGroup
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.JsonReader
 import com.unciv.Constants
+import com.unciv.json.json
 import com.unciv.logic.map.MapGeneratedMainType
 import com.unciv.logic.map.MapParameters
 import com.unciv.logic.map.MapType
@@ -160,6 +162,8 @@ class MapEditorGenerateTab(
         private val parent: MapEditorGenerateTab
     ): Table(BaseScreen.skin) {
         val generateButton = "".toTextButton()
+        private val copyParametersButton = "Copy to clipboard".toTextButton()
+        private val pasteParametersButton = "Paste from clipboard".toTextButton()
         val mapParametersTable = MapParametersTable(null, parent.editorScreen.newMapParameters, MapGeneratedMainType.generated, forMapEditor = true) {
             parent.replacePage(0, this)  // A kludge to get the ScrollPanes to recognize changes in vertical layout??
         }
@@ -168,9 +172,29 @@ class MapEditorGenerateTab(
             top()
             pad(10f)
             add("Map Options".toLabel(fontSize = 24)).row()
+            add(Table().apply {
+                add(copyParametersButton).padRight(15f)
+                add(pasteParametersButton)
+            }).row()
             add(mapParametersTable).row()
             add(generateButton).padTop(15f).row()
             generateButton.onClick { parent.generate(MapGeneratorSteps.All) }
+            copyParametersButton.onClick {
+                Gdx.app.clipboard.contents = json().toJson(parent.editorScreen.newMapParameters)
+            }
+            pasteParametersButton.onClick {
+                try {
+                    val clipboardContents = Gdx.app.clipboard.contents.trim()
+                    json().readFields(
+                        parent.editorScreen.newMapParameters,
+                        JsonReader().parse(clipboardContents)
+                    )
+                    mapParametersTable.update()
+                } catch (exception: Exception) {
+                    Log.error("Could not load map generation settings", exception)
+                    ToastPopup("Could not load map!", parent.editorScreen)
+                }
+            }
             mapParametersTable.resourceSelectBox.onChange {
                 parent.editorScreen.run {
                     // normally the 'new map' parameters are independent, this needs to be an exception so strategic resource painting will use it

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorModsTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorModsTab.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
+import com.unciv.logic.map.MapParameters
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.ui.components.widgets.TabbedPager
@@ -24,7 +25,8 @@ import com.unciv.ui.screens.newgamescreen.ModCheckboxTable
 class MapEditorModsTab(
     private val editorScreen: MapEditorScreen
 ): Table(BaseScreen.skin), TabbedPager.IPageExtensions {
-    private val mods = editorScreen.newMapParameters.mods
+    // Read through a getter: pasting parameters replaces the mod set instance in newMapParameters
+    private val mods get() = editorScreen.newMapParameters.mods
     private var modsTable: ModCheckboxTable
     private val modsTableCell: Cell<ModCheckboxTable>
     private val applyButton = "Change map ruleset".toTextButton()
@@ -79,12 +81,18 @@ class MapEditorModsTab(
         revertButton.isEnabled = enabled
     }
 
-    private fun revertControls() {
-        val currentParameters = editorScreen.tileMap.mapParameters
-        baseRulesetSelectBox.setSelected(currentParameters.baseRuleset)
+    private fun revertControls() = updateControlsFrom(editorScreen.tileMap.mapParameters)
+
+    /** Rebuild the controls to reflect [MapEditorScreen.newMapParameters] - e.g. after parameters were pasted */
+    fun updateControls() = updateControlsFrom(editorScreen.newMapParameters)
+
+    private fun updateControlsFrom(parameters: MapParameters) {
+        // baseRulesetSelectBox.onChange clears the mod set, so keep a copy until the table is rebuilt
+        val savedMods = LinkedHashSet(parameters.mods)
+        baseRulesetSelectBox.setSelected(parameters.baseRuleset)
         mods.clear()
-        mods.addAll(currentParameters.mods)  // clone current "into" editorScreen.newMapParameters.mods
-        modsTable = ModCheckboxTable(mods, currentParameters.baseRuleset, editorScreen, false) {
+        mods.addAll(savedMods)  // clone "into" editorScreen.newMapParameters.mods
+        modsTable = ModCheckboxTable(mods, parameters.baseRuleset, editorScreen, false) {
             enableApplyButton()
         }
         modsTableCell.setActor(modsTable)

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
@@ -483,7 +483,7 @@ class MapParametersTable(
             table.add(checkbox).colspan(2).row()
         }
         if (forMapEditor) {
-            addCheckBox("Randomize seed", true) {
+            addCheckBox("Randomize seed", randomizeSeed) {
                 randomizeSeed = it
             }
         }


### PR DESCRIPTION
Fixes #8108

Add copy and paste controls to the map editor's map-generation options. Settings are serialized from `newMapParameters`, restored into the existing object, and the controls plus preview are refreshed after pasting. Invalid clipboard data is handled with the existing map-load error flow.