### PR TITLE
Automation setting for specialist control in new cities

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -931,6 +931,7 @@ Automated units move on turn start =
 Automated units can upgrade = 
 Automated units choose promotions = 
 Cities auto-bombard at end of turn = 
+Auto-assign specialists in new cities = 
 Order trade offers by amount = 
 Ask for confirmation when pressing next turn = 
 Notifications log max turns = 

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.city
 
 import com.unciv.Constants
+import com.unciv.UncivGame
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.MultiFilter
 import com.unciv.logic.automation.Timers.Companion.timeThis
@@ -107,7 +108,17 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     /** Tiles that the population in them won't be reassigned */
     var lockedTiles = HashSet<HexCoord>()
+
     var manualSpecialists = false
+    fun resetSpecialistsControl() {
+        // if we skip a player's turn in multiplayer, let's not apply our settings
+        val isOfflineOrOurTurn = !civ.gameInfo.gameParameters.isOnlineMultiplayer
+            || civ.playerId == UncivGame.Current.settings.multiplayer.getUserId()
+        manualSpecialists =
+            if (civ.isHuman() && isOfflineOrOurTurn) !UncivGame.Current.settings.autoAssignSpecialistsInNewCities
+            else false // default
+    }
+    
     var isBeingRazed = false
     var attackedThisTurn = false
     var hasSoldBuildingThisTurn = false

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -369,6 +369,7 @@ class CityConquestFunctions(val city: City) {
         }
 
         city.resetDisabledConstructions()
+        city.resetSpecialistsControl()
 
         newCiv.cache.updateOurTiles()
         oldCiv.cache.updateOurTiles()

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -88,6 +88,7 @@ class CityFounder {
         addStartingBuildings(city, civInfo, startingEra)
         
         city.resetDisabledConstructions()
+        city.resetSpecialistsControl()
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingCity,
             GameContext(civInfo, city, unit)

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -116,6 +116,7 @@ class GameSettings {
     var automatedUnitsCanUpgrade = false
     var automatedUnitsChoosePromotions = false
     var citiesAutoBombardAtEndOfTurn = false
+    var autoAssignSpecialistsInNewCities = true
 
     //// Autoplay
     var autoPlay = GameSettingsAutoPlay()

--- a/core/src/com/unciv/ui/popups/options/AutomationTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AutomationTab.kt
@@ -28,6 +28,7 @@ internal class AutomationTab(
         addCheckbox("Automated units can upgrade", settings::automatedUnitsCanUpgrade)
         addCheckbox("Automated units choose promotions", settings::automatedUnitsChoosePromotions)
         addCheckbox("Cities auto-bombard at end of turn", settings::citiesAutoBombardAtEndOfTurn)
+        addCheckbox("Auto-assign specialists in new cities", settings::autoAssignSpecialistsInNewCities)
 
         addHeader("AutoPlay")
 


### PR DESCRIPTION
Auto specialists control can only be turned off per city, and only after the first specialist building has been constructed. It is easy to forget to turn it off, and you may consequently end up with a merchant, doubling the cost of the specialist you actually wanted, for example an engineer or scientist.

This PR adds a toggle in the automation settings, which applies to all future founded / captured / traded / married cities.
Current behavior is the default (see below for AI exception), and toggling the setting does not affect already owned cities.

With the setting enabled (default behavior):
<img width="512" height="267" alt="image" src="https://github.com/user-attachments/assets/cf81ac59-d909-44c2-bcb3-97d02af6c4ec" />
With the setting disabled:
<img width="489" height="267" alt="image" src="https://github.com/user-attachments/assets/8c43458a-56d5-4c89-b812-a3ae1372696f" />

Also:
Previously when the AI captured a city, the specialist control setting was never updated. This means that if the previous owner used manual specialist control, the AI would never be able to reassign specialists in that city. This PR sets specialist control back to automatic when ownership of a city is transferred.