### PR TITLE
Set default max coast extension to 3 instead of 2

### DIFF
--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -93,7 +93,7 @@ class MapParameters : IsPartOfGameInfoSerialization {
 
     var seed: Long = System.currentTimeMillis()
     var tilesPerBiomeArea = 6
-    var maxCoastExtension = 2
+    var maxCoastExtension = 3
     var elevationExponent = 0.7f
     var temperatureintensity = 0.6f
     var vegetationRichness = 0.4f
@@ -140,7 +140,7 @@ class MapParameters : IsPartOfGameInfoSerialization {
     fun resetAdvancedSettings() {
         reseed()
         tilesPerBiomeArea = 6
-        maxCoastExtension = 2
+        maxCoastExtension = 3
         elevationExponent = 0.7f
         temperatureintensity = 0.6f
         temperatureShift = 0.0f


### PR DESCRIPTION
While playing Civ V G&K with default settings, I noticed that coast sometimes spawns 3 tiles away from land, which does not happen in Unciv with default settings.

Therefore I propose changing the default value for max coast extension to 3.

It should be noted that it still does not match Civ V perfectly, as the coast generation algorithtm is likely different. With a value of 3, it seems more coast spawns at this distance in Unciv that it does in Civ V. I still believe it is better than with a value of 2.

This setting is only used during map generation. Changing the default should not affect ongoing games.